### PR TITLE
Run self-tests and repository checks in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+# self-tests と repository checks を PR / push ごとに実行する。
+# scripts は macOS 標準 Ruby 前提なので macOS runner を使う。
+# 外部 dependency の install と secrets は不要。
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  self-tests:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run self-tests
+        run: |
+          for t in scripts/tests/*.sh; do
+            echo "--- $t"
+            "$t"
+          done
+
+      - name: Check repository assets
+        run: |
+          scripts/check-manifests.sh
+          scripts/check-injection.sh
+
+      - name: Build and report status
+        run: |
+          scripts/build.sh
+          scripts/status.sh --json

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,9 @@
 すべての scripts は外部依存ゼロ・network access なしで実行できます。
 実装は macOS 標準の Ruby (YAML stdlib) を使います。
 
+`tests/` の self-tests と repository checks は CI (`.github/workflows/test.yml`) で
+PR / push ごとに実行されます。
+
 ## 実装済み
 
 - `check-manifests.sh`: sidecar asset manifests の static validation。


### PR DESCRIPTION
## Summary
- Add .github/workflows/test.yml running on pull requests and pushes to main
- Execute all scripts/tests/*.sh self-tests on a macOS runner (scripts assume macOS system Ruby)
- Also run check-manifests, check-injection, build, and status --json against the repository
- No external dependencies and no secrets; permissions limited to contents: read
- Note the CI coverage in scripts/README.md

## Checks
- workflow YAML parses
- all five self-tests pass locally
- git diff --check
- public safety scan for private planning tool names, URLs, local paths, and secret-like strings

Closes #20