### PR TITLE
Implement shared asset manifest validator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ local development environment の control plane ではありません。
 
 ## 現在の phase
 
-現在の phase は scaffold と policy documentation のみです。
-follow-up issue で明示的に scope されるまで、build、sync、register、doctor、
-injection-check scripts は実装しないでください。
+scaffold と policy documentation は完了し、check scripts の実装 phase に入っています。
+
+- 実装済み: manifest validation (`scripts/check-manifests.sh`)。
+- script の実装は、対応する GitHub Issue で明示的に scope された範囲だけで行う。
+- issue で scope されていない build、sync、register、doctor scripts を
+  先回りで実装しない。

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -207,11 +207,17 @@ source asset:
 
 - [personal-project-operating-loop.md](../shared/workflows/personal-project-operating-loop.md)
 
+## 実装で決めたこと
+
+validator は `scripts/check-manifests.sh` として実装済みです。
+
+- 実装言語: Ruby (macOS 標準、YAML stdlib)。外部依存ゼロ、network access なし。
+- manifest discovery: `shared/**/*.asset.yml` と `shared/**/asset.yml`。
+- validation error format: `path: message` の line 単位。error があれば exit 1。
+- `shared/<category>/` 直下の asset source に manifest が無い場合も error にする。
+
 ## 後続実装で決めること
 
-- YAML parser / validator の実装言語。
-- manifest discovery の対象 glob。
-- validation error format。
 - generated catalog の形式。
 - prompt injection check result を manifest に書き戻すか、別 report に出すか。
 - `status` / `doctor` output に manifest validation 結果をどう含めるか。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,22 @@
 # Scripts
 
-予定している scripts:
+すべての scripts は外部依存ゼロ・network access なしで実行できます。
+実装は macOS 標準の Ruby (YAML stdlib) を使います。
+
+## 実装済み
+
+- `check-manifests.sh`: sidecar asset manifests の static validation。
+  [Asset Manifest Schema](../docs/asset-manifest-schema.md) v1 に従って検証する。
+
+```text
+usage: check-manifests.sh [--root DIR] [--quiet]
+```
+
+- error は `path: message` の line 単位で出力され、error があれば exit 1。
+- manifest を持たない asset source も検出する。
+- self-test: `tests/check-manifests-test.sh`
+
+## 予定している scripts
 
 - `build.sh`: shared source assets から tool-specific artifacts を生成する。
 - `check-injection.sh`: static prompt injection checks と optional LLM review を実行する。
@@ -8,5 +24,4 @@
 - `sync.sh`: generated artifacts の tool directories への反映を dry-run または apply する。
 - `doctor.sh`: state を変更せず、local environment assumptions を inspect する。
 
-scaffold phase では runnable scripts は含めません。
-sync behavior がすでに実装済み、または安全に実行可能であるかのように見えることを避けるためです。
+sync / build 系 scripts は、対応する GitHub Issue で scope されるまで実装しません。

--- a/scripts/check-manifests.sh
+++ b/scripts/check-manifests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Static validation for sidecar asset manifests.
+# Spec: docs/asset-manifest-schema.md
+# 依存: macOS 標準 Ruby のみ。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec ruby "$script_dir/lib/check_manifests.rb" "$@"

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -1,0 +1,312 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Static validator for sidecar asset manifests.
+# Spec: docs/asset-manifest-schema.md (schema_version 1)
+#
+# 外部依存ゼロ、network access なしで実行できること。
+
+require "yaml"
+
+module CheckManifests
+  KINDS = %w[skill prompt workflow agent instruction template].freeze
+  TRACKED_VISIBILITIES = %w[public personal].freeze
+  FORBIDDEN_VISIBILITIES = %w[private work client secret].freeze
+  TARGETS = %w[codex claude-code].freeze
+  RISK_KEYS = %w[prompt_injection privacy].freeze
+  RISK_LEVELS = %w[low medium high unknown].freeze
+  SOURCE_FORMATS = %w[markdown yaml json toml text directory].freeze
+  REQUIRED_FIELDS = %w[schema_version name kind visibility targets risk source].freeze
+  OPTIONAL_FIELDS = %w[summary description review compatibility].freeze
+  REVIEW_VALUES = {
+    "static_check" => %w[pending pass fail],
+    "llm_review" => %w[allowed blocked not_needed],
+    "human_review" => %w[pending approved rejected not_needed],
+  }.freeze
+  NAME_PATTERN = /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/.freeze
+  ASSET_CATEGORIES = %w[skills prompts workflows agents instructions].freeze
+  NON_ASSET_BASENAMES = %w[README.md].freeze
+
+  class Runner
+    attr_reader :errors
+
+    def initialize(root)
+      @root = File.expand_path(root)
+      @errors = []
+    end
+
+    def run
+      manifests = discover_manifests
+      manifests.each { |path| validate_manifest(path) }
+      check_sources_have_manifests
+      [manifests.size, @errors]
+    end
+
+    private
+
+    def error(path, message)
+      @errors << "#{path}: #{message}"
+    end
+
+    def rel(path)
+      path.sub(%r{\A#{Regexp.escape(@root)}/}, "")
+    end
+
+    def discover_manifests
+      sidecars = Dir.glob(File.join(@root, "shared/**/*.asset.yml"))
+      dir_manifests = Dir.glob(File.join(@root, "shared/**/asset.yml"))
+      (sidecars + dir_manifests).sort.map { |p| rel(p) }
+    end
+
+    def load_yaml(content, path)
+      if Psych::VERSION.split(".").first.to_i >= 4
+        YAML.safe_load(content, filename: path)
+      else
+        YAML.safe_load(content, [], [], false, path)
+      end
+    end
+
+    def validate_manifest(path)
+      content = File.read(File.join(@root, path))
+      data = begin
+        load_yaml(content, path)
+      rescue Psych::Exception => e
+        error(path, "YAML parse error: #{e.message}")
+        return
+      end
+
+      unless data.is_a?(Hash)
+        error(path, "manifest must be a YAML mapping")
+        return
+      end
+
+      (data.keys - REQUIRED_FIELDS - OPTIONAL_FIELDS).each do |key|
+        error(path, "unknown field: #{key}")
+      end
+      REQUIRED_FIELDS.each do |key|
+        error(path, "missing required field: #{key}") unless data.key?(key)
+      end
+
+      validate_schema_version(path, data["schema_version"]) if data.key?("schema_version")
+      validate_name(path, data["name"]) if data.key?("name")
+      validate_kind(path, data["kind"]) if data.key?("kind")
+      validate_visibility(path, data["visibility"]) if data.key?("visibility")
+      validate_targets(path, data["targets"]) if data.key?("targets")
+      validate_risk(path, data["risk"]) if data.key?("risk")
+      validate_source(path, data["source"]) if data.key?("source")
+      validate_review(path, data["review"]) if data.key?("review")
+      validate_text_field(path, "summary", data["summary"]) if data.key?("summary")
+      validate_text_field(path, "description", data["description"]) if data.key?("description")
+    end
+
+    def validate_schema_version(path, value)
+      return if value == 1
+
+      error(path, "schema_version must be 1, got #{value.inspect}")
+    end
+
+    def validate_name(path, value)
+      unless value.is_a?(String) && value.match?(NAME_PATTERN)
+        error(path, "name must be lower kebab-case, got #{value.inspect}")
+        return
+      end
+      error(path, "name must start with personal-") unless value.start_with?("personal-")
+
+      expected = expected_name_for(path)
+      if expected && value != expected
+        error(path, "name #{value.inspect} does not match asset base name #{expected.inspect}")
+      end
+    end
+
+    # sidecar manifest なら source file の base name、directory manifest なら
+    # directory name が asset name の期待値になる。
+    def expected_name_for(path)
+      base = File.basename(path)
+      if base == "asset.yml"
+        File.basename(File.dirname(path))
+      else
+        base.sub(/\.asset\.yml\z/, "")
+      end
+    end
+
+    def validate_kind(path, value)
+      return if KINDS.include?(value)
+
+      error(path, "kind must be one of #{KINDS.join(', ')}, got #{value.inspect}")
+    end
+
+    def validate_visibility(path, value)
+      return if TRACKED_VISIBILITIES.include?(value)
+
+      if FORBIDDEN_VISIBILITIES.include?(value)
+        error(path, "visibility #{value.inspect} must not be tracked in this public repository")
+      else
+        error(path, "visibility must be one of #{TRACKED_VISIBILITIES.join(', ')}, got #{value.inspect}")
+      end
+    end
+
+    def validate_targets(path, value)
+      unless value.is_a?(Array) && !value.empty?
+        error(path, "targets must be a non-empty list")
+        return
+      end
+      value.each do |target|
+        unless TARGETS.include?(target)
+          error(path, "targets must be one of #{TARGETS.join(', ')}, got #{target.inspect}")
+        end
+      end
+      error(path, "targets must not contain duplicates") if value.uniq.size != value.size
+    end
+
+    def validate_risk(path, value)
+      unless value.is_a?(Hash)
+        error(path, "risk must be a mapping with keys #{RISK_KEYS.join(', ')}")
+        return
+      end
+      (value.keys - RISK_KEYS).each { |key| error(path, "unknown risk key: #{key}") }
+      RISK_KEYS.each do |key|
+        unless value.key?(key)
+          error(path, "missing risk key: #{key}")
+          next
+        end
+        unless RISK_LEVELS.include?(value[key])
+          error(path, "risk.#{key} must be one of #{RISK_LEVELS.join(', ')}, got #{value[key].inspect}")
+        end
+      end
+    end
+
+    def validate_source(path, value)
+      unless value.is_a?(Hash)
+        error(path, "source must be a mapping with keys path, format")
+        return
+      end
+      (value.keys - %w[path format]).each { |key| error(path, "unknown source key: #{key}") }
+
+      source_path = value["path"]
+      format = value["format"]
+
+      unless SOURCE_FORMATS.include?(format)
+        error(path, "source.format must be one of #{SOURCE_FORMATS.join(', ')}, got #{format.inspect}")
+      end
+
+      unless source_path.is_a?(String) && !source_path.empty?
+        error(path, "missing source key: path")
+        return
+      end
+      if source_path.start_with?("/")
+        error(path, "source.path must be relative, got #{source_path.inspect}")
+        return
+      end
+      if source_path.split("/").include?("..")
+        error(path, "source.path must not contain '..'")
+        return
+      end
+      unless source_path.start_with?("shared/")
+        error(path, "source.path must be under shared/, got #{source_path.inspect}")
+      end
+
+      full = File.join(@root, source_path)
+      if format == "directory"
+        error(path, "source.path #{source_path.inspect} is not a directory") unless File.directory?(full)
+        expected_dir = File.dirname(path)
+        unless source_path.chomp("/") == expected_dir
+          error(path, "directory manifest must point at its own directory #{expected_dir.inspect}")
+        end
+      else
+        error(path, "source.path #{source_path.inspect} does not exist") unless File.file?(full)
+        if File.basename(path) == "asset.yml"
+          error(path, "directory manifest requires source.format: directory")
+        elsif File.dirname(source_path) != File.dirname(path)
+          error(path, "sidecar manifest must sit next to its source file")
+        end
+      end
+    end
+
+    def validate_review(path, value)
+      unless value.is_a?(Hash)
+        error(path, "review must be a mapping")
+        return
+      end
+      (value.keys - REVIEW_VALUES.keys).each { |key| error(path, "unknown review key: #{key}") }
+      REVIEW_VALUES.each do |key, allowed|
+        next unless value.key?(key)
+
+        unless allowed.include?(value[key])
+          error(path, "review.#{key} must be one of #{allowed.join(', ')}, got #{value[key].inspect}")
+        end
+      end
+    end
+
+    def validate_text_field(path, field, value)
+      return if value.is_a?(String) && !value.strip.empty?
+
+      error(path, "#{field} must be a non-empty string")
+    end
+
+    # shared/<category>/ 直下の asset source に manifest が無いものを検出する。
+    def check_sources_have_manifests
+      ASSET_CATEGORIES.each do |category|
+        dir = File.join(@root, "shared", category)
+        next unless File.directory?(dir)
+
+        Dir.children(dir).sort.each do |entry|
+          next if entry.start_with?(".")
+          next if NON_ASSET_BASENAMES.include?(entry)
+          next if entry.end_with?(".asset.yml")
+
+          full = File.join(dir, entry)
+          if File.directory?(full)
+            unless File.file?(File.join(full, "asset.yml"))
+              error(rel(full), "directory asset is missing asset.yml")
+            end
+          else
+            sidecar = File.join(dir, "#{entry.sub(/\.[^.]+\z/, '')}.asset.yml")
+            unless File.file?(sidecar)
+              error(rel(full), "asset source is missing sidecar manifest #{File.basename(sidecar)}")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def self.main(argv)
+    root = Dir.pwd
+    quiet = false
+    until argv.empty?
+      case (arg = argv.shift)
+      when "--root"
+        root = argv.shift or abort_usage
+      when "--quiet"
+        quiet = true
+      when "-h", "--help"
+        print_usage
+        return 0
+      else
+        warn "unknown option: #{arg}"
+        abort_usage
+      end
+    end
+
+    count, errors = Runner.new(root).run
+    errors.each { |line| puts line }
+    if errors.empty?
+      puts "ok: #{count} manifest(s) validated" unless quiet
+      0
+    else
+      warn "#{errors.size} error(s) in #{count} manifest(s)"
+      1
+    end
+  end
+
+  def self.print_usage
+    puts "usage: check-manifests.sh [--root DIR] [--quiet]"
+  end
+
+  def self.abort_usage
+    print_usage
+    exit 2
+  end
+end
+
+exit CheckManifests.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# check-manifests.sh の self-test。
+# 一時 directory に fixture を生成して検証する。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+check="$script_dir/../check-manifests.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# --- case 1: valid single-file asset + valid directory asset ---
+mkdir -p "$tmp/valid/shared/workflows" "$tmp/valid/shared/skills/personal-demo-skill"
+cat > "$tmp/valid/shared/workflows/personal-demo.md" <<'EOF'
+# demo
+EOF
+cat > "$tmp/valid/shared/workflows/personal-demo.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-demo
+kind: workflow
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/workflows/personal-demo.md
+  format: markdown
+summary: demo workflow
+review:
+  static_check: pending
+  llm_review: allowed
+  human_review: pending
+EOF
+cat > "$tmp/valid/shared/skills/personal-demo-skill/SKILL.md" <<'EOF'
+# demo skill
+EOF
+cat > "$tmp/valid/shared/skills/personal-demo-skill/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-demo-skill
+kind: skill
+visibility: personal
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-demo-skill
+  format: directory
+EOF
+
+"$check" --root "$tmp/valid" > "$tmp/out-valid" 2>&1 \
+  || fail "valid fixture should pass: $(cat "$tmp/out-valid")"
+grep -q "ok: 2 manifest(s) validated" "$tmp/out-valid" \
+  || fail "valid fixture should report 2 manifests: $(cat "$tmp/out-valid")"
+
+# --- case 2: broken manifest ---
+mkdir -p "$tmp/broken/shared/prompts"
+cat > "$tmp/broken/shared/prompts/personal-bad.md" <<'EOF'
+# bad
+EOF
+cat > "$tmp/broken/shared/prompts/personal-bad.asset.yml" <<'EOF'
+schema_version: 2
+name: Bad_Name
+kind: tool
+visibility: work
+targets: []
+risk:
+  prompt_injection: low
+source:
+  path: docs/missing.md
+  format: pdf
+extra_field: true
+EOF
+
+if "$check" --root "$tmp/broken" > "$tmp/out-broken" 2>&1; then
+  fail "broken fixture should fail"
+fi
+for expected in \
+  "schema_version must be 1" \
+  "name must be lower kebab-case" \
+  "kind must be one of" \
+  "must not be tracked" \
+  "targets must be a non-empty list" \
+  "missing risk key: privacy" \
+  "source.path must be under shared/" \
+  "source.format must be one of" \
+  "unknown field: extra_field"
+do
+  grep -q "$expected" "$tmp/out-broken" \
+    || fail "missing error '$expected' in: $(cat "$tmp/out-broken")"
+done
+
+# --- case 3: source without manifest ---
+mkdir -p "$tmp/orphan/shared/agents"
+cat > "$tmp/orphan/shared/agents/personal-orphan.md" <<'EOF'
+# orphan
+EOF
+
+if "$check" --root "$tmp/orphan" > "$tmp/out-orphan" 2>&1; then
+  fail "orphan source should fail"
+fi
+grep -q "missing sidecar manifest personal-orphan.asset.yml" "$tmp/out-orphan" \
+  || fail "missing orphan error in: $(cat "$tmp/out-orphan")"
+
+# --- case 4: repository 本体の manifest が pass する ---
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+"$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \
+  || fail "repository manifests should pass: $(cat "$tmp/out-repo")"
+
+echo "ok: check-manifests self-test passed"


### PR DESCRIPTION
## Summary
- Add scripts/check-manifests.sh and scripts/lib/check_manifests.rb as the first runnable static validator for sidecar asset manifests
- Validate required fields, personal- prefix and kebab-case names, tracked visibility, targets, risk levels, source path rules, and optional review fields per docs/asset-manifest-schema.md
- Detect asset sources under shared/<category>/ that are missing a manifest
- Add a dependency-free self-test (scripts/tests/check-manifests-test.sh) with valid, broken, and orphan fixtures
- Record implementation decisions (Ruby, discovery globs, error format) in docs/asset-manifest-schema.md and update scripts/README.md and AGENTS.md phase notes

## Checks
- scripts/check-manifests.sh passes on the repository
- scripts/tests/check-manifests-test.sh passes
- git diff --check
- public safety scan for private planning tool names, URLs, local paths, and secret-like strings

Closes #8