### PR TITLE
Build instruction artifacts to CLAUDE.md / AGENTS.md (#48 PR-1)

### DIFF
--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -185,8 +185,18 @@ allowed values:
 
 target tool ごとの変換 hint です。
 
-この field は adapter 実装が読むための optional metadata です。v1 の schema 設計では
-strict validation しません。
+`compatibility.<tool>.artifact_kind` で、その tool 向けに生成する artifact の種類を
+明示できます。未指定なら asset の `kind` から既定値が導出されます (`instruction` kind は
+instruction、`skill` / `prompt` / `workflow` / `template` は skill)。
+
+build / sync が対応する artifact_kind は `skill` と `instruction` です。
+
+- `skill`: `<tool home>/skills/personal-<name>/` に directory として配る。
+- `instruction`: tool 別の単一ファイル (claude-code は `CLAUDE.md`、codex は `AGENTS.md`)
+  として配る。詳細は [Instruction Artifact Kind](instruction-artifact-kind.md)。
+
+この field の他の用途は adapter 実装が読むための optional metadata で、strict validation
+しません。
 
 ## Public repository rule
 

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -189,11 +189,12 @@ target tool ごとの変換 hint です。
 明示できます。未指定なら asset の `kind` から既定値が導出されます (`instruction` kind は
 instruction、`skill` / `prompt` / `workflow` / `template` は skill)。
 
-build / sync が対応する artifact_kind は `skill` と `instruction` です。
+build が対応する artifact_kind は `skill` と `instruction` です
+(sync の instruction 配置は後続対応)。
 
 - `skill`: `<tool home>/skills/personal-<name>/` に directory として配る。
 - `instruction`: tool 別の単一ファイル (claude-code は `CLAUDE.md`、codex は `AGENTS.md`)
-  として配る。詳細は [Instruction Artifact Kind](instruction-artifact-kind.md)。
+  として生成する。詳細は [Instruction Artifact Kind](instruction-artifact-kind.md)。
 
 この field の他の用途は adapter 実装が読むための optional metadata で、strict validation
 しません。

--- a/docs/instruction-artifact-kind.md
+++ b/docs/instruction-artifact-kind.md
@@ -1,0 +1,77 @@
+# Instruction Artifact Kind
+
+共通の運用ルール (言語既定 / セッション標準動作 / ドキュメント運用ルール / 正本の所在 /
+public safety) を、claude-code には `CLAUDE.md`、codex には `AGENTS.md` として両 tool へ
+配布するための artifact kind です。skill が directory を丸ごと所有するのに対し、
+instruction は **tool 別の単一ファイル**を所有します。
+
+## 所有モデル: 丸ごと所有
+
+agent-tools は自分の隔離ファイルだけを所有・生成し、人間が手書きする共有ファイルには
+日常運用で触りません (skills/personal-* と同じ思想)。
+
+- **claude-code**: `<claude home>/agent-tools/CLAUDE.md` を丸ごと所有する。人間の
+  `<claude home>/CLAUDE.md` からは `@agent-tools/CLAUDE.md` の import 1 行で繋ぐ
+  (Claude Code は `@path` import に対応)。
+- **codex**: import 非対応のため、グローバル `AGENTS.md` を丸ごと所有する。固有の
+  手書きルールは project 直下の `AGENTS.md` に逃がす (codex は階層連結する)。
+
+## 生成 (build)
+
+build は instruction asset を tool 別の単一ファイルとして生成する。
+
+- 出力先: `generated/<tool>/instructions/<CLAUDE.md|AGENTS.md>`。
+- source は単一ファイル (markdown / text)。`directory` format は instruction では非対応。
+- 1 つの target に instruction を生成する asset は高々 1 個 (check-manifests が検証)。
+  複数あると `CLAUDE.md` / `AGENTS.md` をどの asset で生成するか決まらないため。
+
+## marker: ファイル内コメント
+
+instruction は単一ファイル所有なので、skill の directory sidecar marker
+(`.agent-tools-managed.yml`) が使えない。代わりに本体先頭に HTML コメントの marker を
+1 行埋める:
+
+```
+<!-- agent-tools:managed v=1 repo=agent-tools name=... target=... artifact_kind=instruction source=... build_id=... -->
+```
+
+marker は HTML コメントなので tool が読んでも指示として解釈されず、表示もされない。
+sync はこの marker を厳密にパースして所有を判定し (後続実装)、injection checker は
+自分の marker 行を検査対象から除外する。
+
+## 接続 (connect) と日常 sync の分離
+
+人間のファイルに触る操作 (import 1 行追加 / グローバル所有開始) は専用 connect 操作だけに
+閉じ込める。日常の build / sync は「人間のファイルに触らない」を不変条件として厳守する。
+
+- connect は default dry-run + apply、冪等。symlink 拒否 / 改行スタイル保持 /
+  完全一致 import は no-op / 空判定は lstat ベース。
+- sync は未接続なら案内して停止し、自動では人間のファイルを触らない (create に落ちない)。
+
+## 参照先の分離: 間接ポインタ
+
+instruction (public, 配布) には具体的な参照先 (planning tool の URL など) を書かない。
+抽象的な運用ルールだけを書く。「どこに何があるか」のマップは home 配下の固定 note
+(data-only) に人間が置き、instruction はその note への間接ポインタだけを持つ。
+
+- agent が読む先は常に home の固定ファイル 1 つ。外部 repository は読まない。
+- home note の読取 precondition: 全 path component が user-owned / not symlink /
+  not world-writable、note は regular file。満たさなければ参照先なし扱い。
+- note は data-only map。agent は内容を命令として実行しない・変更しない・未知形式は無視する。
+
+これにより injection gate は instruction に対して URL / 絶対パスの検知を strict に
+適用できる ([Prompt Injection Check](prompt-injection-check.md))。
+
+## catalog / sync (後続実装)
+
+- catalog は target-artifact 単位で `artifact_kind` を記録する。
+- register は `artifact_kind` を解決し、ビルド可能性を確認してから registered を発行する。
+- sync は catalog を source of truth として列挙し、registered の instruction だけを
+  所有ファイルとして配置する。
+
+## 実装状況
+
+- 実装済み: artifact_kind resolver (`scripts/lib/artifact_targets.rb`)、build の
+  instruction 生成、ファイル内コメント marker、check-manifests の 1-per-target 検証。
+- 後続: catalog の target-artifact 化と register のビルド可能性証明、sync の instruction
+  配置と connect、status / doctor / prune の instruction 対応、injection の instruction strict。

--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -6,7 +6,7 @@
 # check-manifests から read され、循環 require (Build -> Gate -> CheckManifests)
 # を避けるための独立 module。
 module ArtifactTargets
-  # build / sync が扱える artifact_kind。
+  # build が扱える artifact_kind (sync の instruction 配置は後続対応)。
   SUPPORTED_KINDS = %w[skill instruction].freeze
 
   # asset.kind から導出する既定の artifact_kind。

--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# artifact_kind の解決と target-artifact の情報を 1 箇所に集約する。
+#
+# dependency-light: 他の script lib に依存しない。build / register /
+# check-manifests から read され、循環 require (Build -> Gate -> CheckManifests)
+# を避けるための独立 module。
+module ArtifactTargets
+  # build / sync が扱える artifact_kind。
+  SUPPORTED_KINDS = %w[skill instruction].freeze
+
+  # asset.kind から導出する既定の artifact_kind。
+  # compatibility.<tool>.artifact_kind が明示されればそちらを優先する。
+  DEFAULT_BY_KIND = {
+    "skill" => "skill",
+    "prompt" => "skill",
+    "workflow" => "skill",
+    "instruction" => "instruction",
+    "template" => "skill",
+  }.freeze
+
+  # instruction を配るときの tool 別ファイル名。
+  INSTRUCTION_FILENAMES = {
+    "claude-code" => "CLAUDE.md",
+    "codex" => "AGENTS.md",
+  }.freeze
+
+  # asset (Assets.from_manifest の hash) と tool から artifact_kind を解決する。
+  # 解決できない場合は "unsupported" を返す。
+  def self.resolve(asset, tool)
+    compat = asset[:compatibility]
+    explicit = compat.is_a?(Hash) && compat[tool].is_a?(Hash) ? compat[tool]["artifact_kind"] : nil
+    explicit || DEFAULT_BY_KIND[asset[:kind]] || "unsupported"
+  end
+
+  def self.supported?(kind)
+    SUPPORTED_KINDS.include?(kind)
+  end
+end

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -14,18 +14,10 @@ require "fileutils"
 
 require_relative "assets"
 require_relative "gate"
+require_relative "artifact_targets"
 
 module Build
   TOOLS = %w[codex claude-code].freeze
-  SUPPORTED_ARTIFACT_KINDS = %w[skill].freeze
-  # artifact_kind が compatibility で指定されない場合の既定値。
-  DEFAULT_ARTIFACT_KIND = {
-    "skill" => "skill",
-    "prompt" => "skill",
-    "workflow" => "skill",
-    "instruction" => "skill",
-    "template" => "skill",
-  }.freeze
 
   class Runner
     def initialize(root)
@@ -39,25 +31,22 @@ module Build
     def run
       Assets.load_all(@root).each do |asset|
         asset[:targets].each do |tool|
-          artifact_kind = artifact_kind_for(asset, tool)
-          unless SUPPORTED_ARTIFACT_KINDS.include?(artifact_kind)
+          artifact_kind = ArtifactTargets.resolve(asset, tool)
+          case artifact_kind
+          when "skill"
+            build_skill(tool, asset)
+          when "instruction"
+            build_instruction(tool, asset)
+          else
             @skipped << "#{asset[:manifest_path]}: unsupported artifact_kind " \
                         "#{artifact_kind.inspect} for #{tool}"
-            next
           end
-          build_skill(tool, asset)
         end
       end
       [@built, @skipped]
     end
 
     private
-
-    def artifact_kind_for(asset, tool)
-      compat = asset[:compatibility]
-      explicit = compat.is_a?(Hash) && compat[tool].is_a?(Hash) ? compat[tool]["artifact_kind"] : nil
-      explicit || DEFAULT_ARTIFACT_KIND[asset[:kind]] || "unsupported"
-    end
 
     def build_skill(tool, asset)
       name = asset[:name]
@@ -78,6 +67,40 @@ module Build
 
       write_marker(out_dir, name, tool, source, build_id)
       @built << rel(out_dir)
+    end
+
+    # instruction asset を tool 別の単一ファイル (claude-code: CLAUDE.md /
+    # codex: AGENTS.md) として生成する。所有 marker は HTML コメントで本体に埋める
+    # (instruction は単一ファイル所有なので skill の dir sidecar marker が使えない)。
+    def build_instruction(tool, asset)
+      filename = ArtifactTargets::INSTRUCTION_FILENAMES[tool]
+      unless filename
+        @skipped << "#{asset[:manifest_path]}: instruction unsupported for #{tool}"
+        return
+      end
+      source = asset[:source]["path"]
+      format = asset[:source]["format"]
+      if format == "directory"
+        @skipped << "#{asset[:manifest_path]}: instruction must be a single file, not a directory"
+        return
+      end
+
+      out_dir = File.join(@root, "generated", tool, "instructions")
+      FileUtils.mkdir_p(out_dir)
+      out = File.join(out_dir, filename)
+      content = File.read(File.join(@root, source))
+      build_id = Build.build_id_for(@root, source, format)
+      File.write(out, instruction_with_marker(content, asset[:name], tool, source, build_id))
+      @built << rel(out)
+    end
+
+    # instruction 本体の先頭に管理 marker (HTML コメント) を 1 行入れる。
+    # marker は injection checker が除外し、sync が所有判定に使う (後続実装)。
+    def instruction_with_marker(content, name, tool, source, build_id)
+      marker = "<!-- agent-tools:managed v=1 repo=agent-tools " \
+               "name=#{name} target=#{tool} artifact_kind=instruction " \
+               "source=#{source} build_id=#{build_id} -->"
+      "#{marker}\n#{content}"
     end
 
     def copy_directory_asset(source, out_dir)

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -38,6 +38,7 @@ module CheckManifests
       @root = File.expand_path(root)
       @errors = []
       @declared_names = Hash.new { |h, k| h[k] = [] }
+      @instruction_targets = Hash.new { |h, k| h[k] = [] }
     end
 
     def run
@@ -86,6 +87,7 @@ module CheckManifests
       end
 
       @declared_names[data["name"]] << path if data["name"].is_a?(String)
+      collect_instruction_targets(data, path)
 
       validate_schema_version(path, data["schema_version"]) if data.key?("schema_version")
       validate_name(path, data["name"]) if data.key?("name")
@@ -256,21 +258,32 @@ module CheckManifests
       end
     end
 
+    # instruction artifact を生成する asset を target 別に集める。validate 済みの
+    # data をそのまま使い (Assets.load_all で再パースしない)、壊れた manifest でも
+    # クラッシュしないようにする。directory format の instruction はここで reject する。
+    def collect_instruction_targets(data, path)
+      targets = data["targets"]
+      return unless targets.is_a?(Array)
+
+      asset = Assets.from_manifest(data, path)
+      instruction_tools = targets.select do |tool|
+        tool.is_a?(String) && ArtifactTargets.resolve(asset, tool) == "instruction"
+      end
+      return if instruction_tools.empty?
+
+      instruction_tools.each { |tool| @instruction_targets[tool] << path }
+
+      format = asset[:source].is_a?(Hash) ? asset[:source]["format"] : nil
+      if format == "directory"
+        error(path, "instruction asset must be a single file, not a directory format")
+      end
+    end
+
     # 1 つの target に instruction artifact を生成する asset は高々 1 個。
     # 複数あると CLAUDE.md / AGENTS.md をどの asset で生成するか決まらない
     # (後勝ち上書きを防ぐ)。
     def check_instruction_uniqueness
-      by_target = Hash.new { |h, k| h[k] = [] }
-      Assets.load_all(@root).each do |asset|
-        next unless asset[:targets].is_a?(Array)
-
-        asset[:targets].each do |tool|
-          next unless ArtifactTargets.resolve(asset, tool) == "instruction"
-
-          by_target[tool] << asset[:manifest_path]
-        end
-      end
-      by_target.each do |tool, paths|
+      @instruction_targets.each do |tool, paths|
         next if paths.size < 2
 
         paths.sort.each do |path|

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -258,14 +258,16 @@ module CheckManifests
       end
     end
 
-    # instruction artifact を生成する asset を target 別に集める。validate 済みの
-    # data をそのまま使い (Assets.load_all で再パースしない)、壊れた manifest でも
-    # クラッシュしないようにする。directory format の instruction はここで reject する。
+    # instruction artifact を生成する asset を target 別に集める。schema の型検証が
+    # 終わる前に呼ばれるため、Assets.from_manifest (risk/review の型を仮定する) は
+    # 使わず、resolve に必要な kind / compatibility / source.format だけを安全に読む
+    # (valid YAML だが型不正な manifest でもクラッシュしない)。directory format の
+    # instruction はここで reject する。
     def collect_instruction_targets(data, path)
       targets = data["targets"]
       return unless targets.is_a?(Array)
 
-      asset = Assets.from_manifest(data, path)
+      asset = { kind: data["kind"], compatibility: data["compatibility"] }
       instruction_tools = targets.select do |tool|
         tool.is_a?(String) && ArtifactTargets.resolve(asset, tool) == "instruction"
       end
@@ -273,7 +275,8 @@ module CheckManifests
 
       instruction_tools.each { |tool| @instruction_targets[tool] << path }
 
-      format = asset[:source].is_a?(Hash) ? asset[:source]["format"] : nil
+      source = data["source"]
+      format = source.is_a?(Hash) ? source["format"] : nil
       if format == "directory"
         error(path, "instruction asset must be a single file, not a directory format")
       end

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -10,6 +10,7 @@ require "yaml"
 
 require_relative "yaml_util"
 require_relative "assets"
+require_relative "artifact_targets"
 
 module CheckManifests
   KINDS = %w[skill prompt workflow agent instruction template].freeze
@@ -44,6 +45,7 @@ module CheckManifests
       manifests.each { |path| validate_manifest(path) }
       check_duplicate_names
       check_sources_have_manifests
+      check_instruction_uniqueness
       [manifests.size, @errors]
     end
 
@@ -250,6 +252,30 @@ module CheckManifests
         paths.each do |path|
           others = (paths - [path]).join(", ")
           error(path, "duplicate asset name #{name.inspect} (also declared in #{others})")
+        end
+      end
+    end
+
+    # 1 つの target に instruction artifact を生成する asset は高々 1 個。
+    # 複数あると CLAUDE.md / AGENTS.md をどの asset で生成するか決まらない
+    # (後勝ち上書きを防ぐ)。
+    def check_instruction_uniqueness
+      by_target = Hash.new { |h, k| h[k] = [] }
+      Assets.load_all(@root).each do |asset|
+        next unless asset[:targets].is_a?(Array)
+
+        asset[:targets].each do |tool|
+          next unless ArtifactTargets.resolve(asset, tool) == "instruction"
+
+          by_target[tool] << asset[:manifest_path]
+        end
+      end
+      by_target.each do |tool, paths|
+        next if paths.size < 2
+
+        paths.sort.each do |path|
+          others = (paths - [path]).sort.join(", ")
+          error(path, "multiple instruction assets target #{tool} (also: #{others}); only one allowed")
         end
       end
     end

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -194,6 +194,50 @@ grep -q "kept (unmanaged, no agent-tools marker): generated/codex/skills/persona
   || fail "unmanaged directory must not be pruned"
 [ -d "$tmp/ok/generated/codex/skills/personal-demo" ] || fail "live artifact must survive prune"
 
+# --- case 4c: instruction asset は tool 別の単一ファイルとして生成される ---
+mkdir -p "$tmp/instr/shared/instructions"
+cat > "$tmp/instr/shared/instructions/personal-ops.md" <<'EOF'
+# operating rules
+
+ドキュメントは日本語を既定にする。
+EOF
+cat > "$tmp/instr/shared/instructions/personal-ops.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-ops
+kind: instruction
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/instructions/personal-ops.md
+  format: markdown
+EOF
+
+"$build" --root "$tmp/instr" > "$tmp/out-instr" 2>&1 \
+  || fail "instruction build should pass: $(cat "$tmp/out-instr")"
+claude_instr="$tmp/instr/generated/claude-code/instructions/CLAUDE.md"
+codex_instr="$tmp/instr/generated/codex/instructions/AGENTS.md"
+[ -f "$claude_instr" ] || fail "missing generated CLAUDE.md"
+[ -f "$codex_instr" ] || fail "missing generated AGENTS.md"
+head -1 "$claude_instr" | grep -q "agent-tools:managed" \
+  || fail "instruction marker missing: $(head -1 "$claude_instr")"
+head -1 "$claude_instr" | grep -q "artifact_kind=instruction" \
+  || fail "instruction marker kind missing: $(head -1 "$claude_instr")"
+head -1 "$claude_instr" | grep -q "target=claude-code" \
+  || fail "claude marker target missing: $(head -1 "$claude_instr")"
+head -1 "$claude_instr" | grep -q "build_id=sha256:" \
+  || fail "instruction marker build_id missing: $(head -1 "$claude_instr")"
+head -1 "$codex_instr" | grep -q "target=codex" \
+  || fail "codex marker target missing: $(head -1 "$codex_instr")"
+grep -q "ドキュメントは日本語" "$claude_instr" \
+  || fail "instruction body missing in CLAUDE.md"
+[ ! -d "$tmp/instr/generated/claude-code/skills" ] \
+  || fail "instruction must not be generated as a skill"
+
 # --- case 5: repository 本体が build できる ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$build" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -199,6 +199,28 @@ fi
 grep -q "YAML parse error" "$tmp/out-yamlbad" \
   || fail "missing YAML parse error (uniqueness check must not crash) in: $(cat "$tmp/out-yamlbad")"
 
+# --- case 4e: valid YAML だが型不正 (risk が mapping でない) でもクラッシュしない ---
+mkdir -p "$tmp/badtype/shared/instructions"
+echo "# ops" > "$tmp/badtype/shared/instructions/personal-ops.md"
+cat > "$tmp/badtype/shared/instructions/personal-ops.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-ops
+kind: instruction
+visibility: public
+targets:
+  - codex
+risk: low
+source:
+  path: shared/instructions/personal-ops.md
+  format: markdown
+EOF
+
+if "$check" --root "$tmp/badtype" > "$tmp/out-badtype" 2>&1; then
+  fail "malformed risk type should fail"
+fi
+grep -q "risk must be a mapping" "$tmp/out-badtype" \
+  || fail "expected clean risk validation error (no crash) in: $(cat "$tmp/out-badtype")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -138,6 +138,32 @@ fi
 grep -q 'duplicate asset name "personal-x"' "$tmp/out-dup" \
   || fail "missing duplicate name error in: $(cat "$tmp/out-dup")"
 
+# --- case 4b: 同一 target に instruction asset が複数あると fail ---
+mkdir -p "$tmp/dupinstr/shared/instructions"
+for n in ops rules; do
+  echo "# $n" > "$tmp/dupinstr/shared/instructions/personal-$n.md"
+  cat > "$tmp/dupinstr/shared/instructions/personal-$n.asset.yml" <<EOF
+schema_version: 1
+name: personal-$n
+kind: instruction
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/instructions/personal-$n.md
+  format: markdown
+EOF
+done
+
+if "$check" --root "$tmp/dupinstr" > "$tmp/out-dupinstr" 2>&1; then
+  fail "duplicate instruction targets should fail"
+fi
+grep -q "multiple instruction assets target claude-code" "$tmp/out-dupinstr" \
+  || fail "missing instruction uniqueness error in: $(cat "$tmp/out-dupinstr")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -164,6 +164,41 @@ fi
 grep -q "multiple instruction assets target claude-code" "$tmp/out-dupinstr" \
   || fail "missing instruction uniqueness error in: $(cat "$tmp/out-dupinstr")"
 
+# --- case 4c: directory format の instruction は fail ---
+mkdir -p "$tmp/dirinstr/shared/instructions/personal-ops"
+echo "# ops" > "$tmp/dirinstr/shared/instructions/personal-ops/CLAUDE.md"
+cat > "$tmp/dirinstr/shared/instructions/personal-ops/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-ops
+kind: instruction
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/instructions/personal-ops
+  format: directory
+EOF
+
+if "$check" --root "$tmp/dirinstr" > "$tmp/out-dirinstr" 2>&1; then
+  fail "directory instruction should fail"
+fi
+grep -q "instruction asset must be a single file" "$tmp/out-dirinstr" \
+  || fail "missing directory instruction error in: $(cat "$tmp/out-dirinstr")"
+
+# --- case 4d: YAML パース不能な manifest でもクラッシュせず error 報告 ---
+mkdir -p "$tmp/yamlbad/shared/prompts"
+echo "# x" > "$tmp/yamlbad/shared/prompts/personal-x.md"
+printf 'name: [unclosed\n' > "$tmp/yamlbad/shared/prompts/personal-x.asset.yml"
+
+if "$check" --root "$tmp/yamlbad" > "$tmp/out-yamlbad" 2>&1; then
+  fail "unparseable manifest should fail"
+fi
+grep -q "YAML parse error" "$tmp/out-yamlbad" \
+  || fail "missing YAML parse error (uniqueness check must not crash) in: $(cat "$tmp/out-yamlbad")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \


### PR DESCRIPTION
## 概要
#48(instruction artifact kind)を依存順に 4 分割した最初の PR(**生成まで**)。instruction を build pipeline に乗せ、tool 別の単一ファイルとして生成できるようにする。

## 変更
- **`scripts/lib/artifact_targets.rb`(新規)**: artifact_kind resolver を dependency-light な独立 module に切り出す。build と check-manifests が共有(`Build → Gate → CheckManifests` の循環 require を避けるための独立化)。`SUPPORTED_KINDS = [skill, instruction]`、tool 別の instruction ファイル名(claude-code=CLAUDE.md / codex=AGENTS.md)を保持。
- **build**: instruction を `generated/<tool>/instructions/<CLAUDE.md|AGENTS.md>` に生成。所有 marker は単一ファイル所有のため HTML コメントで本体先頭に 1 行埋める(skill の dir sidecar marker が使えないため)。`directory` format は instruction では非対応(skip)。
- **check-manifests**: 同一 target に instruction を生成する asset が複数あると fail(後勝ち上書き防止)。
- **docs**: `docs/instruction-artifact-kind.md` を追加(全体設計 + 実装状況)。`asset-manifest-schema.md` の compatibility 節に artifact_kind を明記。
- **self-test**: build / check-manifests に instruction case を追加。

## スコープ外(後続 PR)
- PR-2: catalog の target-artifact 化 + register のビルド可能性証明
- PR-3: sync の instruction 配置 + connect script
- PR-4: status/doctor/prune の instruction 対応 + injection の instruction strict + 実 asset 投入

marker の厳密パース(sync 側)、injection checker の marker 除外、instruction の strict gate は、それぞれ対応する後続 PR で実装する。本 PR は **生成のみ**。

## checks
- 全 self-test(7本)pass。
- `check-manifests / check-injection / build / register / status --json / doctor` で repo 本体が通る。
- 既存 skill asset の生成挙動は不変(`personal-project-operating-loop` は従来どおり skill 生成)。

Refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)