### PR TITLE
Harden CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# pinned action SHA の更新を自動で追従する。
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,11 @@ jobs:
   self-tests:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      # 外部 action は full commit SHA で pin する (タグ移動による差し替え対策)。
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # テストが repo 内の scripts を実行するため、token を .git/config に残さない。
+          persist-credentials: false
 
       - name: Run self-tests
         run: |


### PR DESCRIPTION
## Summary
- Pin actions/checkout to its full commit SHA (34e1148, the commit behind the v4 tag, verified via the GitHub API) so a moved tag cannot swap the action
- Set persist-credentials: false on checkout so the GITHUB_TOKEN is not left in .git/config while repo scripts run
- Add Dependabot for the github-actions ecosystem to keep the pinned SHA updated

## Checks
- workflow and dependabot YAML parse
- CI on this PR runs with the hardened workflow
- git diff --check
- public safety scan for private planning tool names, URLs, local paths, and secret-like strings

Closes #26