### PR TITLE
Treat empty instruction owned file as not-yet-connected in sync

### DIFF
--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -164,8 +164,10 @@ module Sync
       if File.symlink?(target) || File.symlink?(File.dirname(target))
         return Plan.new("conflict", tool, name, target, "existing target is a symlink", "instruction", gen)
       end
-      # 未接続 (所有ファイルが無い) なら connect を促す。sync は create しない。
-      unless File.exist?(target)
+      # 未接続なら connect を促す。sync は create しない。
+      # 所有先が無い場合に加え、空ファイル (空白のみ) も未接続として扱う
+      # (codex の AGENTS.md は空で存在しうる。空の claim は connect の責務)。
+      if !File.exist?(target) || (File.file?(target) && File.read(target).strip.empty?)
         return Plan.new("skip", tool, name, target, "run connect first", "instruction", gen)
       end
 

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -186,4 +186,15 @@ status=0
 grep -q "conflict: \[claude-code\].*symlink" "$tmp/out-adsym" || fail "missing parent symlink conflict: $(cat "$tmp/out-adsym")"
 [ ! -e "$tmp/realad/CLAUDE.md" ] || fail "must not write through a symlinked parent"
 
+# --- case 12: 空の instruction 所有先は conflict でなく run connect first ---
+mkdir -p "$tmp/codex12" "$tmp/claude12"
+"$build" --root "$tmp/repo" --quiet > /dev/null
+"$register" --root "$tmp/repo" --quiet > /dev/null
+: > "$tmp/codex12/AGENTS.md"   # 空ファイルが既に存在する状態
+"$sync" --root "$tmp/repo" --codex-home "$tmp/codex12" --claude-home "$tmp/claude12" > "$tmp/out-empty" 2>&1
+grep -q "skip: \[codex\].*run connect first" "$tmp/out-empty" \
+  || fail "empty instruction owned file should say run connect first: $(cat "$tmp/out-empty")"
+! grep -q "conflict: \[codex\]" "$tmp/out-empty" \
+  || fail "empty owned file must not be reported as a conflict: $(cat "$tmp/out-empty")"
+
 echo "ok: sync self-test passed"

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -190,7 +190,7 @@ grep -q "conflict: \[claude-code\].*symlink" "$tmp/out-adsym" || fail "missing p
 mkdir -p "$tmp/codex12" "$tmp/claude12"
 "$build" --root "$tmp/repo" --quiet > /dev/null
 "$register" --root "$tmp/repo" --quiet > /dev/null
-: > "$tmp/codex12/AGENTS.md"   # 空ファイルが既に存在する状態
+printf '   \n\n  \n' > "$tmp/codex12/AGENTS.md"   # 空白のみ (whitespace-only) が既に存在する状態
 "$sync" --root "$tmp/repo" --codex-home "$tmp/codex12" --claude-home "$tmp/claude12" > "$tmp/out-empty" 2>&1
 grep -q "skip: \[codex\].*run connect first" "$tmp/out-empty" \
   || fail "empty instruction owned file should say run connect first: $(cat "$tmp/out-empty")"


### PR DESCRIPTION
## 概要
実投入の dry-run で見つかった UX のほころびを修正する。

codex の所有ファイル `~/.codex/AGENTS.md` は空で存在しうる(codex のグローバル AGENTS.md)。sync の `plan_instruction` はそれを `existing target is unmanaged` の **conflict** と誤判定していた。空ファイルの claim は connect の責務(connect は空を marker 付きで claim する)なので、sync は空の所有先を「未接続」として扱い **"run connect first"** を案内するようにした。claude 側(所有ファイルが無い)と挙動が揃う。

中身がある unmanaged ファイルは従来どおり conflict のまま(誤って人間の内容を上書きしない)。

## before / after(実 home dry-run)
```
before: conflict: [codex] ~/.codex/AGENTS.md (existing target is unmanaged)  → fail
after:  skip:     [codex] ~/.codex/AGENTS.md (run connect first)             → ok
```

## checks
- self-test 追加(空の instruction 所有先は conflict でなく run connect first)。全 self-test(8本)pass。

Refs #48