### PR TITLE
Document project tracking workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 
 # local handoff notes は machine-specific な planning context を含みうる。
 agent-tools-handoff.md
+.agent-tools.local.md
 
 generated/**
 !generated/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,12 @@ local development environment の control plane ではありません。
 ## 境界
 
 - `dotfiles` は別 repository / 別 project として扱う。
-- この repository の Notion tracking は `dotfiles` と分離して扱う。
-- 設計、計画、アイデア、作業ログは Notion に集約し、随時最新化する。
+- project planning / management docs は `dotfiles` と分離して別管理する。
+- 具体的な管理 tool や参照先は tracked files に書かず、local-only note を参照する。
 - 実作業は GitHub Issue に切り、変更は PR で管理する。
 - 基本 workflow は `shared/workflows/personal-project-operating-loop.md` を参照する。
 - tokens、credentials、private endpoints、client data、work data を追加しない。
-- private local paths、Notion URLs、internal hostnames、scratch handoff notes を
+- private local paths、private planning URLs、internal hostnames、scratch handoff notes を
   tracked files に追加しない。
 - 特定の secret store 実装を前提にした変更を入れない。
 - `dotfiles` からこの repository を自動 clone / pull / sync しない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ local development environment の control plane ではありません。
 
 - `dotfiles` は別 repository / 別 project として扱う。
 - この repository の Notion tracking は `dotfiles` と分離して扱う。
+- 設計、計画、アイデア、作業ログは Notion に集約し、随時最新化する。
+- 実作業は GitHub Issue に切り、変更は PR で管理する。
 - tokens、credentials、private endpoints、client data、work data を追加しない。
 - private local paths、Notion URLs、internal hostnames、scratch handoff notes を
   tracked files に追加しない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ local development environment の control plane ではありません。
 - この repository の Notion tracking は `dotfiles` と分離して扱う。
 - 設計、計画、アイデア、作業ログは Notion に集約し、随時最新化する。
 - 実作業は GitHub Issue に切り、変更は PR で管理する。
+- 基本 workflow は `shared/workflows/personal-project-operating-loop.md` を参照する。
 - tokens、credentials、private endpoints、client data、work data を追加しない。
 - private local paths、Notion URLs、internal hostnames、scratch handoff notes を
   tracked files に追加しない。

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ secret store / local private config
 - secrets、credentials、private endpoints、client/work material は保存しない。
 - project tracking は `dotfiles` の Notion project と分離する。
 - 設計、計画、アイデア、作業ログは Notion に集約し、実作業は GitHub Issue / PR で管理する。
+- 基本 workflow は [personal-project-operating-loop](shared/workflows/personal-project-operating-loop.md) で管理する。
 
 ## 公開 repository の安全方針
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ secret store / local private config
 - 同名 target が unmanaged の場合は、上書きせず conflict として停止する。
 - secrets、credentials、private endpoints、client/work material は保存しない。
 - project tracking は `dotfiles` の Notion project と分離する。
+- 設計、計画、アイデア、作業ログは Notion に集約し、実作業は GitHub Issue / PR で管理する。
 
 ## 公開 repository の安全方針
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ secret store / local private config
 - agent-tools 管理 marker を持つ target だけを更新する。
 - 同名 target が unmanaged の場合は、上書きせず conflict として停止する。
 - secrets、credentials、private endpoints、client/work material は保存しない。
-- project tracking は `dotfiles` の Notion project と分離する。
-- 設計、計画、アイデア、作業ログは Notion に集約し、実作業は GitHub Issue / PR で管理する。
+- project planning / management docs は `dotfiles` と分離して別管理する。
+- 実作業は GitHub Issue / PR で管理する。
 - 基本 workflow は [personal-project-operating-loop](shared/workflows/personal-project-operating-loop.md) で管理する。
 
 ## 公開 repository の安全方針

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -8,6 +8,37 @@
 - local repository path: developer-specific。ここでは固定しない。
 - Notion project: `dotfiles` project とは分離する。
 - GitHub issues: `dotfiles` issues とは分離する。
+- Notion page / database は project planning と knowledge management の正とする。
+- 実作業は GitHub Issue と PR で管理する。
+- public repository には private Notion URL を書かない。
+
+## Notion に置くもの
+
+Notion には、project を進めるための設計・計画・判断材料を集約します。
+
+- 設計メモ。
+- 計画。
+- アイデア。
+- 作業ログ。
+- 方針の背景。
+- issue に切る前の検討。
+- issue / PR の結果を受けた project-level な更新。
+
+Notion 側は随時最新化します。repository に残す docs は、public に共有してよい
+policy、boundary、仕様、運用ルールに限定します。
+
+## GitHub Issue / PR に置くもの
+
+実際の作業単位は GitHub Issue に切り、変更は PR で管理します。
+
+- 実装 task。
+- docs 更新 task。
+- bug fix。
+- follow-up work。
+- review 可能な成果物。
+
+PR は対応する issue に紐づけます。小さなメンテナンスでも、原則として issue と
+PR を使って履歴を残します。
 
 ## 最初の issue
 

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -40,6 +40,15 @@ policy、boundary、仕様、運用ルールに限定します。
 PR は対応する issue に紐づけます。小さなメンテナンスでも、原則として issue と
 PR を使って履歴を残します。
 
+## 共通 workflow
+
+この進め方自体も repository 内の shared asset として管理します。
+
+- [personal-project-operating-loop](../shared/workflows/personal-project-operating-loop.md)
+
+agent が project を進めるときは、この workflow を参照して Notion / GitHub Issue /
+PR / repository docs の置き場所を判断します。
+
 ## 最初の issue
 
 タイトル:

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -6,26 +6,19 @@
 
 - GitHub repository: `https://github.com/kosako/agent-tools`
 - local repository path: developer-specific。ここでは固定しない。
-- Notion project: `dotfiles` project とは分離する。
+- project planning / management docs は `dotfiles` project とは分離し、repository 外で別管理する。
 - GitHub issues: `dotfiles` issues とは分離する。
-- Notion page / database は project planning と knowledge management の正とする。
 - 実作業は GitHub Issue と PR で管理する。
-- public repository には private Notion URL を書かない。
+- public repository には private planning tool の種類、URL、document list を書かない。
+- 具体的な参照先は ignored local note にだけ書く。
 
-## Notion に置くもの
+## 別管理の planning docs
 
-Notion には、project を進めるための設計・計画・判断材料を集約します。
+project を進めるための planning / management docs は repository 外で管理します。
+tracked docs には、何の document があるか、どの tool を使うか、どこを見ればよいかは書きません。
 
-- 設計メモ。
-- 計画。
-- アイデア。
-- 作業ログ。
-- 方針の背景。
-- issue に切る前の検討。
-- issue / PR の結果を受けた project-level な更新。
-
-Notion 側は随時最新化します。repository に残す docs は、public に共有してよい
-policy、boundary、仕様、運用ルールに限定します。
+repository に残す docs は、public に共有してよい policy、boundary、仕様、運用ルールに限定します。
+private な参照先や project-specific な planning index は local-only note に置きます。
 
 ## GitHub Issue / PR に置くもの
 
@@ -46,8 +39,8 @@ PR を使って履歴を残します。
 
 - [personal-project-operating-loop](../shared/workflows/personal-project-operating-loop.md)
 
-agent が project を進めるときは、この workflow を参照して Notion / GitHub Issue /
-PR / repository docs の置き場所を判断します。
+agent が project を進めるときは、この workflow を参照して external planning docs /
+GitHub Issue / PR / repository docs の置き場所を判断します。
 
 ## 最初の issue
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -4,6 +4,8 @@
 
 register / sync 対象になりうる asset names は、すべて `personal-` で始めます。
 
+`workflows/` には、agent が再利用できる進め方や運用 loop も置きます。
+
 将来の実装で推奨する asset metadata:
 
 - `name`

--- a/shared/workflows/personal-project-operating-loop.md
+++ b/shared/workflows/personal-project-operating-loop.md
@@ -1,0 +1,63 @@
+# personal-project-operating-loop
+
+個人 project を AI agent と進めるときの基本 workflow です。
+
+この workflow は public-safe な運用ルールだけを扱います。private Notion URL、local
+path、secret、credential、client/work material は含めません。
+
+## 目的
+
+- 設計、計画、アイデア、作業ログを Notion に集約する。
+- 実作業を GitHub Issue と PR で追跡する。
+- public repository には公開可能な policy、仕様、運用ルールだけを残す。
+- agent が毎回同じ進め方を再現できるようにする。
+
+## 基本 loop
+
+1. Notion で背景、目的、判断材料、未決事項を整理する。
+2. 作業単位が具体化したら GitHub Issue を作る。
+3. Issue ごとに branch を切る。
+4. 変更は小さく保ち、関連する docs / assets / scripts だけを触る。
+5. commit 前に public safety check を行う。
+6. PR を作り、対応する Issue に紐づける。
+7. PR の結果や新しい判断は Notion に反映する。
+
+## 置き場所の判断
+
+| 内容 | 置き場所 |
+| --- | --- |
+| 設計メモ | Notion |
+| 計画 | Notion |
+| アイデア | Notion |
+| 作業ログ | Notion |
+| 方針の背景 | Notion |
+| 実装 task | GitHub Issue |
+| docs 更新 task | GitHub Issue |
+| code / docs / asset の変更 | PR |
+| public に共有してよい policy | repository docs |
+| 再利用可能な agent workflow | `shared/workflows/personal-*` |
+
+## Public safety check
+
+commit / PR 前に、少なくとも以下を確認します。
+
+- private Notion URL が tracked files に入っていない。
+- local machine path が tracked files に入っていない。
+- secret-like string が tracked files に入っていない。
+- generated artifacts が意図せず tracked files に入っていない。
+- work / client / customer / third-party confidential material が入っていない。
+
+## PR の完了条件
+
+- 対応する Issue がある。
+- PR body に summary と checks がある。
+- `Closes #...` などで Issue と紐づいている。
+- public safety check が通っている。
+- Notion 側に残すべき project-level な判断や作業ログが更新されている。
+
+## 判断に迷ったとき
+
+- 公開してよいか迷う内容は repository に入れない。
+- 実装すべきか迷う内容は、先に Notion で検討する。
+- 作業単位が曖昧な内容は、GitHub Issue に切る前に Notion で scope を詰める。
+- 変更が複数の目的を含み始めたら、Issue / PR を分ける。

--- a/shared/workflows/personal-project-operating-loop.md
+++ b/shared/workflows/personal-project-operating-loop.md
@@ -2,35 +2,31 @@
 
 個人 project を AI agent と進めるときの基本 workflow です。
 
-この workflow は public-safe な運用ルールだけを扱います。private Notion URL、local
-path、secret、credential、client/work material は含めません。
+この workflow は public-safe な運用ルールだけを扱います。private planning tool の種類、
+URL、local path、secret、credential、client/work material は含めません。
 
 ## 目的
 
-- 設計、計画、アイデア、作業ログを Notion に集約する。
+- project planning / management docs を repository 外で別管理する。
 - 実作業を GitHub Issue と PR で追跡する。
 - public repository には公開可能な policy、仕様、運用ルールだけを残す。
 - agent が毎回同じ進め方を再現できるようにする。
 
 ## 基本 loop
 
-1. Notion で背景、目的、判断材料、未決事項を整理する。
+1. repository 外の planning docs で背景、目的、判断材料、未決事項を整理する。
 2. 作業単位が具体化したら GitHub Issue を作る。
 3. Issue ごとに branch を切る。
 4. 変更は小さく保ち、関連する docs / assets / scripts だけを触る。
 5. commit 前に public safety check を行う。
 6. PR を作り、対応する Issue に紐づける。
-7. PR の結果や新しい判断は Notion に反映する。
+7. PR の結果や新しい判断は repository 外の planning docs に反映する。
 
 ## 置き場所の判断
 
 | 内容 | 置き場所 |
 | --- | --- |
-| 設計メモ | Notion |
-| 計画 | Notion |
-| アイデア | Notion |
-| 作業ログ | Notion |
-| 方針の背景 | Notion |
+| project planning / management docs | repository 外 |
 | 実装 task | GitHub Issue |
 | docs 更新 task | GitHub Issue |
 | code / docs / asset の変更 | PR |
@@ -41,7 +37,7 @@ path、secret、credential、client/work material は含めません。
 
 commit / PR 前に、少なくとも以下を確認します。
 
-- private Notion URL が tracked files に入っていない。
+- private planning tool の種類や URL が tracked files に入っていない。
 - local machine path が tracked files に入っていない。
 - secret-like string が tracked files に入っていない。
 - generated artifacts が意図せず tracked files に入っていない。
@@ -53,11 +49,11 @@ commit / PR 前に、少なくとも以下を確認します。
 - PR body に summary と checks がある。
 - `Closes #...` などで Issue と紐づいている。
 - public safety check が通っている。
-- Notion 側に残すべき project-level な判断や作業ログが更新されている。
+- repository 外に残すべき project-level な判断や作業ログが更新されている。
 
 ## 判断に迷ったとき
 
 - 公開してよいか迷う内容は repository に入れない。
-- 実装すべきか迷う内容は、先に Notion で検討する。
-- 作業単位が曖昧な内容は、GitHub Issue に切る前に Notion で scope を詰める。
+- 実装すべきか迷う内容は、先に repository 外の planning docs で検討する。
+- 作業単位が曖昧な内容は、GitHub Issue に切る前に scope を詰める。
 - 変更が複数の目的を含み始めたら、Issue / PR を分ける。


### PR DESCRIPTION
## Summary
- Document that project planning and management docs are managed outside the public repository
- Document that implementation work is tracked through GitHub Issues and PRs
- Add a reusable shared workflow: shared/workflows/personal-project-operating-loop.md
- Keep private planning tool names, URLs, and document lists out of tracked files
- Add an ignored local note path for private project pointers

## Checks
- git diff --check
- secret/private path scan
- tracked-file scan for private planning tool names and URLs

Closes #1