### PR TITLE
運用者向けドキュメントを整備する (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ instruction templates を管理するための個人用 AI agent asset repositor
 
 ## インストール / クイックスタート
 
-macOS 標準の Ruby と git だけで動きます(追加依存・ネットワーク不要)。
+各 script は macOS 標準の Ruby だけで動きます(追加依存なし・ネットワーク不要)。clone / pull には git を使います。
 
 ```sh
 git clone <this-repo> agent-tools && cd agent-tools

--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ instruction templates を管理するための個人用 AI agent asset repositor
 
 > 全体像・設計・現在地を一度に把握したい場合は
 > [docs/onboarding.md](docs/onboarding.md) から読んでください。
+> 新しい環境に入れて使う手順は [docs/install-and-usage.md](docs/install-and-usage.md)。
+
+## インストール / クイックスタート
+
+macOS 標準の Ruby と git だけで動きます(追加依存・ネットワーク不要)。
+
+```sh
+git clone <this-repo> agent-tools && cd agent-tools
+./scripts/build.sh            # generated/ に生成
+./scripts/register.sh         # 配ってよい asset を catalog に記録
+./scripts/connect.sh --apply  # instruction の所有を確立(初回のみ)
+./scripts/sync.sh --apply     # tool home に配置
+```
+
+アップデートは `git pull && ./scripts/build.sh && ./scripts/register.sh && ./scripts/sync.sh --apply`
+(`connect` は初回だけ)。前提条件・配置先・トラブルシュートを含む詳細は
+[docs/install-and-usage.md](docs/install-and-usage.md) を参照してください。
 
 この repository は `dotfiles` とは意図的に分離します。
 public repository として公開する前提なので、追跡する内容はすべて公開可能なものに限定します。

--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -7,7 +7,7 @@
 
 - **Ruby**: macOS 標準の Ruby で動きます(YAML stdlib のみ使用)。追加 gem は不要。
 - **git**: clone / pull に使います。
-- ネットワーク不要・外部依存ゼロ。各 script は手元だけで完結します。
+- 各 script はネットワーク不要・外部依存ゼロで、手元だけで完結します。
 - `gh`(GitHub CLI)は asset の利用には不要です。repository へ変更を出す
   (Issue / PR)ときだけ使います。
 

--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -51,6 +51,8 @@ cd agent-tools
 - `connect` は冪等です。既に import 行があれば no-op。symlink / 既存の手書き内容が
   ある所有先は触らず conflict で停止します(何も書きません)。
 - instruction を配らない(skill だけの)構成なら手順 3 は不要です。
+- `register` と `connect` はどちらも `build` の後・`sync` の前であればよく、相互に依存
+  しません(上の番号は推奨順)。`sync` だけが両者(catalog と所有確立)を前提とします。
 
 ## アップデート
 
@@ -92,7 +94,7 @@ git pull
 | 症状(plan / 出力) | 意味 | 対処 |
 | --- | --- | --- |
 | `skip ... (run build first)` | generated が無い / 古い | `./scripts/build.sh` を実行 |
-| `skip ... (run connect first)` | instruction の所有先が未確立 / 空 | `./scripts/connect.sh --apply` |
+| `skip ... (run connect first)` | instruction の所有先が未確立(未接続 / 空ファイル) | `./scripts/connect.sh --apply` |
 | `skip ... (human_review_required)` | catalog で human review 待ち | manifest の `review.human_review` を解決して `register` し直す |
 | `conflict ... (existing target is unmanaged)` | 同名の手書き / 別管理ファイルがある | 中身を確認。agent-tools に委ねてよいなら退避してから再実行(無断上書きはしない) |
 | `conflict ... (existing target is a symlink)` | 所有先 / 親が symlink | symlink を解消するか、別 home を指定 |

--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -1,0 +1,108 @@
+# Install & Usage(運用ガイド)
+
+`agent-tools` を新しい環境に入れて、更新しながら使うための運用者向けランブックです。
+フレームワークの設計や pipeline の中身は [onboarding.md](onboarding.md) を参照してください。
+
+## 前提条件
+
+- **Ruby**: macOS 標準の Ruby で動きます(YAML stdlib のみ使用)。追加 gem は不要。
+- **git**: clone / pull に使います。
+- ネットワーク不要・外部依存ゼロ。各 script は手元だけで完結します。
+- `gh`(GitHub CLI)は asset の利用には不要です。repository へ変更を出す
+  (Issue / PR)ときだけ使います。
+
+配置先となる tool home(既定):
+
+- Codex: `~/.codex`
+- Claude Code: `~/.claude`
+
+## 何がどこに置かれるか
+
+| asset | 配置先 | 確立する操作 |
+| --- | --- | --- |
+| skill | `~/.codex/skills/personal-*` / `~/.claude/skills/personal-*` | `sync`(直接 create) |
+| instruction | `~/.codex/AGENTS.md` / `~/.claude/agent-tools/CLAUDE.md`(人間の `~/.claude/CLAUDE.md` から `@agent-tools/CLAUDE.md` で import) | `connect`(初回所有)→ `sync`(更新) |
+
+skill は隔離 directory なので `sync` が直接置けますが、instruction は共有ファイル
+(`CLAUDE.md` / `AGENTS.md`)に載るため、**先に `connect` で所有を確立**してから
+`sync` が更新します。
+
+## 初回インストール
+
+```sh
+git clone <this-repo> agent-tools
+cd agent-tools
+
+# 1. 生成(generated/ にのみ書き込む。tool home には触れない)
+./scripts/build.sh
+
+# 2. 登録(配ってよい asset を catalog に記録)
+./scripts/register.sh
+
+# 3. 所有の確立(instruction のみ。default dry-run → 確認して --apply)
+./scripts/connect.sh            # 何が起きるか確認
+./scripts/connect.sh --apply    # 実際に所有ファイルを作り、CLAUDE.md に import 1 行を足す
+
+# 4. 配置(default dry-run → 確認して --apply)
+./scripts/sync.sh               # plan を確認(create / update / skip / conflict)
+./scripts/sync.sh --apply       # tool home に反映
+```
+
+- `connect` は冪等です。既に import 行があれば no-op。symlink / 既存の手書き内容が
+  ある所有先は触らず conflict で停止します(何も書きません)。
+- instruction を配らない(skill だけの)構成なら手順 3 は不要です。
+
+## アップデート
+
+```sh
+cd agent-tools
+git pull
+
+./scripts/build.sh
+./scripts/register.sh
+./scripts/sync.sh           # dry-run で差分確認
+./scripts/sync.sh --apply   # 反映
+```
+
+- `connect` は初回だけ。所有が確立済みなら以後の更新は `sync` が担います。
+- source asset を編集したときも同じ流れです(`build` が source の sha256 で
+  `build_id` を再計算し、`sync` が差分のある target だけ `update` します)。
+
+## 日常の使い方
+
+### 状態を見る
+
+```sh
+./scripts/status.sh         # human-readable サマリ(--json で機械可読)
+./scripts/doctor.sh         # 環境点検(ruby/git、tool home、catalog の鮮度など)
+```
+
+どちらも read-only で、state を一切変更しません。
+
+### asset を追加する
+
+1. `shared/<category>/` に source と sidecar manifest(`<name>.asset.yml`)を置く。
+   manifest の書式は [asset-manifest-schema.md](asset-manifest-schema.md)。
+   name は `personal-` 始まりが必須。
+2. `./scripts/check-manifests.sh` と `./scripts/check-injection.sh` で検証。
+3. `build` → `register` → `sync --apply` で配置(上の「アップデート」と同じ)。
+
+## トラブルシュート
+
+| 症状(plan / 出力) | 意味 | 対処 |
+| --- | --- | --- |
+| `skip ... (run build first)` | generated が無い / 古い | `./scripts/build.sh` を実行 |
+| `skip ... (run connect first)` | instruction の所有先が未確立 / 空 | `./scripts/connect.sh --apply` |
+| `skip ... (human_review_required)` | catalog で human review 待ち | manifest の `review.human_review` を解決して `register` し直す |
+| `conflict ... (existing target is unmanaged)` | 同名の手書き / 別管理ファイルがある | 中身を確認。agent-tools に委ねてよいなら退避してから再実行(無断上書きはしない) |
+| `conflict ... (existing target is a symlink)` | 所有先 / 親が symlink | symlink を解消するか、別 home を指定 |
+| `no catalog; run register first` | catalog 未生成 | `./scripts/register.sh` |
+
+`--codex-home` / `--claude-home` で home を上書きできます(検証用)。
+
+## 関連ドキュメント
+
+- pipeline と各 script の役割: [onboarding.md](onboarding.md)
+- コマンド別の詳細 usage: [../scripts/README.md](../scripts/README.md)
+- 配置の安全則: [sync-policy.md](sync-policy.md)
+- instruction の所有モデル: [instruction-artifact-kind.md](instruction-artifact-kind.md)

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -32,6 +32,9 @@ shared/<category>/personal-*        ← source asset + sidecar manifest (.asset.
         │
         ▼  register.sh              generated/catalog.json に「配ってよいか」を記録
         │
+        ▼  connect.sh               instruction のみ: 所有ファイルを確立し CLAUDE.md に
+        │  (--apply, 初回のみ)        import を繋ぐ (skill は不要 / sync が直接 create)
+        │
         ▼  sync.sh                  catalog を見て registered のものだけ tool home に配置
                                     (default dry-run / --apply で実書き込み)
 
@@ -39,7 +42,9 @@ shared/<category>/personal-*        ← source asset + sidecar manifest (.asset.
 ```
 
 実行は手動。典型的には `build.sh && register.sh && sync.sh`
-(dry-run で確認 → `sync.sh --apply`)。CI が PR ごとに全 self-test + 上記一周を回す。
+(dry-run で確認 → `sync.sh --apply`)。instruction を初めて配るときは sync の前に
+`connect.sh --apply` で所有を確立する(冪等・初回のみ)。CI が PR ごとに全 self-test +
+上記一周を回す。新環境への install / update 手順は [install-and-usage](install-and-usage.md)。
 
 ## 3. コンポーネントとコードの場所
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -43,8 +43,10 @@ shared/<category>/personal-*        ← source asset + sidecar manifest (.asset.
 
 実行は手動。典型的には `build.sh && register.sh && sync.sh`
 (dry-run で確認 → `sync.sh --apply`)。instruction を初めて配るときは sync の前に
-`connect.sh --apply` で所有を確立する(冪等・初回のみ)。CI が PR ごとに全 self-test +
-上記一周を回す。新環境への install / update 手順は [install-and-usage](install-and-usage.md)。
+`connect.sh --apply` で所有を確立する(冪等・初回のみ)。`register` と `connect` は
+build 後・sync 前であればよく相互依存しない(図は直列に見えるが推奨順)。CI が PR ごとに
+全 self-test + 上記一周を回す。新環境への install / update 手順は
+[install-and-usage](install-and-usage.md)。
 
 ## 3. コンポーネントとコードの場所
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,6 +49,24 @@ usage: build.sh [--root DIR] [--prune] [--quiet]
   directory は警告して残す。
 - self-test: `tests/build-test.sh`
 
+- `connect.sh`: instruction の所有ファイルを確立し、人間の instruction ファイルから
+  繋ぎ込む。[Instruction Artifact Kind](../docs/instruction-artifact-kind.md) に従う。
+
+```text
+usage: connect.sh [--root DIR] [--apply] [--codex-home DIR] [--claude-home DIR] [--quiet]
+```
+
+- default は dry-run。書き込みには `--apply` が必須。冪等(再実行しても安全)。
+- **claude-code**: `<claude home>/agent-tools/CLAUDE.md` を所有ファイルとして作成し、
+  人間の `<claude home>/CLAUDE.md` に `@agent-tools/CLAUDE.md` の import 1 行を足す
+  (既にあれば no-op)。
+- **codex**: import 非対応のため `<codex home>/AGENTS.md` を直接所有する
+  (空ファイルのみ claim 可)。
+- symlink / dir / 特殊ファイルは触らない。所有先に unmanaged な中身があれば
+  conflict で停止し、何も書き込まない。先に `build.sh` で generated instruction が
+  必要。instruction を配らない構成なら不要。
+- self-test: `tests/connect-test.sh`
+
 - `sync.sh`: `generated/` の personal assets を tool directories へ反映する。
   [Sync Policy](../docs/sync-policy.md) を enforce する。
 


### PR DESCRIPTION
## 概要
実環境への配備時に install / update / 使い方の導線が無いと判明したため、運用者向けランブックを整備する。closes #71。

## 変更(docs のみ・挙動変更なし)
- **新規 `docs/install-and-usage.md`**: 前提条件、初回 install(build→register→connect --apply→sync --apply)、update(pull→build→register→sync --apply)、日常運用(asset 追加・status/doctor・配置先)、トラブルシュート(conflict / run connect first / run build first 等)。
- **README**: 「インストール / クイックスタート」節を追加しガイドへリンク。
- **scripts/README.md**: `connect.sh` の項目を追記(所有確立の役割・dry-run/--apply・冪等性)。
- **docs/onboarding.md**: pipeline 図に `connect` を追加。

## connect の欠落も解消
`connect.sh` は instruction の所有確立に必須なのに onboarding の pipeline 図にも scripts/README にも未記載だった。今回まとめて埋めた。

## 検証
- `check-manifests` / `check-injection` pass、`scripts/tests/*.sh` 全 8 本 OK。
- ガイド内の相互リンク先ファイルの存在を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)