### PR TITLE
Refresh stale docs after script implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,19 @@ generated/
   codex/          生成された Codex artifacts。README と .gitkeep 以外は ignored。
   claude-code/    生成された Claude Code artifacts。README と .gitkeep 以外は ignored。
 
-scripts/          build / check / register / sync / doctor scripts の予定地。
+scripts/          check / build / sync / status / doctor / register scripts。
+                  usage は scripts/README.md を参照。
 docs/             boundary と policy documents。
 ```
 
-## 初期 scope
+## 現在の scope
 
-この repository の最初の issue scope は、意図的に小さくします。
+scaffold と policy documentation、および check-manifests / check-injection /
+build / sync / status / doctor / register の各 script は実装済みです。
+self-tests は CI で PR ごとに実行されます。
 
-1. repository scaffold を作る。
-2. `dotfiles` との boundary を document にする。
-3. sync policy と forbidden targets を document にする。
-4. prompt injection check policy を document にする。
-5. Codex / Claude Code compatibility assumptions を document にする。
-
-build、sync、registration、prompt injection checker の実装は follow-up issue で扱います。
+残作業は GitHub Issues で管理します。script の実装は、対応する issue で
+scope された範囲だけで行います。
 
 ## License
 

--- a/docs/tool-compatibility.md
+++ b/docs/tool-compatibility.md
@@ -28,9 +28,12 @@
 - secret / credential distribution。
 - private local path / endpoint distribution。
 
-## 未決事項
+## 決定済み事項
 
-- Codex skills 向け adapter schema。
-- Claude Code skills 向け adapter schema。
-- generated artifacts に review reports を同梱するか。
-- review 後の prompt injection risk metadata をどう表現するか。
+- Codex / Claude Code skills 向け adapter spec:
+  [adapters/codex/README.md](../adapters/codex/README.md) /
+  [adapters/claude-code/README.md](../adapters/claude-code/README.md)。
+- review 結果は generated artifacts に同梱せず、
+  [catalog](register-catalog.md) に別出しする。
+- review 後の risk / registration 状態は catalog の `checks` と
+  `registration` で表現する。


### PR DESCRIPTION
## Summary
- README: replace the "scripts 予定地" line and the original "初期 scope" section with the current implemented state (C6 in #36)
- docs/tool-compatibility.md: convert the resolved 未決事項 into 決定済み事項 pointing at the adapter specs and the catalog design

Refs #36 (C6 のみ解消。checklist は issue 側で更新する)

## Checks
- scripts/check-manifests.sh and scripts/check-injection.sh pass
- git diff --check
- public safety scan