### PR TITLE
一発 setup スクリプトを追加する (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ instruction templates を管理するための個人用 AI agent asset repositor
 
 ```sh
 git clone <this-repo> agent-tools && cd agent-tools
-./scripts/build.sh            # generated/ に生成
-./scripts/register.sh         # 配ってよい asset を catalog に記録
-./scripts/connect.sh --apply  # instruction の所有を確立(初回のみ)
-./scripts/sync.sh --apply     # tool home に配置
+./scripts/setup.sh           # dry-run: 何が起きるか plan を表示(書き込まない)
+./scripts/setup.sh --apply   # build → register → connect → sync を通しで実環境に反映
 ```
 
-アップデートは `git pull && ./scripts/build.sh && ./scripts/register.sh && ./scripts/sync.sh --apply`
-(`connect` は初回だけ)。前提条件・配置先・トラブルシュートを含む詳細は
-[docs/install-and-usage.md](docs/install-and-usage.md) を参照してください。
+`setup.sh` は初回 install と更新の両方に使えます(`git pull` 後に再実行するだけ)。
+既定は dry-run で、`--apply` のときだけ実環境へ書き込みます。build / register /
+connect / sync を1つずつ個別に実行することもできます。前提条件・配置先・
+トラブルシュートを含む詳細は [docs/install-and-usage.md](docs/install-and-usage.md) を参照してください。
 
 この repository は `dotfiles` とは意図的に分離します。
 public repository として公開する前提なので、追跡する内容はすべて公開可能なものに限定します。

--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -29,30 +29,39 @@ skill は隔離 directory なので `sync` が直接置けますが、instructio
 
 ## 初回インストール
 
+### 一発で通す(推奨)
+
 ```sh
 git clone <this-repo> agent-tools
 cd agent-tools
 
-# 1. 生成(generated/ にのみ書き込む。tool home には触れない)
-./scripts/build.sh
+./scripts/setup.sh           # dry-run: build → register → connect → sync の plan を表示
+./scripts/setup.sh --apply   # 確認できたら実環境へ反映
+```
 
-# 2. 登録(配ってよい asset を catalog に記録)
-./scripts/register.sh
+`setup.sh` は `build → register → connect → sync` を順に実行します。**既定は dry-run**
+(何も書き込まない)で、`--apply` を付けたときだけ connect / sync が実環境へ書き込みます。
+初回 install と更新の両方に使えます(connect は冪等なので毎回通して無害)。
 
-# 3. 所有の確立(instruction のみ。default dry-run → 確認して --apply)
-./scripts/connect.sh            # 何が起きるか確認
-./scripts/connect.sh --apply    # 実際に所有ファイルを作り、CLAUDE.md に import 1 行を足す
+### 個別に実行する場合
 
-# 4. 配置(default dry-run → 確認して --apply)
-./scripts/sync.sh               # plan を確認(create / update / skip / conflict)
-./scripts/sync.sh --apply       # tool home に反映
+中で何が起きるかを段階で確認したいときは、個別 script を順に実行します。
+
+```sh
+./scripts/build.sh              # 1. 生成(generated/ のみ。tool home には触れない)
+./scripts/register.sh           # 2. 登録(配ってよい asset を catalog に記録)
+./scripts/connect.sh            #    instruction の所有確立: まず dry-run で確認
+./scripts/connect.sh --apply    # 3. 所有ファイルを作り、CLAUDE.md に import 1 行を足す
+./scripts/sync.sh               #    まず dry-run で plan を確認
+./scripts/sync.sh --apply       # 4. tool home に配置
 ```
 
 - `connect` は冪等です。既に import 行があれば no-op。symlink / 既存の手書き内容が
   ある所有先は触らず conflict で停止します(何も書きません)。
-- instruction を配らない(skill だけの)構成なら手順 3 は不要です。
+- instruction を配らない(skill だけの)構成なら connect は不要です。
 - `register` と `connect` はどちらも `build` の後・`sync` の前であればよく、相互に依存
-  しません(上の番号は推奨順)。`sync` だけが両者(catalog と所有確立)を前提とします。
+  しません。`sync` だけが両者(catalog と所有確立)を前提とします。`setup.sh` はこの
+  順序で通します。
 
 ## アップデート
 
@@ -60,13 +69,12 @@ cd agent-tools
 cd agent-tools
 git pull
 
-./scripts/build.sh
-./scripts/register.sh
-./scripts/sync.sh           # dry-run で差分確認
-./scripts/sync.sh --apply   # 反映
+./scripts/setup.sh           # dry-run で差分確認
+./scripts/setup.sh --apply   # 反映
 ```
 
-- `connect` は初回だけ。所有が確立済みなら以後の更新は `sync` が担います。
+- `setup.sh` は冪等な connect を含むので、更新でもそのまま使えます。個別に回すなら
+  `build → register → sync --apply`(connect は所有確立済みなら不要)。
 - source asset を編集したときも同じ流れです(`build` が source の sha256 で
   `build_id` を再計算し、`sync` が差分のある target だけ `update` します)。
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,22 @@ PR / push ごとに実行されます。
 
 ## 実装済み
 
+- `setup.sh`: `build → register → connect → sync` を一括実行する一発 setup。
+  初回 install と更新の両方に使える。詳細は
+  [Install & Usage](../docs/install-and-usage.md)。
+
+```text
+usage: setup.sh [--apply] [--root DIR] [--codex-home DIR] [--claude-home DIR] [--quiet]
+```
+
+- **既定は dry-run**(plan を表示するだけ・実環境に書き込まない)。`--apply` を付けた
+  ときだけ connect / sync に `--apply` を渡す。
+- build の gate fail / connect・sync の conflict では停止する。register の human review
+  待ち(exit 3)は非致命として継続し、note を出す(sync は registered のものだけ配置)。
+- 引数は各 sub-script へ forward する(`--root` / `--quiet` は全段、`--codex-home` /
+  `--claude-home` は connect / sync)。
+- self-test: `tests/setup-test.sh`
+
 - `check-manifests.sh`: sidecar asset manifests の static validation。
   [Asset Manifest Schema](../docs/asset-manifest-schema.md) v1 に従って検証する。
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,44 +16,62 @@ usage() {
 }
 
 apply=""
-common=""   # build/register/connect/sync 共通 (--root, --quiet)
-homes=""    # connect/sync 専用 (--codex-home, --claude-home)
+root=""
+quiet=""
+codex_home=""
+claude_home=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --apply) apply="--apply" ;;
-    --root) [ $# -ge 2 ] || { usage >&2; exit 2; }; common="$common --root $2"; shift ;;
-    --quiet) common="$common --quiet" ;;
-    --codex-home) [ $# -ge 2 ] || { usage >&2; exit 2; }; homes="$homes --codex-home $2"; shift ;;
-    --claude-home) [ $# -ge 2 ] || { usage >&2; exit 2; }; homes="$homes --claude-home $2"; shift ;;
+    --apply) apply=1 ;;
+    --root) [ $# -ge 2 ] || { usage >&2; exit 2; }; root=$2; shift ;;
+    --quiet) quiet=1 ;;
+    --codex-home) [ $# -ge 2 ] || { usage >&2; exit 2; }; codex_home=$2; shift ;;
+    --claude-home) [ $# -ge 2 ] || { usage >&2; exit 2; }; claude_home=$2; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
   shift
 done
 
-# sub-script へ語分割で引数を渡すため、$common / $homes / $apply は意図的に unquoted。
-# shellcheck disable=SC2086
+# 各 sub-script を、正しく quote された引数で呼ぶ。文字列連結 + 語分割は path に
+# 空白 (例: "Application Support") や glob 文字が入ると壊れるため使わない。
+# set -- で positional params を組み立て "$@" で渡す (POSIX sh で配列の代替)。
+#   run <script> <with_homes:0|1> <with_apply:0|1>
+run() {
+  _script=$1
+  _with_homes=$2
+  _with_apply=$3
+  set --
+  [ -n "$root" ] && set -- "$@" --root "$root"
+  [ -n "$quiet" ] && set -- "$@" --quiet
+  if [ "$_with_homes" = 1 ]; then
+    [ -n "$codex_home" ] && set -- "$@" --codex-home "$codex_home"
+    [ -n "$claude_home" ] && set -- "$@" --claude-home "$claude_home"
+  fi
+  [ "$_with_apply" = 1 ] && [ -n "$apply" ] && set -- "$@" --apply
+  "$script_dir/$_script" "$@"
+}
 
 echo "==> build"
-"$script_dir/build.sh" $common
+run build.sh 0 0
 
 echo "==> register"
 # register は human_review 待ちがあると exit 3 を返す。これは致命ではない
 # (catalog は書かれ、sync は registered のものだけ配置する) ので継続する。
 # build の gate fail (1) や他の異常はそのまま伝播させる。
 register_rc=0
-"$script_dir/register.sh" $common || register_rc=$?
+run register.sh 0 0 || register_rc=$?
 if [ "$register_rc" -ne 0 ] && [ "$register_rc" -ne 3 ]; then
   exit "$register_rc"
 fi
 [ "$register_rc" -eq 3 ] && echo "note: human review 待ちの asset があります (registered のものだけ配置されます)"
 
 echo "==> connect${apply:+ (apply)}"
-"$script_dir/connect.sh" $common $homes $apply
+run connect.sh 1 1
 
 echo "==> sync${apply:+ (apply)}"
-"$script_dir/sync.sh" $common $homes $apply
+run sync.sh 1 1
 
 if [ -z "$apply" ]; then
   echo

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# build → register → connect → sync を一括実行する一発 setup。
+# 既定は dry-run (plan を表示するだけ・実環境に書き込まない)。
+# 実環境へ反映するには --apply を付ける。初回 install と更新の両方に使える
+# (connect は冪等なので毎回通して無害)。
+# Spec: docs/install-and-usage.md
+# 依存: macOS 標準 Ruby のみ。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+usage() {
+  echo "usage: setup.sh [--apply] [--root DIR] [--codex-home DIR] [--claude-home DIR] [--quiet]"
+  echo "  build → register → connect → sync を通しで実行する。"
+  echo "  既定は dry-run (何も書き込まない)。--apply で connect/sync を実環境に反映する。"
+}
+
+apply=""
+common=""   # build/register/connect/sync 共通 (--root, --quiet)
+homes=""    # connect/sync 専用 (--codex-home, --claude-home)
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) apply="--apply" ;;
+    --root) [ $# -ge 2 ] || { usage >&2; exit 2; }; common="$common --root $2"; shift ;;
+    --quiet) common="$common --quiet" ;;
+    --codex-home) [ $# -ge 2 ] || { usage >&2; exit 2; }; homes="$homes --codex-home $2"; shift ;;
+    --claude-home) [ $# -ge 2 ] || { usage >&2; exit 2; }; homes="$homes --claude-home $2"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# sub-script へ語分割で引数を渡すため、$common / $homes / $apply は意図的に unquoted。
+# shellcheck disable=SC2086
+
+echo "==> build"
+"$script_dir/build.sh" $common
+
+echo "==> register"
+# register は human_review 待ちがあると exit 3 を返す。これは致命ではない
+# (catalog は書かれ、sync は registered のものだけ配置する) ので継続する。
+# build の gate fail (1) や他の異常はそのまま伝播させる。
+register_rc=0
+"$script_dir/register.sh" $common || register_rc=$?
+if [ "$register_rc" -ne 0 ] && [ "$register_rc" -ne 3 ]; then
+  exit "$register_rc"
+fi
+[ "$register_rc" -eq 3 ] && echo "note: human review 待ちの asset があります (registered のものだけ配置されます)"
+
+echo "==> connect${apply:+ (apply)}"
+"$script_dir/connect.sh" $common $homes $apply
+
+echo "==> sync${apply:+ (apply)}"
+"$script_dir/sync.sh" $common $homes $apply
+
+if [ -z "$apply" ]; then
+  echo
+  echo "dry-run のみ・実環境には書き込んでいません。反映するには --apply を付けて再実行してください。"
+fi

--- a/scripts/tests/setup-test.sh
+++ b/scripts/tests/setup-test.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# setup.sh の self-test。
+# fake home でだけ検証し、実 tool homes には決して触れない。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+setup="$script_dir/../setup.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# fixture: single-file skill asset (build → register → connect(noop) → sync を通せる)
+mkdir -p "$tmp/shared/skills" "$tmp/codex" "$tmp/claude"
+cat > "$tmp/shared/skills/personal-demo-skill.md" <<'EOF'
+# demo skill
+
+body for the demo skill.
+EOF
+cat > "$tmp/shared/skills/personal-demo-skill.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-demo-skill
+kind: skill
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-demo-skill.md
+  format: markdown
+summary: demo skill for setup-test
+EOF
+
+common="--root $tmp --codex-home $tmp/codex --claude-home $tmp/claude"
+
+# --- case 1: dry-run は全段を通すが実 home には書き込まない ---
+# shellcheck disable=SC2086
+out=$("$setup" $common 2>&1) || fail "dry-run exited non-zero: $out"
+echo "$out" | grep -q "==> build" || fail "dry-run: build step missing"
+echo "$out" | grep -q "==> register" || fail "dry-run: register step missing"
+echo "$out" | grep -q "==> connect" || fail "dry-run: connect step missing"
+echo "$out" | grep -q "==> sync" || fail "dry-run: sync step missing"
+[ -d "$tmp/codex/skills/personal-demo-skill" ] && fail "dry-run wrote to codex home"
+[ -d "$tmp/claude/skills/personal-demo-skill" ] && fail "dry-run wrote to claude home"
+echo "$out" | grep -q "dry-run のみ" || fail "dry-run: hint missing"
+
+# --- case 2: --apply は skill を実 home (fake) に配置する ---
+# shellcheck disable=SC2086
+out=$("$setup" --apply $common 2>&1) || fail "apply exited non-zero: $out"
+[ -f "$tmp/codex/skills/personal-demo-skill/SKILL.md" ] || fail "apply did not place codex skill"
+[ -f "$tmp/claude/skills/personal-demo-skill/SKILL.md" ] || fail "apply did not place claude skill"
+
+# --- case 3: 未知オプションは usage を出して exit 2 ---
+rc=0
+"$setup" --bogus >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 2 ] || fail "unknown option should exit 2, got $rc"
+
+echo "ok: setup-test passed"

--- a/scripts/tests/setup-test.sh
+++ b/scripts/tests/setup-test.sh
@@ -6,13 +6,18 @@ set -eu
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 setup="$script_dir/../setup.sh"
 
-tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
+tmpbase=$(mktemp -d)
+trap 'rm -rf "$tmpbase"' EXIT
 
 fail() {
   echo "FAIL: $1" >&2
   exit 1
 }
+
+# root / home に空白を含めて、引数 forwarding の quoting を検証する
+# ("Application Support" のような空白入り path での破綻を捕まえる)。
+tmp="$tmpbase/with space"
+mkdir -p "$tmp"
 
 # fixture: single-file skill asset (build → register → connect(noop) → sync を通せる)
 mkdir -p "$tmp/shared/skills" "$tmp/codex" "$tmp/claude"
@@ -38,11 +43,11 @@ source:
 summary: demo skill for setup-test
 EOF
 
-common="--root $tmp --codex-home $tmp/codex --claude-home $tmp/claude"
-
+# 引数は quote して渡す (root/home に空白を含むため)。setup.sh 側の forwarding の
+# quoting が壊れていれば、空白入り path の sub-script 呼び出しで失敗する。
 # --- case 1: dry-run は全段を通すが実 home には書き込まない ---
-# shellcheck disable=SC2086
-out=$("$setup" $common 2>&1) || fail "dry-run exited non-zero: $out"
+out=$("$setup" --root "$tmp" --codex-home "$tmp/codex" --claude-home "$tmp/claude" 2>&1) \
+  || fail "dry-run exited non-zero: $out"
 echo "$out" | grep -q "==> build" || fail "dry-run: build step missing"
 echo "$out" | grep -q "==> register" || fail "dry-run: register step missing"
 echo "$out" | grep -q "==> connect" || fail "dry-run: connect step missing"
@@ -52,8 +57,8 @@ echo "$out" | grep -q "==> sync" || fail "dry-run: sync step missing"
 echo "$out" | grep -q "dry-run のみ" || fail "dry-run: hint missing"
 
 # --- case 2: --apply は skill を実 home (fake) に配置する ---
-# shellcheck disable=SC2086
-out=$("$setup" --apply $common 2>&1) || fail "apply exited non-zero: $out"
+out=$("$setup" --apply --root "$tmp" --codex-home "$tmp/codex" --claude-home "$tmp/claude" 2>&1) \
+  || fail "apply exited non-zero: $out"
 [ -f "$tmp/codex/skills/personal-demo-skill/SKILL.md" ] || fail "apply did not place codex skill"
 [ -f "$tmp/claude/skills/personal-demo-skill/SKILL.md" ] || fail "apply did not place claude skill"
 


### PR DESCRIPTION
## 概要
`build → register → connect → sync` を一括実行する `scripts/setup.sh` を追加。初回 install と更新の両方を1コマンドで。closes #73。

## 安全モデル(重要)
repo の根幹原則「sync は default dry-run / `--apply` 明示必須」を維持:
- **既定は dry-run**(全段を通すが plan を表示するだけ・実環境に書き込まない)。
- `--apply` を付けたときだけ connect / sync に `--apply` を渡す。

## 挙動
- build の gate fail / connect・sync の conflict では停止(`set -e`)。
- register の human review 待ち(exit 3)は**非致命**として継続し note を出す(catalog は書かれ、sync は registered のものだけ配置)。
- 引数 forward: `--root` / `--quiet` は全段、`--codex-home` / `--claude-home` は connect / sync。
- connect は冪等なので初回・更新で同じコマンドが使える。

## テスト
- `scripts/tests/setup-test.sh` を追加: (1) dry-run が fake home に書き込まないこと、(2) `--apply` で skill が配置されること、(3) 未知オプションで exit 2。
- CI(`.github/workflows/test.yml`)は `scripts/tests/*.sh` を glob するので自動で実行。
- 全 self-test 9 本 OK、`check-manifests` / `check-injection` pass。

## docs
README クイックスタート / `docs/install-and-usage.md` / `scripts/README.md` を setup.sh 中心に更新(個別 script の手順も残す)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)