### PR TITLE
Add orphan artifact pruning to build

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,7 @@ usage: check-injection.sh [--root DIR] [--quiet]
   adapter spec は [adapters/](../adapters/README.md) を参照。
 
 ```text
-usage: build.sh [--root DIR] [--quiet]
+usage: build.sh [--root DIR] [--prune] [--quiet]
 ```
 
 - 生成前に manifest validation と static injection check を必ず通す。
@@ -44,6 +44,9 @@ usage: build.sh [--root DIR] [--quiet]
 - 各 artifact に management marker (`.agent-tools-managed.yml`) を埋め込む。
   `build_id` は source content の sha256 なので build は決定的。
 - 書き込み先は `generated/` のみ。tool directories には書き込まない。
+- `--prune` で manifest に対応しなくなった generated artifact を削除する。
+  削除するのは agent-tools marker を持つ directory のみで、marker のない
+  directory は警告して残す。
 - self-test: `tests/build-test.sh`
 
 - `sync.sh`: `generated/` の personal assets を tool directories へ反映する。

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -124,6 +124,47 @@ module Build
     def rel(path)
       path.sub(%r{\A#{Regexp.escape(@root)}/}, "")
     end
+
+    public
+
+    # 現在の manifests に対応しない generated artifacts を削除する。
+    # 削除するのは agent-tools marker を持つ directory のみ。
+    # marker のない directory は warning として返し、残す。
+    def prune
+      expected = Hash.new { |h, k| h[k] = [] }
+      manifests.each do |_path, data|
+        data["targets"].each { |tool| expected[tool] << data["name"] }
+      end
+
+      pruned = []
+      kept = []
+      TOOLS.each do |tool|
+        Dir.glob(File.join(@root, "generated", tool, "skills", "*")).sort.each do |dir|
+          next unless File.directory?(dir)
+          next if expected[tool].include?(File.basename(dir))
+
+          if managed_marker?(dir)
+            FileUtils.rm_rf(dir)
+            pruned << rel(dir)
+          else
+            kept << rel(dir)
+          end
+        end
+      end
+      [pruned, kept]
+    end
+
+    private
+
+    def managed_marker?(dir)
+      path = File.join(dir, ".agent-tools-managed.yml")
+      return false unless File.file?(path)
+
+      data = YamlUtil.load(File.read(path), path)
+      data.is_a?(Hash) && data["repo"] == "agent-tools"
+    rescue Psych::Exception
+      false
+    end
   end
 
   # source content から決定的な build_id を作る。status の stale 判定でも使う。
@@ -148,12 +189,15 @@ module Build
   def self.main(argv)
     root = Dir.pwd
     quiet = false
+    prune = false
     until argv.empty?
       case (arg = argv.shift)
       when "--root"
         root = argv.shift or abort_usage
       when "--quiet"
         quiet = true
+      when "--prune"
+        prune = true
       when "-h", "--help"
         print_usage
         return 0
@@ -168,9 +212,15 @@ module Build
       return 1
     end
 
-    built, skipped = Runner.new(root).run
+    runner = Runner.new(root)
+    built, skipped = runner.run
     built.each { |line| puts "built: #{line}" }
     skipped.each { |line| warn "skipped: #{line}" }
+    if prune
+      pruned, kept = runner.prune
+      pruned.each { |line| puts "pruned: #{line}" }
+      kept.each { |line| warn "kept (unmanaged, no agent-tools marker): #{line}" }
+    end
     puts "ok: #{built.size} artifact(s) built" unless quiet
     0
   end
@@ -197,7 +247,7 @@ module Build
   end
 
   def self.print_usage
-    puts "usage: build.sh [--root DIR] [--quiet]"
+    puts "usage: build.sh [--root DIR] [--prune] [--quiet]"
   end
 
   def self.abort_usage

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -179,6 +179,21 @@ grep -q "registration fail" "$tmp/out-inj" \
   || fail "missing registration fail notice: $(cat "$tmp/out-inj")"
 [ ! -d "$tmp/inj/generated" ] || fail "nothing should be generated on injection failure"
 
+# --- case 4b: --prune は manifest の消えた managed artifact だけを削除する ---
+rm -f "$tmp/ok/shared/prompts/personal-colon.md" "$tmp/ok/shared/prompts/personal-colon.asset.yml"
+mkdir -p "$tmp/ok/generated/codex/skills/personal-stray"
+echo "user file" > "$tmp/ok/generated/codex/skills/personal-stray/SKILL.md"
+
+"$build" --root "$tmp/ok" --prune > "$tmp/out-prune" 2>&1 || fail "prune build should pass: $(cat "$tmp/out-prune")"
+grep -q "pruned: generated/codex/skills/personal-colon" "$tmp/out-prune" \
+  || fail "missing pruned line: $(cat "$tmp/out-prune")"
+[ ! -e "$tmp/ok/generated/codex/skills/personal-colon" ] || fail "orphan artifact should be pruned"
+grep -q "kept (unmanaged, no agent-tools marker): generated/codex/skills/personal-stray" "$tmp/out-prune" \
+  || fail "missing kept warning: $(cat "$tmp/out-prune")"
+[ -f "$tmp/ok/generated/codex/skills/personal-stray/SKILL.md" ] \
+  || fail "unmanaged directory must not be pruned"
+[ -d "$tmp/ok/generated/codex/skills/personal-demo" ] || fail "live artifact must survive prune"
+
 # --- case 5: repository 本体が build できる ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$build" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \


### PR DESCRIPTION
## Summary
- build.sh --prune removes generated/<tool>/skills/* directories that no longer correspond to a current manifest target
- Only directories carrying a valid agent-tools marker are deleted; unmanaged directories are kept with a warning
- Pruning runs only after a successful build (gates already passed)
- Document the flag in scripts/README.md and cover prune/keep behavior in the build self-test

## Checks
- all self-tests pass; ruby -wc clean
- git diff --check
- public safety scan

Closes #22