### PR TITLE
Detect duplicate asset names in manifest validation

### DIFF
--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -33,11 +33,13 @@ module CheckManifests
     def initialize(root)
       @root = File.expand_path(root)
       @errors = []
+      @declared_names = Hash.new { |h, k| h[k] = [] }
     end
 
     def run
       manifests = discover_manifests
       manifests.each { |path| validate_manifest(path) }
+      check_duplicate_names
       check_sources_have_manifests
       [manifests.size, @errors]
     end
@@ -86,6 +88,8 @@ module CheckManifests
       REQUIRED_FIELDS.each do |key|
         error(path, "missing required field: #{key}") unless data.key?(key)
       end
+
+      @declared_names[data["name"]] << path if data["name"].is_a?(String)
 
       validate_schema_version(path, data["schema_version"]) if data.key?("schema_version")
       validate_name(path, data["name"]) if data.key?("name")
@@ -241,6 +245,19 @@ module CheckManifests
       return if value.is_a?(String) && !value.strip.empty?
 
       error(path, "#{field} must be a non-empty string")
+    end
+
+    # asset name は generated artifact の path になるため、repository 全体で一意でなければ
+    # ならない。重複すると build が後勝ちで上書きしてしまう。
+    def check_duplicate_names
+      @declared_names.each do |name, paths|
+        next if paths.size < 2
+
+        paths.each do |path|
+          others = (paths - [path]).join(", ")
+          error(path, "duplicate asset name #{name.inspect} (also declared in #{others})")
+        end
+      end
     end
 
     # shared/<category>/ 直下の asset source に manifest が無いものを検出する。

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -111,7 +111,34 @@ fi
 grep -q "missing sidecar manifest personal-orphan.asset.yml" "$tmp/out-orphan" \
   || fail "missing orphan error in: $(cat "$tmp/out-orphan")"
 
-# --- case 4: repository 本体の manifest が pass する ---
+# --- case 4: 重複 asset name は fail する ---
+mkdir -p "$tmp/dup/shared/workflows" "$tmp/dup/shared/prompts"
+for d in workflows prompts; do
+  k=workflow; [ "$d" = prompts ] && k=prompt
+  echo "# x" > "$tmp/dup/shared/$d/personal-x.md"
+  cat > "$tmp/dup/shared/$d/personal-x.asset.yml" <<EOF
+schema_version: 1
+name: personal-x
+kind: $k
+visibility: public
+targets:
+  - codex
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/$d/personal-x.md
+  format: markdown
+EOF
+done
+
+if "$check" --root "$tmp/dup" > "$tmp/out-dup" 2>&1; then
+  fail "duplicate names should fail"
+fi
+grep -q 'duplicate asset name "personal-x"' "$tmp/out-dup" \
+  || fail "missing duplicate name error in: $(cat "$tmp/out-dup")"
+
+# --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \
   || fail "repository manifests should pass: $(cat "$tmp/out-repo")"


### PR DESCRIPTION
## Summary
- Asset names map to generated artifact paths, so duplicates across categories made build silently overwrite one artifact with another (last writer wins) and confused status staleness tracking
- Collect declared names across all manifests and report an error on every manifest involved in a duplicate, naming the other locations
- Build and register inherit the protection through their manifest-validation gate
- Add a duplicate-name fixture to the validator self-test

## Checks
- all self-tests pass
- git diff --check
- public safety scan

Closes #33