### PR TITLE
Integrate pipeline: centralize gate, sync respects catalog

### DIFF
--- a/docs/register-catalog.md
+++ b/docs/register-catalog.md
@@ -51,20 +51,37 @@ source content の決定的 hash (build の marker と同じ計算)。doctor が
 
 | value | 意味 |
 | --- | --- |
-| `registered` | build / sync の対象にしてよい。 |
-| `human_review_required` | medium finding があり、human review が未解決。build / sync の対象外。 |
+| `registered` | sync が配置してよい。 |
+| `human_review_required` | medium があり human review が未解決。sync は配置しない。 |
+
+## Gate は build / register / sync で一貫させる
+
+安全判定の source of truth は **致命 gate** (`scripts/lib/gate.rb`)。build と register が
+同じ判定を共有するので、同じ asset に対して両者の合否は必ず一致する。
+
+致命 gate (どれか 1 つでも該当すれば fail):
+
+- manifest validation error。
+- static injection high finding。
+- 宣言 risk (prompt_injection / privacy) が `high`。
+- `review.human_review: rejected`。
+
+致命 gate を通った後の medium の扱いは段階で異なる:
+
+- **build**: medium では止めない。artifact を `generated/` に生成する (中間物)。
+- **register**: medium を `human_review` と突き合わせ、catalog に
+  `registered` / `human_review_required` を記録する (次節)。
+- **sync**: catalog を読み、`registration: registered` の artifact だけ配置する。
+  `human_review_required` / catalog 不在の artifact は配置せず、理由つきで skip する。
+
+これにより「build は生成するが、human review 未解決のものは sync が止める」という
+一貫した流れになる。
 
 ## Register の意味論
 
 - 単位は repository 全体。register の実行は catalog を丸ごと再生成する。
-- register = manifest validation + static injection check + catalog 書き込み。
+- register = 致命 gate + medium 突き合わせ + catalog 書き込み。
 - catalog 書き込みが唯一の副作用で、書き込み先は `generated/` のみ。
-
-gate は build と同じ判定に揃える:
-
-- manifest validation error が 1 件でもあれば register は fail し、catalog を更新しない。
-- high risk finding があれば register は fail し、catalog を更新しない。
-- medium risk finding は asset 単位で解決する (次節)。
 
 ## Medium finding と human review の解決
 
@@ -109,18 +126,14 @@ enforce する。static finding と宣言 risk の厳しい方が勝つ。
 - catalog は repository 内部の中間生成物。dotfiles は catalog を直接読まない。
 - `status.sh` には register summary を追加する (contract_version 2 に bump):
   `"register": {"catalog_present": true, "registered": 1, "human_review_required": 0}`。
-- `doctor.sh` は catalog の存在と鮮度 (manifest より新しいか) を check する。
-- build / sync は将来、catalog の `registration: registered` を前提条件にできる
-  (v1 では build が直接 gate を実行しており、挙動は等価)。
+- `doctor.sh` は catalog の存在と鮮度 (build_id 比較) を check する。
+- sync は catalog の `registration: registered` の artifact だけを配置する。
 
 ## 実装状態
 
-- `scripts/register.sh`: 実装済み (catalog 生成、human_review 突き合わせ)。
+- 致命 gate (`scripts/lib/gate.rb`): build と register が共有。
+- `scripts/register.sh`: catalog 生成、human_review 突き合わせ。
   exit code は 0 (全 registered) / 3 (human_review_required あり) / 1 (gate fail)。
-- status contract v2 (register summary): 実装済み。
-- doctor での catalog 鮮度 check: 実装済み。
-
-## 後続実装
-
-- build / sync の前提条件を catalog の `registration: registered` に切り替えるか
-  の判断 (v1 では build が直接 gate を実行しており、挙動は等価)。
+- `scripts/sync.sh`: catalog を尊重し registered のみ配置。
+- status contract v2 (register summary) / doctor の鮮度 check: 実装済み。
+- asset discovery/load は `scripts/lib/assets.rb` に集約。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,8 +39,8 @@ usage: check-injection.sh [--root DIR] [--quiet]
 usage: build.sh [--root DIR] [--prune] [--quiet]
 ```
 
-- 生成前に manifest validation と static injection check を必ず通す。
-  gate が fail のときは何も生成しない。
+- 生成前に register と共有の致命 gate (`lib/gate.rb`) を通す。fail なら何も生成しない。
+  medium finding では止めず生成する (中間物。配置は sync が catalog を見て止める)。
 - 各 artifact に management marker (`.agent-tools-managed.yml`) を埋め込む。
   `build_id` は source content の sha256 なので build は決定的。
 - 書き込み先は `generated/` のみ。tool directories には書き込まない。
@@ -57,14 +57,15 @@ usage: sync.sh [--root DIR] [--apply] [--codex-home DIR] [--claude-home DIR] [--
 ```
 
 - default は dry-run。書き込みには `--apply` が必須。
-- plan は `create` / `update` / `skip (up-to-date)` / `conflict` で表示される。
+- **catalog (`generated/catalog.json`) を尊重する。`registration: registered` の
+  artifact だけを配置する。** `human_review_required` / catalog 不在は理由つきで skip。
+  先に `register.sh` を実行する必要がある。
+- plan は `create` / `update` / `skip` / `conflict` で表示される。
 - 更新するのは agent-tools management marker を持つ target のみ。
-  unmanaged な同名 target は conflict として exit 1 で停止し、何も書き込まない。
-- symlink の target も conflict として扱い、決して触らない。
+  unmanaged な同名 target / symlink は conflict として exit 1 で停止し、何も書き込まない。
 - 書き込み先は `<tool home>/skills/personal-*` のみ。それ以外の path は構成しない。
 - `--codex-home` / `--claude-home` は inspection / test 用の override。
 - self-test: `tests/sync-test.sh` (fake home のみを使い、実際の tool homes には触れない)
-- 残課題: `stale` / `missing` state の status 連携は `status.sh` 実装時に扱う。
 
 - `status.sh`: report-only status。
   [Status / Manifest Contract](../docs/status-manifest-contract.md) の JSON を出力する。

--- a/scripts/lib/assets.rb
+++ b/scripts/lib/assets.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "yaml_util"
+
+# shared asset の discovery と load を 1 箇所に集約する。
+# manifest glob / parse / 正規化を各 script で重複させない。
+module Assets
+  # sidecar manifest と directory manifest を sort して返す (絶対 path)。
+  def self.manifest_paths(root)
+    root = File.expand_path(root)
+    (Dir.glob(File.join(root, "shared/**/*.asset.yml")) +
+     Dir.glob(File.join(root, "shared/**/asset.yml"))).sort
+  end
+
+  # すべての asset を正規化した hash で返す。
+  def self.load_all(root)
+    root = File.expand_path(root)
+    manifest_paths(root).map do |full|
+      rel = full.sub(%r{\A#{Regexp.escape(root)}/}, "")
+      from_manifest(YamlUtil.load(File.read(full), rel), rel)
+    end
+  end
+
+  # name => source の hash。stale 判定で source を引くのに使う。
+  def self.sources_by_name(root)
+    load_all(root).each_with_object({}) do |a, map|
+      next unless a[:name] && a[:source].is_a?(Hash)
+
+      map[a[:name]] = a[:source]
+    end
+  end
+
+  def self.from_manifest(data, rel)
+    data = {} unless data.is_a?(Hash)
+    {
+      name: data["name"],
+      kind: data["kind"],
+      visibility: data["visibility"],
+      targets: data["targets"],
+      source: data["source"],
+      compatibility: data["compatibility"],
+      summary: data["summary"],
+      description: data["description"],
+      human_review: data.dig("review", "human_review"),
+      declared_risks: (data["risk"] || {}).values,
+      manifest_path: rel,
+    }
+  end
+end

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -12,9 +12,8 @@ require "yaml"
 require "digest"
 require "fileutils"
 
-require_relative "yaml_util"
-require_relative "check_manifests"
-require_relative "check_injection"
+require_relative "assets"
+require_relative "gate"
 
 module Build
   TOOLS = %w[codex claude-code].freeze
@@ -38,15 +37,15 @@ module Build
     attr_reader :built, :skipped
 
     def run
-      manifests.each do |path, data|
-        kind = data["kind"]
-        data["targets"].each do |tool|
-          artifact_kind = artifact_kind_for(data, tool, kind)
+      Assets.load_all(@root).each do |asset|
+        asset[:targets].each do |tool|
+          artifact_kind = artifact_kind_for(asset, tool)
           unless SUPPORTED_ARTIFACT_KINDS.include?(artifact_kind)
-            @skipped << "#{path}: unsupported artifact_kind #{artifact_kind.inspect} for #{tool}"
+            @skipped << "#{asset[:manifest_path]}: unsupported artifact_kind " \
+                        "#{artifact_kind.inspect} for #{tool}"
             next
           end
-          build_skill(tool, data)
+          build_skill(tool, asset)
         end
       end
       [@built, @skipped]
@@ -54,26 +53,16 @@ module Build
 
     private
 
-    def manifests
-      paths = Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
-              Dir.glob(File.join(@root, "shared/**/asset.yml"))
-      paths.sort.map do |full|
-        rel = full.sub(%r{\A#{Regexp.escape(@root)}/}, "")
-        [rel, YamlUtil.load(File.read(full), rel)]
-      end
-    end
-
-
-    def artifact_kind_for(data, tool, kind)
-      compat = data["compatibility"]
+    def artifact_kind_for(asset, tool)
+      compat = asset[:compatibility]
       explicit = compat.is_a?(Hash) && compat[tool].is_a?(Hash) ? compat[tool]["artifact_kind"] : nil
-      explicit || DEFAULT_ARTIFACT_KIND[kind] || "unsupported"
+      explicit || DEFAULT_ARTIFACT_KIND[asset[:kind]] || "unsupported"
     end
 
-    def build_skill(tool, data)
-      name = data["name"]
-      source = data.dig("source", "path")
-      format = data.dig("source", "format")
+    def build_skill(tool, asset)
+      name = asset[:name]
+      source = asset[:source]["path"]
+      format = asset[:source]["format"]
       out_dir = File.join(@root, "generated", tool, "skills", name)
 
       FileUtils.rm_rf(out_dir)
@@ -83,7 +72,7 @@ module Build
         copy_directory_asset(source, out_dir)
       else
         content = File.read(File.join(@root, source))
-        File.write(File.join(out_dir, "SKILL.md"), skill_markdown(content, data))
+        File.write(File.join(out_dir, "SKILL.md"), skill_markdown(content, asset))
       end
       build_id = Build.build_id_for(@root, source, format)
 
@@ -102,11 +91,11 @@ module Build
 
     # source が frontmatter を持たない場合のみ、manifest から frontmatter を生成する。
     # YAML dump を使い、特殊文字を含む summary でも frontmatter が壊れないようにする。
-    def skill_markdown(content, data)
+    def skill_markdown(content, asset)
       return content if content.start_with?("---\n")
 
-      description = data["summary"] || data["description"] || data["name"]
-      frontmatter = YAML.dump("name" => data["name"], "description" => description)
+      description = asset[:summary] || asset[:description] || asset[:name]
+      frontmatter = YAML.dump("name" => asset[:name], "description" => description)
       "#{frontmatter}---\n\n#{content}"
     end
 
@@ -132,8 +121,8 @@ module Build
     # marker のない directory は warning として返し、残す。
     def prune
       expected = Hash.new { |h, k| h[k] = [] }
-      manifests.each do |_path, data|
-        data["targets"].each { |tool| expected[tool] << data["name"] }
+      Assets.load_all(@root).each do |asset|
+        asset[:targets].each { |tool| expected[tool] << asset[:name] }
       end
 
       pruned = []
@@ -225,25 +214,12 @@ module Build
     0
   end
 
-  # build 前の必須 gate。manifest validation と static injection check。
+  # build 前の必須 gate。register と同じ致命 gate を共有する (Gate.fatal_errors)。
+  # medium finding では止めない。生成は中間物で、sync が catalog を見て止める。
   def self.run_gates(root)
-    _, errors = CheckManifests::Runner.new(root).run
+    errors = Gate.fatal_errors(root)
     errors.each { |line| warn line }
-    return false unless errors.empty?
-
-    _, findings = CheckInjection::Runner.new(root).run
-    findings.each { |line| warn line.to_s }
-    findings.each do |f|
-      if f.risk == "high"
-        warn "fail: high risk findings present (registration fail)"
-        return false
-      end
-    end
-    if findings.any? { |f| f.risk == "medium" }
-      warn "fail: medium risk findings require human review before build"
-      return false
-    end
-    true
+    errors.empty?
   end
 
   def self.print_usage

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -9,6 +9,7 @@
 require "yaml"
 
 require_relative "yaml_util"
+require_relative "assets"
 
 module CheckManifests
   KINDS = %w[skill prompt workflow agent instruction template].freeze
@@ -57,9 +58,7 @@ module CheckManifests
     end
 
     def discover_manifests
-      sidecars = Dir.glob(File.join(@root, "shared/**/*.asset.yml"))
-      dir_manifests = Dir.glob(File.join(@root, "shared/**/asset.yml"))
-      (sidecars + dir_manifests).sort.map { |p| rel(p) }
+      Assets.manifest_paths(@root).map { |p| rel(p) }
     end
 
 

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -12,7 +12,7 @@
 require "json"
 require "yaml"
 
-require_relative "yaml_util"
+require_relative "assets"
 require_relative "status"
 require_relative "sync"
 require_relative "build"
@@ -138,7 +138,7 @@ module Doctor
 
       entries = JSON.parse(File.read(catalog)).fetch("assets", [])
       by_name = entries.each_with_object({}) { |e, h| h[e["name"]] = e }
-      manifests = current_manifest_sources
+      manifests = Assets.sources_by_name(@root)
 
       stale = []
       manifests.each do |name, source|
@@ -158,19 +158,6 @@ module Doctor
       end
     rescue JSON::ParserError
       report("fail", "catalog", "unreadable (invalid JSON)")
-    end
-
-    def current_manifest_sources
-      paths = Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
-              Dir.glob(File.join(@root, "shared/**/asset.yml"))
-      paths.each_with_object({}) do |full, map|
-        data = YamlUtil.load(File.read(full), full)
-        next unless data.is_a?(Hash) && data["name"] && data["source"].is_a?(Hash)
-
-        map[data["name"]] = data["source"]
-      rescue Psych::Exception
-        next
-      end
     end
 
     def tilde(path)

--- a/scripts/lib/gate.rb
+++ b/scripts/lib/gate.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "assets"
+require_relative "check_manifests"
+require_relative "check_injection"
+
+# 安全判定の source of truth。build と register が共有する致命 gate。
+# ここを通った asset だけが生成・登録に進んでよい。
+module Gate
+  # pass なら []、fail なら human-readable な error message の配列を返す。
+  # 致命 = manifest validation error / injection high / 宣言 risk high /
+  #        human_review: rejected。
+  def self.fatal_errors(root)
+    root = File.expand_path(root)
+
+    _, manifest_errors = CheckManifests::Runner.new(root).run
+    # manifest が壊れていると以降の判定が不正確なので、ここで打ち切る。
+    return manifest_errors + ["manifest validation failed"] unless manifest_errors.empty?
+
+    errors = []
+    findings = CheckInjection::Runner.new(root).run.last
+    findings.select { |f| f.risk == "high" }.each { |f| errors << "high risk finding: #{f}" }
+
+    assets = Assets.load_all(root)
+    rejected = assets.select { |a| a[:human_review] == "rejected" }.map { |a| a[:name] }
+    errors << "rejected asset(s) still present: #{rejected.join(', ')}" unless rejected.empty?
+
+    declared_high = assets.select { |a| a[:declared_risks].include?("high") }.map { |a| a[:name] }
+    errors << "declared high risk asset(s): #{declared_high.join(', ')}" unless declared_high.empty?
+
+    errors
+  end
+end

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -10,11 +10,10 @@
 # - 外部依存ゼロ、network access なし。
 
 require "json"
-require "yaml"
 require "fileutils"
 
-require_relative "yaml_util"
-require_relative "check_manifests"
+require_relative "assets"
+require_relative "gate"
 require_relative "check_injection"
 require_relative "build"
 
@@ -31,35 +30,15 @@ module Register
 
     # catalog hash を返す。gate violation は Error を raise し、catalog は書かない。
     def run
-      _, manifest_errors = CheckManifests::Runner.new(@root).run
-      unless manifest_errors.empty?
-        manifest_errors.each { |line| warn line }
-        raise Error, "manifest validation failed; catalog not updated"
+      # 致命 gate は build と共有する (docs/register-catalog.md)。
+      errors = Gate.fatal_errors(@root)
+      unless errors.empty?
+        errors.each { |line| warn line }
+        raise Error, "fatal gate failed; catalog not updated"
       end
 
-      _, findings = CheckInjection::Runner.new(@root).run
-      high = findings.select { |f| f.risk == "high" }
-      unless high.empty?
-        high.each { |f| warn f.to_s }
-        raise Error, "high risk findings present; catalog not updated"
-      end
-
-      assets = load_assets
-
-      # human_review: rejected は finding の有無によらず矛盾状態なので fail。
-      rejected = assets.select { |a| a[:human_review] == "rejected" }
-      unless rejected.empty?
-        names = rejected.map { |a| a[:name] }.join(", ")
-        raise Error, "rejected asset(s) still present: #{names}; fix or remove them"
-      end
-
-      # manifest が宣言した risk も enforce する (docs/asset-manifest-schema.md)。
-      declared_high = assets.select { |a| a[:declared_risks].include?("high") }
-      unless declared_high.empty?
-        names = declared_high.map { |a| a[:name] }.join(", ")
-        raise Error, "declared high risk asset(s): #{names}; catalog not updated"
-      end
-
+      findings = CheckInjection::Runner.new(@root).run.last
+      assets = Assets.load_all(@root).map { |a| a.merge(flagged: false) }
       mediums = findings.select { |f| f.risk == "medium" }
       assign_findings(assets, mediums)
 
@@ -76,26 +55,6 @@ module Register
     end
 
     private
-
-    def load_assets
-      paths = Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
-              Dir.glob(File.join(@root, "shared/**/asset.yml"))
-      paths.sort.map do |full|
-        rel = full.sub(%r{\A#{Regexp.escape(@root)}/}, "")
-        data = YamlUtil.load(File.read(full), rel)
-        {
-          name: data["name"],
-          kind: data["kind"],
-          visibility: data["visibility"],
-          targets: data["targets"],
-          source: data["source"],
-          human_review: data.dig("review", "human_review"),
-          declared_risks: (data["risk"] || {}).values,
-          manifest_path: rel,
-          flagged: false,
-        }
-      end
-    end
 
     # medium finding の path を asset の source path / manifest path に対応づける。
     def assign_findings(assets, mediums)

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -11,7 +11,7 @@
 require "json"
 require "yaml"
 
-require_relative "yaml_util"
+require_relative "assets"
 require_relative "check_manifests"
 require_relative "check_injection"
 require_relative "build"
@@ -19,13 +19,6 @@ require_relative "sync"
 
 module Status
   CONTRACT_VERSION = 2
-  # Sync の plan action から contract の target state への対応。
-  ACTION_TO_STATE = {
-    "skip" => "managed",
-    "update" => "stale",
-    "conflict" => "conflict",
-    "create" => "missing",
-  }.freeze
 
   class Runner
     def initialize(root, homes)
@@ -79,7 +72,7 @@ module Status
 
     # generated artifacts の数と、source より古い (build_id 不一致) artifact の数。
     def generated_state
-      sources = manifest_sources
+      sources = Assets.sources_by_name(@root)
       total = 0
       stale = 0
       Sync::TOOLS.each do |tool|
@@ -108,19 +101,6 @@ module Status
       false
     end
 
-    def manifest_sources
-      paths = Dir.glob(File.join(@root, "shared/**/*.asset.yml")) +
-              Dir.glob(File.join(@root, "shared/**/asset.yml"))
-      paths.each_with_object({}) do |full, map|
-        data = YamlUtil.load(File.read(full), full)
-        next unless data.is_a?(Hash) && data["name"] && data["source"].is_a?(Hash)
-
-        map[data["name"]] = data["source"]
-      rescue Psych::Exception
-        next
-      end
-    end
-
     # catalog (docs/register-catalog.md) の register summary。
     def register_summary
       catalog_path = File.join(@root, "generated", "catalog.json")
@@ -141,8 +121,19 @@ module Status
         {
           "tool" => p.tool,
           "name" => p.name,
-          "state" => ACTION_TO_STATE.fetch(p.action),
+          "state" => target_state(p),
         }
+      end
+    end
+
+    # Sync plan を contract の target state にマップする。
+    # registered でない artifact は配置されないため、target は missing 扱い。
+    def target_state(plan)
+      case plan.action
+      when "update" then "stale"
+      when "conflict" then "conflict"
+      when "create" then "missing"
+      when "skip" then plan.reason == "up-to-date" ? "managed" : "missing"
       end
     end
 

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -11,12 +11,14 @@
 # - 許可 target は <tool home>/skills/personal-* のみ。それ以外の path は構成しない。
 
 require "yaml"
+require "json"
+require "fileutils"
 
 require_relative "yaml_util"
-require "fileutils"
 
 module Sync
   MARKER_FILE = ".agent-tools-managed.yml"
+  CATALOG_PATH = "generated/catalog.json"
   TOOLS = %w[codex claude-code].freeze
 
   Plan = Struct.new(:action, :tool, :name, :target, :reason) do
@@ -30,6 +32,21 @@ module Sync
     def initialize(root, homes)
       @root = File.expand_path(root)
       @homes = homes
+      load_catalog
+    end
+
+    # catalog から name => registration を作る。registered の artifact だけ配置する。
+    def load_catalog
+      @catalog_present = false
+      @registrations = {}
+      path = File.join(@root, CATALOG_PATH)
+      return unless File.file?(path)
+
+      assets = JSON.parse(File.read(path)).fetch("assets", [])
+      @catalog_present = true
+      assets.each { |a| @registrations[a["name"]] = a["registration"] }
+    rescue JSON::ParserError
+      @catalog_present = false
     end
 
     def plan
@@ -68,6 +85,15 @@ module Sync
       source_marker = read_marker(artifact)
       unless managed?(source_marker, tool, name)
         return Plan.new("conflict", tool, name, target, "generated artifact is missing a valid marker")
+      end
+
+      # catalog の registration を尊重する。registered 以外は配置しない (課題1)。
+      registration = @registrations[name]
+      if registration.nil?
+        reason = @catalog_present ? "not in catalog" : "no catalog (run scripts/register.sh first)"
+        return Plan.new("skip", tool, name, target, reason)
+      elsif registration != "registered"
+        return Plan.new("skip", tool, name, target, registration)
       end
 
       # symlink は実体の所在によらず unmanaged target として扱い、決して触らない。

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -175,8 +175,8 @@ EOF
 if "$build" --root "$tmp/inj" > "$tmp/out-inj" 2>&1; then
   fail "build should fail on high risk findings"
 fi
-grep -q "registration fail" "$tmp/out-inj" \
-  || fail "missing registration fail notice: $(cat "$tmp/out-inj")"
+grep -q "high risk finding" "$tmp/out-inj" \
+  || fail "missing high risk finding notice: $(cat "$tmp/out-inj")"
 [ ! -d "$tmp/inj/generated" ] || fail "nothing should be generated on injection failure"
 
 # --- case 4b: --prune は manifest の消えた managed artifact だけを削除する ---

--- a/scripts/tests/doctor-test.sh
+++ b/scripts/tests/doctor-test.sh
@@ -44,6 +44,7 @@ source:
 summary: demo workflow
 EOF
 "$build" --root "$tmp/repo" --quiet > /dev/null
+"$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null
 "$sync" --root "$tmp/repo" --codex-home "$tmp/codex" --claude-home "$tmp/claude" --apply --quiet > /dev/null
 
 # --- case 1: 健全な環境では exit 0 で各 check が ok ---
@@ -55,7 +56,7 @@ for expected in \
   "ok: target: \[codex\] personal-demo managed" \
   "ok: home: \[codex\]" \
   "ok: forbidden: no agent-tools markers" \
-  "info: catalog: not present" \
+  "ok: catalog: present" \
   "doctor: ok"
 do
   grep -q "$expected" "$tmp/d1" || fail "missing '$expected' in: $(cat "$tmp/d1")"

--- a/scripts/tests/status-test.sh
+++ b/scripts/tests/status-test.sh
@@ -57,11 +57,13 @@ run_status > "$tmp/s1" 2>&1 || fail "status should succeed: $(cat "$tmp/s1")"
 [ "$(jget "$tmp/s1" checks prompt_injection_static)" = '"pass"' ] || fail "injection check should pass"
 [ "$(jget "$tmp/s1" generated total)" = "0" ] || fail "generated.total should be 0"
 
-# --- case 2: build 後。missing が報告される ---
+# --- case 2: build + register 後。missing が報告される ---
 "$build" --root "$tmp/repo" --quiet > /dev/null
+"$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null
 run_status > "$tmp/s2" 2>&1
 [ "$(jget "$tmp/s2" generated total)" = "2" ] || fail "generated.total should be 2"
 [ "$(jget "$tmp/s2" generated stale)" = "0" ] || fail "generated.stale should be 0"
+[ "$(jget "$tmp/s2" register registered)" = "1" ] || fail "register.registered should be 1"
 [ "$(jget "$tmp/s2" sync_targets 0 state)" = '"missing"' ] || fail "target should be missing"
 
 # --- case 3: sync apply 後は managed ---

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -6,6 +6,7 @@ set -eu
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 build="$script_dir/../build.sh"
+register="$script_dir/../register.sh"
 sync="$script_dir/../sync.sh"
 
 tmp=$(mktemp -d)
@@ -42,6 +43,13 @@ source:
 summary: demo workflow
 EOF
 "$build" --root "$tmp/repo" --quiet > /dev/null
+
+# --- case 0: catalog が無いと sync は何も配置しない (register を促す) ---
+run_sync > "$tmp/out-nocat" 2>&1 || fail "sync without catalog should succeed: $(cat "$tmp/out-nocat")"
+grep -q "skip: \[codex\].*no catalog" "$tmp/out-nocat" || fail "missing no-catalog skip: $(cat "$tmp/out-nocat")"
+
+# register して catalog を作る (以降の case は registered 前提)
+"$register" --root "$tmp/repo" --quiet > /dev/null
 
 # --- case 1: dry-run が default で、何も書き込まれない ---
 run_sync > "$tmp/out-dry" 2>&1 || fail "dry-run should succeed: $(cat "$tmp/out-dry")"


### PR DESCRIPTION
## Summary
中間 review で見つかった 3 つの構造的課題 (#44) を一括で解消する。

- **課題2 (gate 非対称) を解消**: 安全判定の source of truth を `scripts/lib/gate.rb`
  に集約。build と register が `Gate.fatal_errors` を共有するので、同じ asset に対する
  両者の致命 gate 判定 (manifest error / injection high / 宣言 risk high /
  human_review: rejected) が必ず一致する。build は宣言 high risk を無視して生成していたが、
  これも止まるようになった (実地確認済み)。
- **課題1 (registration が未使用) を解消**: sync が `generated/catalog.json` を読み、
  `registration: registered` の artifact だけを配置する。`human_review_required` /
  catalog 不在は理由つきで skip。これで register の判定が実際に enforce される。
- **課題3 (discovery 重複) を解消**: manifest discovery/load を `scripts/lib/assets.rb`
  に集約し、build / check_manifests / doctor / register / status の重複を除去。

## 挙動変更
- build は medium finding で止めなくなった (生成は中間物)。代わりに sync が registered の
  artifact だけ配置する。「build は生成、human review 未解決は sync が止める」という一貫した流れ。
- status の target state は sync plan から導出 (skip 理由で managed/missing を区別)。contract は v2 のまま。

## Checks
- 全 7 self-test pass (新経路 = no-catalog skip, 宣言 high で build/register 一致 を追加)
- repo で build→register→sync 一周を確認 (register 前は skip、register 後は create)
- docs 更新: register-catalog / scripts/README
- git diff --check / public safety scan

Closes #44