### PR TITLE
kind taxonomy を整理し README から辿れるようにする (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ scripts/          check / build / sync / status / doctor / register scripts。
 docs/             boundary と policy documents。
 ```
 
+`shared/` 配下のサブディレクトリは整理のための置き場所で、asset の種類は manifest の
+`kind` で決まります。各 `kind` (`skill` / `prompt` / `workflow` / `instruction` /
+`template` / `agent`) の意味・使い分け・配置のされ方は
+[Asset Manifest Schema の「kind」](docs/asset-manifest-schema.md#kind) を参照してください。
+
 ## 現在の scope
 
 scaffold と policy documentation、および check-manifests / check-injection /

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -88,16 +88,32 @@ rules:
 
 ### `kind`
 
-asset の種類です。
+asset の種類を表す意味ラベルです。**用途に応じて選びます**。ただし現在 build / 配置の
+挙動を分けるのは `instruction` か否かだけで、それ以外はすべて skill として配られます
+(下表の「配置挙動」を参照)。kind がどの artifact に解決されるかの仕組みは
+[compatibility / artifact_kind](#compatibility) を参照してください。
 
-allowed values:
+| kind | 意味・用途 | 配置挙動 (artifact_kind) |
+| --- | --- | --- |
+| `skill` | モデルが必要時に参照する手順・能力のまとまり。`SKILL.md` 本体 + 任意の `references/` `assets/` `evals/`。 | `skill` |
+| `prompt` | 定型のプロンプト断片やテンプレート的な指示。 | `skill` (skill として配置) |
+| `workflow` | 複数ステップの再利用可能な作業手順。 | `skill` |
+| `template` | 出力フォーマットなどの雛形。 | `skill` |
+| `instruction` | 常時読まれる運用ルール。tool 別の `CLAUDE.md` / `AGENTS.md` として生成。詳細は [Instruction Artifact Kind](instruction-artifact-kind.md)。 | `instruction` |
+| `agent` | サブエージェント定義。**現状は配備未対応** (各 tool の agent 形式へのマッピングが未設計)。register では `unsupported` になる。 | 未対応 |
 
-- `skill`
-- `prompt`
-- `workflow`
-- `agent`
-- `instruction`
-- `template`
+補足:
+
+- `prompt` / `workflow` / `template` は現状いずれも **skill として build・配置** されます
+  (skill の意味別名)。意味のラベルとして使い分けつつ、配られ方は skill と同じです。
+  必要なら `compatibility.<tool>.artifact_kind` で明示的に上書きできます。
+- `agent` kind は現状 build 対象外で、配備したい需要が出た時点で設計します
+  (各 tool の agent 形式へのマッピングが論点)。
+- `shared/` 配下のサブディレクトリ (`skills/` `prompts/` `workflows/` `agents/`
+  `instructions/`) は **整理のための置き場所**で、kind を決定しません。asset の kind は
+  必ず manifest の `kind` フィールドで決まります (discovery は `shared/**/*.asset.yml`)。
+  例: `personal-project-operating-loop` は `workflows/` 配下にありつつ `kind: workflow`
+  → skill として配置されます。
 
 ### `visibility`
 

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -88,10 +88,12 @@ rules:
 
 ### `kind`
 
-asset の種類を表す意味ラベルです。**用途に応じて選びます**。ただし現在 build / 配置の
-挙動を分けるのは `instruction` か否かだけで、それ以外はすべて skill として配られます
-(下表の「配置挙動」を参照)。kind がどの artifact に解決されるかの仕組みは
-[compatibility / artifact_kind](#compatibility) を参照してください。
+asset の種類を表す意味ラベルです。**用途に応じて選びます**。配置のされ方は kind ごとに
+下表の「配置挙動」のとおりで、配備対象は skill 系 (`skill` / `prompt` / `workflow` /
+`template` → skill target) と `instruction` (→ tool 別の `CLAUDE.md` / `AGENTS.md`) の
+2 系統です。`agent` は現状どの target にも解決されず未対応 (unsupported) です。kind が
+どの artifact に解決されるかの仕組みは [compatibility / artifact_kind](#compatibility)
+を参照してください。
 
 | kind | 意味・用途 | 配置挙動 (artifact_kind) |
 | --- | --- | --- |
@@ -111,7 +113,8 @@ asset の種類を表す意味ラベルです。**用途に応じて選びます
   (各 tool の agent 形式へのマッピングが論点)。
 - `shared/` 配下のサブディレクトリ (`skills/` `prompts/` `workflows/` `agents/`
   `instructions/`) は **整理のための置き場所**で、kind を決定しません。asset の kind は
-  必ず manifest の `kind` フィールドで決まります (discovery は `shared/**/*.asset.yml`)。
+  必ず manifest の `kind` フィールドで決まります (discovery は sidecar manifest
+  `shared/**/*.asset.yml` と directory manifest `shared/**/asset.yml` の両方)。
   例: `personal-project-operating-loop` は `workflows/` 配下にありつつ `kind: workflow`
   → skill として配置されます。
 
@@ -222,8 +225,8 @@ target tool ごとの変換 hint です。
 明示できます。未指定なら asset の `kind` から既定値が導出されます (`instruction` kind は
 instruction、`skill` / `prompt` / `workflow` / `template` は skill)。
 
-build が対応する artifact_kind は `skill` と `instruction` です
-(sync の instruction 配置は後続対応)。
+build が対応する artifact_kind は `skill` と `instruction` です。どちらも build →
+register → sync で配置されます (instruction の所有確立は connect が担当)。
 
 - `skill`: `<tool home>/skills/personal-<name>/` に directory として配る。
 - `instruction`: tool 別の単一ファイル (claude-code は `CLAUDE.md`、codex は `AGENTS.md`)


### PR DESCRIPTION
## 概要

#67。manifest の `kind` は値一覧しか docs に無く、各 kind の意味・使い分けが書かれていなかった。人向けドキュメントとして taxonomy を整理し、README から到達できるようにする。

## 変更点

- **docs/asset-manifest-schema.md** の `kind` セクションを taxonomy 表に拡充:
  - 各 kind の意味・用途、現在の配置挙動 (artifact_kind) を表で明示。
  - `prompt` / `workflow` / `template` は skill の意味別名 (artifact_kind: skill)、`instruction` だけ CLAUDE.md/AGENTS.md 生成、`agent` は配備未対応 (unsupported, #24)。
  - `shared/` サブディレクトリは organizational で kind を決定しない (kind は manifest フィールドで決まる、discovery は glob) ことを明記。例 (workflows/ 配下の workflow → skill 配置) も追加。
- **README.md** の Repository 構成から kind 説明 (`docs/asset-manifest-schema.md#kind`) へのリンクを追加。

## 整合

記述は現行コードの挙動と一致 (`artifact_targets.rb` の `DEFAULT_BY_KIND`: skill/prompt/workflow/template→skill, instruction→instruction, agent は map に無く unsupported)。docs のみの変更で pipeline 非影響。

## レビュー観点

ドキュメント記述と実装挙動の一致、README リンク (アンカー `#kind`) の有効性、説明の正確さ。

Closes #67