### PR TITLE
Add connect script and instruction marker module (#48 PR-3a)

### DIFF
--- a/docs/instruction-artifact-kind.md
+++ b/docs/instruction-artifact-kind.md
@@ -69,9 +69,25 @@ instruction (public, 配布) には具体的な参照先 (planning tool の URL 
 - sync は catalog を source of truth として列挙し、registered の instruction だけを
   所有ファイルとして配置する。
 
+## connect の挙動
+
+`scripts/connect.sh` が接続を確立する (default dry-run、`--apply` で書き込み、冪等):
+
+- **claude-code**: `<claude home>/agent-tools/CLAUDE.md` を所有ファイルとして作成し
+  (generated instruction をコピー)、`<claude home>/CLAUDE.md` に `@agent-tools/CLAUDE.md`
+  の import 1 行を足す。既存内容と改行スタイルは保持し、import が既にあれば no-op。
+- **codex**: `<codex home>/AGENTS.md` を直接所有する。空ファイル (空白のみ) のみ claim 可。
+- symlink / dir / 特殊ファイルは決して触らない。所有ファイルに unmanaged な中身が
+  あれば conflict として停止し、何も書き込まない。
+
+marker の生成・解析は `scripts/lib/instruction_marker.rb` に集約し、build (生成) と
+connect / sync (所有判定) が同じ format を共有する。
+
 ## 実装状況
 
 - 実装済み: artifact_kind resolver (`scripts/lib/artifact_targets.rb`)、build の
-  instruction 生成、ファイル内コメント marker、check-manifests の 1-per-target 検証。
-- 後続: catalog の target-artifact 化と register のビルド可能性証明、sync の instruction
-  配置と connect、status / doctor / prune の instruction 対応、injection の instruction strict。
+  instruction 生成、ファイル内コメント marker (`scripts/lib/instruction_marker.rb`)、
+  check-manifests の 1-per-target 検証、catalog の target-artifact 化と register の
+  ビルド可能性証明、connect (`scripts/connect.sh`)。
+- 後続: sync の instruction 配置 (catalog 列挙源化)、status / doctor / prune の
+  instruction 対応、injection の instruction strict。

--- a/scripts/connect.sh
+++ b/scripts/connect.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# instruction の所有ファイルを確立し、人間の instruction ファイルから繋ぎ込む。
+# 人間のファイルに触る唯一の操作 (日常 build/sync は触らない)。
+# Spec: docs/instruction-artifact-kind.md
+# 依存: macOS 標準 Ruby のみ。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec ruby "$script_dir/lib/connect.rb" "$@"

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -15,6 +15,7 @@ require "fileutils"
 require_relative "assets"
 require_relative "gate"
 require_relative "artifact_targets"
+require_relative "instruction_marker"
 
 module Build
   TOOLS = %w[codex claude-code].freeze
@@ -95,11 +96,9 @@ module Build
     end
 
     # instruction 本体の先頭に管理 marker (HTML コメント) を 1 行入れる。
-    # marker は injection checker が除外し、sync が所有判定に使う (後続実装)。
+    # marker format は InstructionMarker に集約し、connect / sync が同じ解析を使う。
     def instruction_with_marker(content, name, tool, source, build_id)
-      marker = "<!-- agent-tools:managed v=1 repo=agent-tools " \
-               "name=#{name} target=#{tool} artifact_kind=instruction " \
-               "source=#{source} build_id=#{build_id} -->"
+      marker = InstructionMarker.render(name: name, target: tool, source: source, build_id: build_id)
       "#{marker}\n#{content}"
     end
 

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -81,6 +81,9 @@ module Connect
     # 所有ファイルの create / 接続済み skip / conflict を判定する。
     # symlink / dir / 特殊ファイルは触らない。空ファイルのみ claim 可。
     def owned_plan(tool, gen, owned)
+      if File.symlink?(File.dirname(owned))
+        return Plan.new("conflict", tool, "owned", owned, "owned parent dir is a symlink", gen)
+      end
       if File.symlink?(owned)
         return Plan.new("conflict", tool, "owned", owned, "owned path is a symlink", gen)
       end
@@ -105,6 +108,9 @@ module Connect
       if File.symlink?(import_file)
         return Plan.new("conflict", tool, "import", import_file, "CLAUDE.md is a symlink", nil)
       end
+      if File.exist?(import_file) && !File.file?(import_file)
+        return Plan.new("conflict", tool, "import", import_file, "CLAUDE.md is not a regular file", nil)
+      end
       if File.file?(import_file)
         content = File.read(import_file)
         if content.lines.any? { |l| l.strip == CLAUDE_IMPORT }
@@ -123,8 +129,9 @@ module Connect
     def do_add_import(plan)
       if File.file?(plan.path)
         content = File.read(plan.path)
-        sep = content.empty? || content.end_with?("\n") ? "" : "\n"
-        File.write(plan.path, "#{content}#{sep}#{CLAUDE_IMPORT}\n")
+        nl = content.include?("\r\n") ? "\r\n" : "\n"
+        sep = content.empty? || content.end_with?(nl) ? "" : nl
+        File.write(plan.path, "#{content}#{sep}#{CLAUDE_IMPORT}#{nl}")
       else
         FileUtils.mkdir_p(File.dirname(plan.path))
         File.write(plan.path, "#{CLAUDE_IMPORT}\n")

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -1,0 +1,200 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# connect: instruction の所有ファイルを確立し、人間の instruction ファイルから繋ぎ込む。
+# Spec: docs/instruction-artifact-kind.md
+#
+# - これが人間のファイルに触る唯一の操作。日常の build / sync は触らない。
+# - default は dry-run。書き込みには --apply が必須。
+# - 冪等: 既に接続済みなら no-op。
+# - claude-code: <claude home>/agent-tools/CLAUDE.md を所有し、<claude home>/CLAUDE.md に
+#   import 1 行を足す。
+# - codex: import 非対応のため <codex home>/AGENTS.md を直接所有する (空ファイルのみ
+#   claim 可。中身があれば conflict)。
+# - symlink / 非通常ファイルは決して触らない。
+# - 外部依存ゼロ、network access なし。
+
+require "fileutils"
+
+require_relative "instruction_marker"
+
+module Connect
+  # 人間の CLAUDE.md から所有ファイルを取り込む import 行。
+  CLAUDE_IMPORT = "@agent-tools/CLAUDE.md"
+
+  Plan = Struct.new(:action, :tool, :kind, :path, :reason, :gen) do
+    def to_s
+      line = "#{action}: [#{tool}] #{kind} #{path}"
+      reason ? "#{line} (#{reason})" : line
+    end
+  end
+
+  class Runner
+    def initialize(root, homes)
+      @root = File.expand_path(root)
+      @homes = homes
+    end
+
+    def plan
+      claude_plans + codex_plans
+    end
+
+    def apply(plans)
+      plans.each do |p|
+        case p.action
+        when "create" then do_create(p)
+        when "add-import" then do_add_import(p)
+        end
+      end
+    end
+
+    private
+
+    def generated_instruction(tool, filename)
+      path = File.join(@root, "generated", tool, "instructions", filename)
+      File.file?(path) ? path : nil
+    end
+
+    # claude-code: 所有ファイル (agent-tools/CLAUDE.md) と人間の CLAUDE.md への import。
+    def claude_plans
+      tool = "claude-code"
+      home = @homes.fetch(tool)
+      gen = generated_instruction(tool, "CLAUDE.md")
+      return [] unless gen # instruction artifact が無ければ connect 不要
+
+      owned = File.join(home, "agent-tools", "CLAUDE.md")
+      import_file = File.join(home, "CLAUDE.md")
+      [owned_plan(tool, gen, owned), claude_import_plan(tool, import_file)]
+    end
+
+    # codex: import 非対応なのでグローバル AGENTS.md を直接所有する。
+    def codex_plans
+      tool = "codex"
+      home = @homes.fetch(tool)
+      gen = generated_instruction(tool, "AGENTS.md")
+      return [] unless gen
+
+      owned = File.join(home, "AGENTS.md")
+      [owned_plan(tool, gen, owned)]
+    end
+
+    # 所有ファイルの create / 接続済み skip / conflict を判定する。
+    # symlink / dir / 特殊ファイルは触らない。空ファイルのみ claim 可。
+    def owned_plan(tool, gen, owned)
+      if File.symlink?(owned)
+        return Plan.new("conflict", tool, "owned", owned, "owned path is a symlink", gen)
+      end
+      if File.exist?(owned) && !File.file?(owned)
+        return Plan.new("conflict", tool, "owned", owned, "owned path is not a regular file", gen)
+      end
+      return Plan.new("create", tool, "owned", owned, nil, gen) unless File.exist?(owned)
+
+      content = File.read(owned)
+      if content.strip.empty?
+        return Plan.new("create", tool, "owned", owned, "claiming empty file", gen)
+      end
+      if InstructionMarker.managed?(content, tool)
+        return Plan.new("skip", tool, "owned", owned, "already connected", gen)
+      end
+
+      Plan.new("conflict", tool, "owned", owned, "unmanaged file at owned path", gen)
+    end
+
+    # 人間の CLAUDE.md へ import 1 行を足す plan。symlink は触らない。冪等。
+    def claude_import_plan(tool, import_file)
+      if File.symlink?(import_file)
+        return Plan.new("conflict", tool, "import", import_file, "CLAUDE.md is a symlink", nil)
+      end
+      if File.file?(import_file)
+        content = File.read(import_file)
+        if content.lines.any? { |l| l.strip == CLAUDE_IMPORT }
+          return Plan.new("skip", tool, "import", import_file, "import already present", nil)
+        end
+      end
+      Plan.new("add-import", tool, "import", import_file, nil, nil)
+    end
+
+    def do_create(plan)
+      FileUtils.mkdir_p(File.dirname(plan.path))
+      FileUtils.cp(plan.gen, plan.path)
+    end
+
+    # 既存内容と改行スタイルを保持して import 1 行を追記する。
+    def do_add_import(plan)
+      if File.file?(plan.path)
+        content = File.read(plan.path)
+        sep = content.empty? || content.end_with?("\n") ? "" : "\n"
+        File.write(plan.path, "#{content}#{sep}#{CLAUDE_IMPORT}\n")
+      else
+        FileUtils.mkdir_p(File.dirname(plan.path))
+        File.write(plan.path, "#{CLAUDE_IMPORT}\n")
+      end
+    end
+  end
+
+  def self.main(argv)
+    root = Dir.pwd
+    apply = false
+    quiet = false
+    homes = {
+      "codex" => File.expand_path("~/.codex"),
+      "claude-code" => File.expand_path("~/.claude"),
+    }
+    until argv.empty?
+      case (arg = argv.shift)
+      when "--root"
+        root = argv.shift or abort_usage
+      when "--apply"
+        apply = true
+      when "--codex-home"
+        homes["codex"] = File.expand_path(argv.shift || abort_usage)
+      when "--claude-home"
+        homes["claude-code"] = File.expand_path(argv.shift || abort_usage)
+      when "--quiet"
+        quiet = true
+      when "-h", "--help"
+        print_usage
+        return 0
+      else
+        warn "unknown option: #{arg}"
+        abort_usage
+      end
+    end
+
+    runner = Runner.new(root, homes)
+    plans = runner.plan
+
+    if plans.empty?
+      puts "ok: no instruction artifacts to connect (run scripts/build.sh first)" unless quiet
+      return 0
+    end
+
+    plans.each { |p| puts p.to_s.sub(Dir.home, "~") }
+
+    conflicts = plans.select { |p| p.action == "conflict" }
+    unless conflicts.empty?
+      warn "fail: #{conflicts.size} conflict(s); nothing was applied"
+      return 1
+    end
+
+    changes = plans.count { |p| %w[create add-import].include?(p.action) }
+    if apply
+      runner.apply(plans)
+      puts "ok: applied #{changes} change(s)" unless quiet
+    else
+      puts "ok: dry-run only, #{changes} change(s) pending (use --apply to write)" unless quiet
+    end
+    0
+  end
+
+  def self.print_usage
+    puts "usage: connect.sh [--root DIR] [--apply] [--codex-home DIR] [--claude-home DIR] [--quiet]"
+  end
+
+  def self.abort_usage
+    print_usage
+    exit 2
+  end
+end
+
+exit Connect.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/instruction_marker.rb
+++ b/scripts/lib/instruction_marker.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# instruction artifact の管理 marker (ファイル内 HTML コメント) の生成と解析を
+# 1 箇所に集約する。build が生成し、connect / sync が所有判定に使う。
+#
+# format: 本体先頭行に 1 行。
+#   <!-- agent-tools:managed v=1 repo=agent-tools name=... target=... \
+#        artifact_kind=instruction source=... build_id=... -->
+#
+# 値に空白を含まない前提 (name=kebab, source=path, build_id=sha256:..., target=tool)。
+module InstructionMarker
+  PREFIX = "<!-- agent-tools:managed"
+  SUFFIX = "-->"
+  VERSION = "1"
+  REQUIRED_FIELDS = %w[v repo name target artifact_kind source build_id].freeze
+
+  # marker 行を生成する。
+  def self.render(name:, target:, source:, build_id:)
+    "#{PREFIX} v=#{VERSION} repo=agent-tools " \
+      "name=#{name} target=#{target} artifact_kind=instruction " \
+      "source=#{source} build_id=#{build_id} #{SUFFIX}"
+  end
+
+  # content の先頭行から marker を厳密に解析する。
+  # 妥当な agent-tools instruction marker でなければ nil を返す。
+  def self.parse(content)
+    first = content.to_s.lines.first&.strip
+    return nil unless first&.start_with?(PREFIX) && first.end_with?(SUFFIX)
+
+    body = first[PREFIX.length...-SUFFIX.length].strip
+    pairs = {}
+    body.split(/\s+/).each do |token|
+      key, value = token.split("=", 2)
+      return nil if value.nil? || value.empty?
+
+      return nil if pairs.key?(key) # 重複キーは不正
+
+      pairs[key] = value
+    end
+
+    return nil unless REQUIRED_FIELDS.all? { |f| pairs.key?(f) }
+    return nil unless pairs["v"] == VERSION
+    return nil unless pairs["repo"] == "agent-tools"
+    return nil unless pairs["artifact_kind"] == "instruction"
+
+    pairs
+  end
+
+  # content が指定 target の agent-tools instruction として管理されているか。
+  def self.managed?(content, target)
+    marker = parse(content)
+    !marker.nil? && marker["target"] == target
+  end
+end

--- a/scripts/lib/instruction_marker.rb
+++ b/scripts/lib/instruction_marker.rb
@@ -38,10 +38,14 @@ module InstructionMarker
       pairs[key] = value
     end
 
-    return nil unless REQUIRED_FIELDS.all? { |f| pairs.key?(f) }
+    # 厳密: 必須フィールドと完全一致する (余分キーは不正)。
+    return nil unless pairs.keys.sort == REQUIRED_FIELDS.sort
     return nil unless pairs["v"] == VERSION
     return nil unless pairs["repo"] == "agent-tools"
     return nil unless pairs["artifact_kind"] == "instruction"
+    # 値形式の基本検証: build_id は hash、source は相対 path。
+    return nil unless pairs["build_id"].start_with?("sha256:")
+    return nil if pairs["source"].start_with?("/")
 
     pairs
   end

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -103,4 +103,36 @@ status=0
 grep -q "conflict: \[claude-code\] import.*symlink" "$tmp/c6" || fail "missing symlink conflict: $(cat "$tmp/c6")"
 [ -L "$tmp/claude4/CLAUDE.md" ] || fail "symlink must not be replaced"
 
+# --- case 7: CLAUDE.md がディレクトリなら conflict (部分適用しない) ---
+mkdir -p "$tmp/codex5" "$tmp/claude5/CLAUDE.md"
+status=0
+"$connect" --root "$tmp/repo" --codex-home "$tmp/codex5" --claude-home "$tmp/claude5" --apply > "$tmp/c7" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "directory CLAUDE.md should conflict: $(cat "$tmp/c7")"
+grep -q "conflict: \[claude-code\] import.*not a regular file" "$tmp/c7" || fail "missing non-regular conflict: $(cat "$tmp/c7")"
+[ ! -e "$tmp/claude5/agent-tools/CLAUDE.md" ] || fail "conflict must prevent owned write"
+
+# --- case 8: 余分キーを持つ marker は managed と認識しない (厳密 parse) ---
+mkdir -p "$tmp/codex6" "$tmp/claude6"
+printf '<!-- agent-tools:managed v=1 repo=agent-tools name=x target=codex artifact_kind=instruction source=shared/x.md build_id=sha256:abc evil=1 -->\nbody\n' > "$tmp/codex6/AGENTS.md"
+status=0
+"$connect" --root "$tmp/repo" --codex-home "$tmp/codex6" --claude-home "$tmp/claude6" --apply > "$tmp/c8" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "marker with extra key should not be managed: $(cat "$tmp/c8")"
+grep -q "conflict: \[codex\] owned.*unmanaged" "$tmp/c8" || fail "extra-key marker should be treated as unmanaged: $(cat "$tmp/c8")"
+
+# --- case 9: CRLF の CLAUDE.md に import を足しても改行スタイルを保つ ---
+mkdir -p "$tmp/codex7" "$tmp/claude7"
+printf '# notes\r\nhello\r\n' > "$tmp/claude7/CLAUDE.md"
+"$connect" --root "$tmp/repo" --codex-home "$tmp/codex7" --claude-home "$tmp/claude7" --apply > /dev/null 2>&1
+ruby -e 'c=File.binread(ARGV[0]); abort "CRLF not preserved" unless c.include?("@agent-tools/CLAUDE.md\r\n")' \
+  "$tmp/claude7/CLAUDE.md" || fail "import line should keep CRLF newline style"
+
+# --- case 10: 所有先の親 dir が symlink なら conflict (意図外書き込みを防ぐ) ---
+mkdir -p "$tmp/codex8" "$tmp/claude8" "$tmp/realdir"
+ln -s "$tmp/realdir" "$tmp/claude8/agent-tools"
+status=0
+"$connect" --root "$tmp/repo" --codex-home "$tmp/codex8" --claude-home "$tmp/claude8" --apply > "$tmp/c10" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlinked owned parent should conflict: $(cat "$tmp/c10")"
+grep -q "conflict: \[claude-code\] owned.*symlink" "$tmp/c10" || fail "missing parent symlink conflict: $(cat "$tmp/c10")"
+[ ! -e "$tmp/realdir/CLAUDE.md" ] || fail "must not write through a symlinked parent"
+
 echo "ok: connect self-test passed"

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# connect.sh の self-test。
+# 一時 directory に fixture と fake tool homes を生成して検証する。
+# 実際の ~/.codex / ~/.claude には一切触れない。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+build="$script_dir/../build.sh"
+connect="$script_dir/../connect.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+run_connect() {
+  "$connect" --root "$tmp/repo" --codex-home "$tmp/codex" --claude-home "$tmp/claude" "$@"
+}
+
+# --- fixture: instruction asset ---
+mkdir -p "$tmp/repo/shared/instructions" "$tmp/codex" "$tmp/claude"
+cat > "$tmp/repo/shared/instructions/personal-ops.md" <<'EOF'
+# operating rules
+
+ドキュメントは日本語を既定にする。
+EOF
+cat > "$tmp/repo/shared/instructions/personal-ops.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-ops
+kind: instruction
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/instructions/personal-ops.md
+  format: markdown
+EOF
+
+# --- case 0: build 前は connect する artifact が無い ---
+run_connect > "$tmp/c0" 2>&1 || fail "connect without artifacts should succeed: $(cat "$tmp/c0")"
+grep -q "no instruction artifacts to connect" "$tmp/c0" || fail "missing no-artifacts notice: $(cat "$tmp/c0")"
+
+"$build" --root "$tmp/repo" --quiet > /dev/null
+
+# --- case 1: dry-run は plan を出すが書き込まない ---
+run_connect > "$tmp/c1" 2>&1 || fail "dry-run should succeed: $(cat "$tmp/c1")"
+grep -q "create: \[claude-code\] owned" "$tmp/c1" || fail "missing claude owned create: $(cat "$tmp/c1")"
+grep -q "add-import: \[claude-code\] import" "$tmp/c1" || fail "missing claude import plan: $(cat "$tmp/c1")"
+grep -q "create: \[codex\] owned" "$tmp/c1" || fail "missing codex owned create: $(cat "$tmp/c1")"
+grep -q "dry-run only" "$tmp/c1" || fail "missing dry-run notice"
+[ ! -e "$tmp/claude/agent-tools/CLAUDE.md" ] || fail "dry-run must not write owned file"
+[ ! -e "$tmp/claude/CLAUDE.md" ] || fail "dry-run must not write import file"
+[ ! -e "$tmp/codex/AGENTS.md" ] || fail "dry-run must not write codex owned file"
+
+# --- case 2: --apply で所有ファイルと import が作られる ---
+run_connect --apply > "$tmp/c2" 2>&1 || fail "apply should succeed: $(cat "$tmp/c2")"
+[ -f "$tmp/claude/agent-tools/CLAUDE.md" ] || fail "owned CLAUDE.md not created"
+head -1 "$tmp/claude/agent-tools/CLAUDE.md" | grep -q "agent-tools:managed" || fail "owned file missing marker"
+grep -q "ドキュメントは日本語" "$tmp/claude/agent-tools/CLAUDE.md" || fail "owned file missing body"
+grep -q '^@agent-tools/CLAUDE.md$' "$tmp/claude/CLAUDE.md" || fail "import line not added"
+[ -f "$tmp/codex/AGENTS.md" ] || fail "codex AGENTS.md not created (empty file should be claimable)"
+head -1 "$tmp/codex/AGENTS.md" | grep -q "target=codex" || fail "codex owned missing marker"
+
+# --- case 3: 冪等 (再 apply は skip、0 changes) ---
+run_connect --apply > "$tmp/c3" 2>&1 || fail "second apply should succeed: $(cat "$tmp/c3")"
+grep -q "skip: \[claude-code\] owned.*already connected" "$tmp/c3" || fail "owned should skip when connected: $(cat "$tmp/c3")"
+grep -q "skip: \[claude-code\] import.*already present" "$tmp/c3" || fail "import should skip when present"
+grep -q "skip: \[codex\] owned.*already connected" "$tmp/c3" || fail "codex owned should skip"
+grep -q "0 change(s)" "$tmp/c3" || fail "idempotent run should have 0 changes"
+
+# --- case 4: 人間が書いた CLAUDE.md の内容を保持して import を足す ---
+mkdir -p "$tmp/codex2" "$tmp/claude2"
+printf '# my notes\nhello\n' > "$tmp/claude2/CLAUDE.md"
+"$connect" --root "$tmp/repo" --codex-home "$tmp/codex2" --claude-home "$tmp/claude2" --apply > /dev/null 2>&1
+grep -q "hello" "$tmp/claude2/CLAUDE.md" || fail "existing CLAUDE.md content must be preserved"
+grep -q '^@agent-tools/CLAUDE.md$' "$tmp/claude2/CLAUDE.md" || fail "import appended to existing CLAUDE.md"
+
+# --- case 5: codex AGENTS.md に unmanaged な中身があると conflict (書き込まない) ---
+mkdir -p "$tmp/codex3" "$tmp/claude3"
+echo "my codex notes" > "$tmp/codex3/AGENTS.md"
+status=0
+"$connect" --root "$tmp/repo" --codex-home "$tmp/codex3" --claude-home "$tmp/claude3" --apply > "$tmp/c5" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "unmanaged codex AGENTS.md should conflict (exit 1): $(cat "$tmp/c5")"
+grep -q "conflict: \[codex\] owned.*unmanaged" "$tmp/c5" || fail "missing codex conflict: $(cat "$tmp/c5")"
+grep -q "my codex notes" "$tmp/codex3/AGENTS.md" || fail "unmanaged codex file must not be overwritten"
+grep -q "nothing was applied" "$tmp/c5" || fail "conflict should stop all writes"
+[ ! -e "$tmp/claude3/agent-tools/CLAUDE.md" ] || fail "conflict must stop claude writes too"
+
+# --- case 6: claude CLAUDE.md が symlink なら conflict (置き換えない) ---
+mkdir -p "$tmp/codex4" "$tmp/claude4"
+echo "real" > "$tmp/realclaude.md"
+ln -s "$tmp/realclaude.md" "$tmp/claude4/CLAUDE.md"
+status=0
+"$connect" --root "$tmp/repo" --codex-home "$tmp/codex4" --claude-home "$tmp/claude4" --apply > "$tmp/c6" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlink CLAUDE.md should conflict: $(cat "$tmp/c6")"
+grep -q "conflict: \[claude-code\] import.*symlink" "$tmp/c6" || fail "missing symlink conflict: $(cat "$tmp/c6")"
+[ -L "$tmp/claude4/CLAUDE.md" ] || fail "symlink must not be replaced"
+
+echo "ok: connect self-test passed"


### PR DESCRIPTION
## 概要
#48 PR-3 を 3a/3b に分割した前半(**接続まで**)。instruction の所有ファイルを確立し、人間の instruction ファイルから繋ぎ込む `connect` を追加する。**connect は人間のファイルに触る唯一の操作**で、日常 build/sync は触らない不変条件を守る。

## 変更
- **`scripts/lib/instruction_marker.rb`(新規)**: ファイル内コメント marker の生成(`render`)と**厳密解析**(`parse`)を集約。build が生成し、connect / sync が所有判定に使う。重複キー・必須フィールド欠落・version/repo/artifact_kind 不一致を弾く。
- **build**: instruction marker 生成を `InstructionMarker.render` に委譲(format 一元化)。
- **`scripts/connect.sh` + `scripts/lib/connect.rb`(新規)**: 接続を確立(default dry-run、`--apply` で書き込み、冪等)。
  - **claude-code**: `<claude home>/agent-tools/CLAUDE.md` を所有(generated をコピー)+ `<claude home>/CLAUDE.md` に `@agent-tools/CLAUDE.md` の import 1 行(既存内容と改行を保持、既にあれば no-op)。
  - **codex**: `<codex home>/AGENTS.md` を直接所有(空ファイルのみ claim)。
  - symlink / dir / 特殊ファイルは触らない。unmanaged な所有先は conflict で停止し何も書き込まない。
- **self-test**: `connect-test.sh`(dry-run / apply / 冪等 / 既存内容保持 / unmanaged conflict / symlink conflict)。
- docs `instruction-artifact-kind.md` を更新。

## 設計の要点(レビュー観点)
- connect が人間のファイル(`~/.claude/CLAUDE.md`)に触る唯一の経路。symlink 拒否・改行スタイル保持・完全一致 import は no-op・lstat 相当の空判定で安全側に倒す。
- conflict が 1 件でもあれば全 plan の apply を中止(部分適用しない)。

## スコープ外(PR-3b)
- sync の instruction 配置(catalog を source of truth として列挙、registered instruction を所有ファイルへ update)。本 PR の connect は初回 create + import まで。

## checks
- 全 self-test(8本)pass。CI は `scripts/tests/*.sh` を glob 実行するため connect-test も自動で走る(実行権限付与済み)。
- repo 本体(instruction asset 無し)では connect は "no instruction artifacts to connect" で no-op。

Refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)