### PR TITLE
Make catalog freshness hash-based instead of mtime-based

### DIFF
--- a/docs/register-catalog.md
+++ b/docs/register-catalog.md
@@ -31,6 +31,7 @@ catalog に記録する step です。
         "path": "shared/workflows/personal-example.md",
         "format": "markdown"
       },
+      "build_id": "sha256:0123456789ab",
       "checks": {
         "manifest_validation": "pass",
         "prompt_injection_static": "pass"
@@ -40,6 +41,11 @@ catalog に記録する step です。
   ]
 }
 ```
+
+### `build_id`
+
+source content の決定的 hash (build の marker と同じ計算)。doctor が catalog の
+鮮度判定に使う。mtime には依存しない。
 
 ### `registration`
 

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -14,6 +14,7 @@ require "yaml"
 
 require_relative "status"
 require_relative "sync"
+require_relative "build"
 
 module Doctor
   LEVELS = %w[ok info warn fail].freeze
@@ -126,6 +127,7 @@ module Doctor
     end
 
     # catalog の存在と鮮度 (docs/register-catalog.md)。
+    # mtime ではなく、catalog の build_id を source content から再計算して比較する。
     def check_catalog
       catalog = File.join(@root, "generated", "catalog.json")
       unless File.file?(catalog)
@@ -133,21 +135,53 @@ module Doctor
         return
       end
 
-      data = JSON.parse(File.read(catalog))
-      newest_manifest = (Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
-                         Dir.glob(File.join(@root, "shared/**/asset.yml")))
-                        .map { |f| File.mtime(f) }.max
-      if newest_manifest && File.mtime(catalog) < newest_manifest
-        report("warn", "catalog", "stale (manifests changed after last register)")
+      entries = JSON.parse(File.read(catalog)).fetch("assets", [])
+      by_name = entries.each_with_object({}) { |e, h| h[e["name"]] = e }
+      manifests = current_manifest_sources
+
+      stale = []
+      manifests.each do |name, source|
+        entry = by_name[name]
+        if entry.nil?
+          stale << "#{name}: not in catalog"
+        elsif entry["build_id"] != Build.build_id_for(@root, source["path"], source["format"])
+          stale << "#{name}: content changed since register"
+        end
+      end
+      (by_name.keys - manifests.keys).each { |name| stale << "#{name}: manifest removed" }
+
+      if stale.empty?
+        report("ok", "catalog", "present, #{entries.size} asset(s), fresh")
       else
-        report("ok", "catalog", "present, #{data.fetch('assets', []).size} asset(s)")
+        report("warn", "catalog", "stale (#{stale.join('; ')})")
       end
     rescue JSON::ParserError
       report("fail", "catalog", "unreadable (invalid JSON)")
     end
 
+    def current_manifest_sources
+      paths = Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
+              Dir.glob(File.join(@root, "shared/**/asset.yml"))
+      paths.each_with_object({}) do |full, map|
+        data = load_yaml(File.read(full), full)
+        next unless data.is_a?(Hash) && data["name"] && data["source"].is_a?(Hash)
+
+        map[data["name"]] = data["source"]
+      rescue Psych::Exception
+        next
+      end
+    end
+
     def tilde(path)
       path.sub(Dir.home, "~")
+    end
+
+    def load_yaml(content, path)
+      if Psych::VERSION.split(".").first.to_i >= 4
+        YAML.safe_load(content, filename: path)
+      else
+        YAML.safe_load(content, [], [], false, path)
+      end
     end
   end
 

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -15,6 +15,7 @@ require "fileutils"
 
 require_relative "check_manifests"
 require_relative "check_injection"
+require_relative "build"
 
 module Register
   CATALOG_VERSION = 1
@@ -133,6 +134,8 @@ module Register
         "visibility" => asset[:visibility],
         "targets" => asset[:targets],
         "source" => asset[:source],
+        # source content の決定的 hash。doctor の鮮度判定に使う。
+        "build_id" => Build.build_id_for(@root, asset[:source]["path"], asset[:source]["format"]),
         "checks" => {
           "manifest_validation" => "pass",
           "prompt_injection_static" => asset[:flagged] ? "human_review" : "pass",

--- a/scripts/tests/doctor-test.sh
+++ b/scripts/tests/doctor-test.sh
@@ -85,15 +85,22 @@ grep -q "fail: target: \[codex\] personal-demo conflict" "$tmp/d4" || fail "miss
 "$sync" --root "$tmp/repo" --codex-home "$tmp/codex" --claude-home "$tmp/claude" > /dev/null 2>&1 \
   && fail "sync should also report the conflict" || true
 
-# --- case 5: catalog があれば鮮度を check する ---
+# --- case 5: catalog があれば build_id で鮮度を check する ---
 rm -rf "$tmp/codex/skills/personal-demo"
 "$sync" --root "$tmp/repo" --codex-home "$tmp/codex" --claude-home "$tmp/claude" --apply --quiet > /dev/null
-echo '{"catalog_version":1,"assets":[{"name":"personal-demo"}]}' > "$tmp/repo/generated/catalog.json"
+"$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null
 run_doctor > "$tmp/d5" 2>&1 || fail "doctor with catalog should pass: $(cat "$tmp/d5")"
-grep -q "ok: catalog: present, 1 asset(s)" "$tmp/d5" || fail "missing catalog ok line: $(cat "$tmp/d5")"
+grep -q "ok: catalog: present, 1 asset(s), fresh" "$tmp/d5" || fail "missing catalog ok line: $(cat "$tmp/d5")"
 
-touch "$tmp/repo/shared/workflows/personal-demo.asset.yml"
+# mtime だけが変わっても stale にならない
+touch "$tmp/repo/shared/workflows/personal-demo.asset.yml" "$tmp/repo/shared/workflows/personal-demo.md"
+run_doctor > "$tmp/d5a" 2>&1 || fail "touched files should not be stale"
+grep -q "ok: catalog: present, 1 asset(s), fresh" "$tmp/d5a" || fail "mtime change must not cause stale: $(cat "$tmp/d5a")"
+
+# source content の変更は stale になる
+echo "changed" >> "$tmp/repo/shared/workflows/personal-demo.md"
 run_doctor > "$tmp/d5b" 2>&1 || fail "stale catalog should still exit 0"
-grep -q "warn: catalog: stale" "$tmp/d5b" || fail "missing catalog stale warn: $(cat "$tmp/d5b")"
+grep -q "warn: catalog: stale (personal-demo: content changed since register)" "$tmp/d5b" \
+  || fail "missing catalog stale warn: $(cat "$tmp/d5b")"
 
 echo "ok: doctor self-test passed"

--- a/scripts/tests/register-test.sh
+++ b/scripts/tests/register-test.sh
@@ -48,6 +48,7 @@ catalog="$tmp/ok/generated/catalog.json"
 [ "$(jget "$catalog" catalog_version)" = "1" ] || fail "catalog_version should be 1"
 [ "$(jget "$catalog" assets 0 registration)" = '"registered"' ] || fail "asset should be registered"
 [ "$(jget "$catalog" assets 0 checks prompt_injection_static)" = '"pass"' ] || fail "injection check should be pass"
+jget "$catalog" assets 0 build_id | grep -q '"sha256:' || fail "catalog entry should carry build_id"
 
 # --- case 2: status が register summary を返す (contract v2) ---
 "$status_sh" --root "$tmp/ok" --json > "$tmp/s2" 2>&1


### PR DESCRIPTION
## Summary
- Doctor judged catalog freshness by manifest mtimes only, so changing an asset's source file alone never flagged the catalog as stale, and mtime churn caused false positives
- Record a build_id (the same deterministic source-content hash build uses for markers) on every catalog entry in register
- Doctor now recomputes build_id per current manifest and reports stale with a reason (content changed / not in catalog / manifest removed); mtime no longer matters
- Document the build_id field in docs/register-catalog.md
- Update self-tests: catalog generated via register, mtime-only changes stay fresh, content change goes stale, catalog entries must carry build_id

## Checks
- all self-tests pass
- git diff --check
- public safety scan

Closes #35