### PR TITLE
Resolve review cleanup items

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,9 @@ jobs:
           scripts/check-manifests.sh
           scripts/check-injection.sh
 
-      - name: Build and report status
+      - name: Build, register, and report status
         run: |
           scripts/build.sh
+          scripts/register.sh
           scripts/status.sh --json
+          scripts/doctor.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,7 @@ usage: sync.sh [--root DIR] [--apply] [--codex-home DIR] [--claude-home DIR] [--
 - plan は `create` / `update` / `skip (up-to-date)` / `conflict` で表示される。
 - 更新するのは agent-tools management marker を持つ target のみ。
   unmanaged な同名 target は conflict として exit 1 で停止し、何も書き込まない。
+- symlink の target も conflict として扱い、決して触らない。
 - 書き込み先は `<tool home>/skills/personal-*` のみ。それ以外の path は構成しない。
 - `--codex-home` / `--claude-home` は inspection / test 用の override。
 - self-test: `tests/sync-test.sh` (fake home のみを使い、実際の tool homes には触れない)

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -12,6 +12,7 @@ require "yaml"
 require "digest"
 require "fileutils"
 
+require_relative "yaml_util"
 require_relative "check_manifests"
 require_relative "check_injection"
 
@@ -58,17 +59,10 @@ module Build
               Dir.glob(File.join(@root, "shared/**/asset.yml"))
       paths.sort.map do |full|
         rel = full.sub(%r{\A#{Regexp.escape(@root)}/}, "")
-        [rel, load_yaml(File.read(full), rel)]
+        [rel, YamlUtil.load(File.read(full), rel)]
       end
     end
 
-    def load_yaml(content, path)
-      if Psych::VERSION.split(".").first.to_i >= 4
-        YAML.safe_load(content, filename: path)
-      else
-        YAML.safe_load(content, [], [], false, path)
-      end
-    end
 
     def artifact_kind_for(data, tool, kind)
       compat = data["compatibility"]
@@ -107,17 +101,13 @@ module Build
     end
 
     # source が frontmatter を持たない場合のみ、manifest から frontmatter を生成する。
+    # YAML dump を使い、特殊文字を含む summary でも frontmatter が壊れないようにする。
     def skill_markdown(content, data)
       return content if content.start_with?("---\n")
 
       description = data["summary"] || data["description"] || data["name"]
-      <<~FRONTMATTER + content
-        ---
-        name: #{data['name']}
-        description: #{description}
-        ---
-
-      FRONTMATTER
+      frontmatter = YAML.dump("name" => data["name"], "description" => description)
+      "#{frontmatter}---\n\n#{content}"
     end
 
     def write_marker(out_dir, name, tool, source, build_id)
@@ -143,7 +133,8 @@ module Build
       digest = Digest::SHA256.new
       Dir.glob(File.join(src_dir, "**/*")).sort.each do |f|
         next unless File.file?(f)
-        next if File.basename(f) == "asset.yml"
+        # copy と同じく、manifest として除外するのは top-level の asset.yml のみ。
+        next if f == File.join(src_dir, "asset.yml")
 
         digest.update(f.sub(src_dir, ""))
         digest.update(File.read(f, mode: "rb"))

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -8,6 +8,8 @@
 
 require "yaml"
 
+require_relative "yaml_util"
+
 module CheckManifests
   KINDS = %w[skill prompt workflow agent instruction template].freeze
   TRACKED_VISIBILITIES = %w[public personal].freeze
@@ -60,18 +62,11 @@ module CheckManifests
       (sidecars + dir_manifests).sort.map { |p| rel(p) }
     end
 
-    def load_yaml(content, path)
-      if Psych::VERSION.split(".").first.to_i >= 4
-        YAML.safe_load(content, filename: path)
-      else
-        YAML.safe_load(content, [], [], false, path)
-      end
-    end
 
     def validate_manifest(path)
       content = File.read(File.join(@root, path))
       data = begin
-        load_yaml(content, path)
+        YamlUtil.load(content, path)
       rescue Psych::Exception => e
         error(path, "YAML parse error: #{e.message}")
         return

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -12,6 +12,7 @@
 require "json"
 require "yaml"
 
+require_relative "yaml_util"
 require_relative "status"
 require_relative "sync"
 require_relative "build"
@@ -163,7 +164,7 @@ module Doctor
       paths = Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
               Dir.glob(File.join(@root, "shared/**/asset.yml"))
       paths.each_with_object({}) do |full, map|
-        data = load_yaml(File.read(full), full)
+        data = YamlUtil.load(File.read(full), full)
         next unless data.is_a?(Hash) && data["name"] && data["source"].is_a?(Hash)
 
         map[data["name"]] = data["source"]
@@ -176,13 +177,6 @@ module Doctor
       path.sub(Dir.home, "~")
     end
 
-    def load_yaml(content, path)
-      if Psych::VERSION.split(".").first.to_i >= 4
-        YAML.safe_load(content, filename: path)
-      else
-        YAML.safe_load(content, [], [], false, path)
-      end
-    end
   end
 
   def self.main(argv)

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -13,6 +13,7 @@ require "json"
 require "yaml"
 require "fileutils"
 
+require_relative "yaml_util"
 require_relative "check_manifests"
 require_relative "check_injection"
 require_relative "build"
@@ -81,7 +82,7 @@ module Register
               Dir.glob(File.join(@root, "shared/**/asset.yml"))
       paths.sort.map do |full|
         rel = full.sub(%r{\A#{Regexp.escape(@root)}/}, "")
-        data = load_yaml(File.read(full), rel)
+        data = YamlUtil.load(File.read(full), rel)
         {
           name: data["name"],
           kind: data["kind"],
@@ -101,7 +102,8 @@ module Register
       mediums.each do |finding|
         asset = assets.find { |a| owns_path?(a, finding.path) }
         unless asset
-          raise Error, "medium finding on #{finding.path} cannot be attributed to any asset"
+          raise Error, "medium finding on #{finding.path}, which is not part of any asset; " \
+                       "clean the file or move it out of shared/"
         end
 
         warn finding.to_s
@@ -144,13 +146,6 @@ module Register
       }
     end
 
-    def load_yaml(content, path)
-      if Psych::VERSION.split(".").first.to_i >= 4
-        YAML.safe_load(content, filename: path)
-      else
-        YAML.safe_load(content, [], [], false, path)
-      end
-    end
   end
 
   def self.main(argv)

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -11,6 +11,7 @@
 require "json"
 require "yaml"
 
+require_relative "yaml_util"
 require_relative "check_manifests"
 require_relative "check_injection"
 require_relative "build"
@@ -96,7 +97,7 @@ module Status
       marker_path = File.join(artifact, Sync::MARKER_FILE)
       return false unless File.file?(marker_path)
 
-      marker = load_yaml(File.read(marker_path), marker_path)
+      marker = YamlUtil.load(File.read(marker_path), marker_path)
       return false unless marker.is_a?(Hash)
 
       source = sources[marker["name"]]
@@ -111,7 +112,7 @@ module Status
       paths = Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
               Dir.glob(File.join(@root, "shared/**/asset.yml"))
       paths.each_with_object({}) do |full, map|
-        data = load_yaml(File.read(full), full)
+        data = YamlUtil.load(File.read(full), full)
         next unless data.is_a?(Hash) && data["name"] && data["source"].is_a?(Hash)
 
         map[data["name"]] = data["source"]
@@ -145,13 +146,6 @@ module Status
       end
     end
 
-    def load_yaml(content, path)
-      if Psych::VERSION.split(".").first.to_i >= 4
-        YAML.safe_load(content, filename: path)
-      else
-        YAML.safe_load(content, [], [], false, path)
-      end
-    end
   end
 
   def self.main(argv)

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -11,6 +11,8 @@
 # - 許可 target は <tool home>/skills/personal-* のみ。それ以外の path は構成しない。
 
 require "yaml"
+
+require_relative "yaml_util"
 require "fileutils"
 
 module Sync
@@ -68,6 +70,11 @@ module Sync
         return Plan.new("conflict", tool, name, target, "generated artifact is missing a valid marker")
       end
 
+      # symlink は実体の所在によらず unmanaged target として扱い、決して触らない。
+      if File.symlink?(target)
+        return Plan.new("conflict", tool, name, target, "existing target is a symlink")
+      end
+
       unless File.exist?(target)
         return Plan.new("create", tool, name, target)
       end
@@ -88,7 +95,7 @@ module Sync
       path = File.join(dir, MARKER_FILE)
       return nil unless File.file?(path)
 
-      data = load_yaml(File.read(path), path)
+      data = YamlUtil.load(File.read(path), path)
       data.is_a?(Hash) ? data : nil
     rescue Psych::Exception
       nil
@@ -101,13 +108,6 @@ module Sync
         marker["name"] == name
     end
 
-    def load_yaml(content, path)
-      if Psych::VERSION.split(".").first.to_i >= 4
-        YAML.safe_load(content, filename: path)
-      else
-        YAML.safe_load(content, [], [], false, path)
-      end
-    end
   end
 
   def self.main(argv)

--- a/scripts/lib/yaml_util.rb
+++ b/scripts/lib/yaml_util.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+# psych 3 (positional args) と psych 4 (keyword args) の両方で動く safe_load。
+module YamlUtil
+  def self.load(content, path)
+    if Psych::VERSION.split(".").first.to_i >= 4
+      YAML.safe_load(content, filename: path)
+    else
+      YAML.safe_load(content, [], [], false, path)
+    end
+  end
+end

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -101,6 +101,32 @@ build_id_1=$(grep build_id "$marker")
 build_id_2=$(grep build_id "$marker")
 [ "$build_id_1" = "$build_id_2" ] || fail "build_id should be deterministic"
 
+# --- case 2b: 特殊文字を含む summary でも frontmatter が valid YAML になる ---
+mkdir -p "$tmp/ok/shared/prompts"
+echo "# colon" > "$tmp/ok/shared/prompts/personal-colon.md"
+cat > "$tmp/ok/shared/prompts/personal-colon.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-colon
+kind: prompt
+visibility: public
+targets:
+  - codex
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/prompts/personal-colon.md
+  format: markdown
+summary: "demo: with colon #and hash"
+EOF
+"$build" --root "$tmp/ok" --quiet > /dev/null 2>&1 || fail "colon summary build should pass"
+ruby -ryaml -e '
+  fm = File.read(ARGV[0]).split(/^---$/)[1]
+  d = YAML.safe_load(fm)
+  abort "frontmatter broken: #{d.inspect}" unless d["description"] == "demo: with colon #and hash"
+' "$tmp/ok/generated/codex/skills/personal-colon/SKILL.md" \
+  || fail "generated frontmatter must stay valid YAML with special chars"
+
 # --- case 3: manifest error で build が止まる ---
 mkdir -p "$tmp/badmanifest/shared/prompts"
 cat > "$tmp/badmanifest/shared/prompts/personal-x.md" <<'EOF'

--- a/scripts/tests/doctor-test.sh
+++ b/scripts/tests/doctor-test.sh
@@ -62,9 +62,9 @@ do
 done
 
 # --- case 2: doctor は read-only ---
-before=$(find "$tmp" -type f -exec md5 -q {} + | sort)
+before=$(find "$tmp" -type f -exec cksum {} + | sort)
 run_doctor > /dev/null 2>&1
-after=$(find "$tmp" -type f -exec md5 -q {} + | sort)
+after=$(find "$tmp" -type f -exec cksum {} + | sort)
 [ "$before" = "$after" ] || fail "doctor must not modify anything"
 
 # --- case 3: 禁止 target に marker が紛れ込むと fail ---

--- a/scripts/tests/status-test.sh
+++ b/scripts/tests/status-test.sh
@@ -109,10 +109,10 @@ run_status > "$tmp/s6" 2>&1
 
 # --- case 7: status は read-only (fixture を一切変更しない) ---
 before=$(find "$tmp/repo" "$tmp/codex" "$tmp/claude" -type f | sort)
-ls_before=$(find "$tmp/repo" "$tmp/codex" "$tmp/claude" -type f -exec md5 -q {} + | sort)
+ls_before=$(find "$tmp/repo" "$tmp/codex" "$tmp/claude" -type f -exec cksum {} + | sort)
 run_status > /dev/null 2>&1
 after=$(find "$tmp/repo" "$tmp/codex" "$tmp/claude" -type f | sort)
-ls_after=$(find "$tmp/repo" "$tmp/codex" "$tmp/claude" -type f -exec md5 -q {} + | sort)
+ls_after=$(find "$tmp/repo" "$tmp/codex" "$tmp/claude" -type f -exec cksum {} + | sort)
 [ "$before" = "$after" ] || fail "status must not add or remove files"
 [ "$ls_before" = "$ls_after" ] || fail "status must not modify files"
 

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -93,4 +93,18 @@ run_sync > "$tmp/out-badmarker" 2>&1 || status=$?
 [ "$status" -eq 1 ] || fail "missing marker should exit 1: $(cat "$tmp/out-badmarker")"
 grep -q "missing a valid marker" "$tmp/out-badmarker" || fail "missing marker conflict line"
 
+# --- case 7: symlink target は conflict として扱い、決して触らない ---
+"$build" --root "$tmp/repo" --quiet > /dev/null
+rm -rf "$tmp/codex/skills/personal-demo"
+mkdir -p "$tmp/real-skill"
+echo "real content" > "$tmp/real-skill/SKILL.md"
+ln -s "$tmp/real-skill" "$tmp/codex/skills/personal-demo"
+
+status=0
+run_sync --apply > "$tmp/out-symlink" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlink target should exit 1: $(cat "$tmp/out-symlink")"
+grep -q "conflict: \[codex\].*symlink" "$tmp/out-symlink" || fail "missing symlink conflict line"
+[ -L "$tmp/codex/skills/personal-demo" ] || fail "symlink must not be replaced"
+grep -q "real content" "$tmp/real-skill/SKILL.md" || fail "symlink destination must be untouched"
+
 echo "ok: sync self-test passed"


### PR DESCRIPTION
## Summary
Resolves the remaining checklist items of #36:
- C1: generate SKILL.md frontmatter via YAML.dump so special characters in summary cannot break it (covered by a new build self-test case)
- C2: align build_id hashing with the copy rule — only the top-level asset.yml is excluded from directory hashing
- C3: clearer register error when a medium finding hits a file that belongs to no asset
- C4: CI now also runs register.sh and doctor.sh against the repository
- C5: replace macOS-only md5 with POSIX cksum in self-tests
- C7: extract the psych 3/4 compatible safe_load into scripts/lib/yaml_util.rb and remove the five duplicated copies
- C8: sync treats symlinked targets as conflicts and never touches them (covered by a new sync self-test case); documented in scripts/README.md

## Checks
- all self-tests pass; ruby -wc clean
- git diff --check
- public safety scan

Closes #36