### PR TITLE
personal-codex-review skill を登録する (#75)

### DIFF
--- a/shared/skills/personal-codex-review/SKILL.md
+++ b/shared/skills/personal-codex-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: personal-codex-review
+description: >-
+  別モデル (Codex / GPT-5.x) に diff や PR を実際にレビューさせ、安定して結果を得るための
+  skill。「Codex にレビューさせて」「codex でこの差分/PR を見て」「second opinion を
+  Codex で」「codex review が固まる/返ってこない」のときに使う。codex exec を直接呼び、
+  承認待ちで hang しない flag を付けて回すのが要点。相互レビュー (author ≠ reviewer) の
+  どちら側を呼ぶかは運用ルールの「相互レビュー」節に従う。
+---
+
+# personal-codex-review
+
+別モデルの目 (Codex / GPT-5.x) で diff や PR をレビューさせ、結果を安定して取得するための
+手順。**この repo がどこにあっても**(任意の repository で)使える。
+
+## いつ使うか
+
+- 自分 (Claude) が書いたコードを相互レビューに出すとき。どちら側がレビュアーになるかは
+  運用ルールの「AI エージェント間のコードレビュー (相互レビュー)」に従う
+  (author ≠ reviewer、判定は commit の `Co-Authored-By:` トレーラ)。
+- second opinion / 設計レビューを別モデルに求めたいとき。
+
+## 安定した呼び方 (重要)
+
+`codex exec` を直接呼ぶ。承認待ちで固まらないよう、次の flag を必ず付ける:
+
+```sh
+codex exec --skip-git-repo-check \
+  -s read-only \
+  -c approval_policy="never" \
+  -c model_reasoning_effort="medium" \
+  "$(cat /tmp/review-brief.md)"
+```
+
+- `-c approval_policy="never"`: **これが無いと hang する。** ローカル設定が
+  `approval_policy = "on-request"` の場合、codex exec がファイル読取やコマンド実行で
+  承認を要求し、非対話/バックグラウンドでは誰も承認できず無限に待つ
+  (観測: 16 分以上 stall)。`never` に上書きすると同じ処理が十数秒で返る。
+- `-s read-only`: repo を**読ませて**実装と突き合わせた検証レビューができる
+  (書き込みはさせない)。
+- `-c model_reasoning_effort="medium"`: 既定の `xhigh` は遅い。review 用途は medium で十分。
+- グローバルの `approval_policy` は対話 codex の安全装置なので**変えない**。
+  レビュー時にこの呼び出しで override する。
+
+## 手順
+
+1. **自己完結のブリーフを書く。** codex exec は会話文脈を持たないので、ファイル
+   (例 `/tmp/review-brief.md`) に「役割・観点・出力形式・対象 diff」を全部入れる。
+   diff は `git diff <base>...HEAD` や `gh pr diff <番号>` で取得して同梱する。
+   実装と突き合わせてほしいなら「リポジトリ内の該当ファイルを読んで検証せよ」と明記する
+   (`-s read-only` なので読める)。
+2. **出力形式を指定する。** 冒頭に判定 (merge 可 / 要対応)、各指摘に 3 段階ランクと
+   `file:行` を付けさせる:
+   - 🔴 must: 放置して merge すると実害が出るもの (バグ・データ破壊・セキュリティ・挙動退行)。
+   - 🟡 should: 推奨だが必須でない。
+   - ⚪ nit: スタイル・好み・任意。
+   「念のため直しては」を must に格上げさせない。
+3. **上の安定形コマンドで実行。** foreground でよい。返ってこない時間が普段の数倍なら
+   approval 待ちを疑い、`approval_policy="never"` が付いているか確認する。
+4. **結果を評価して扱う。** 明らかな誤検知は黙って消さず、転記したうえで「採用しない理由」を
+   併記する。must は対応するまで merge しない。
+5. **やり取りの正本は PR に残す。** GitHub PR の文脈で使うときは、依頼・結果・再レビューを
+   PR コメントとして残す (会話内だけで完結させない)。
+
+## 落とし穴
+
+- `codex:codex-rescue` サブエージェント経由だと、コード読み書きを伴わない分析タスクで
+  **Codex に転送せず自分 (Claude) で答えてしまう**ことがある。確実に別モデルの目を入れたい
+  なら上の `codex exec` 直叩きを使う。
+- `service_tier` 設定が古い CLI/プラグインで解釈できず起動失敗することがある。起動自体が
+  失敗するときは設定を疑う (内容は無断で書き換えず、ユーザーに確認)。

--- a/shared/skills/personal-codex-review/asset.yml
+++ b/shared/skills/personal-codex-review/asset.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+name: personal-codex-review
+kind: skill
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-codex-review
+  format: directory
+summary: run a stable second-model code review via codex exec (read-only, no approval hang)
+description: public-safe procedure for getting a genuine Codex (GPT-5.x) review of a diff or PR via codex exec, with the flags that avoid the approval-policy hang
+review:
+  static_check: pending
+  llm_review: allowed
+  human_review: pending
+compatibility:
+  codex:
+    artifact_kind: skill
+  claude-code:
+    artifact_kind: skill


### PR DESCRIPTION
## 概要
Codex で安定してレビューを回す知見を agent-tools の skill として登録し、両 agent・全マシンへ配布する。closes #75。

これまでこの知見は private memory にしか無く他 repo へ転用できなかった。skill 化により setup.sh で Codex / Claude Code 両方へ配られ、どの repository でも使えるようになる。

## 内容
`shared/skills/personal-codex-review/`(asset.yml + SKILL.md):
- **安定形** `codex exec --skip-git-repo-check -s read-only -c approval_policy="never" -c model_reasoning_effort="medium"`。
- **stall の原因と回避**: `approval_policy = on-request` だと codex exec が承認待ちで hang(16分+ 観測)→ `never` 上書きで十数秒に。
- ランク形式(🔴must/🟡should/⚪nit)、自己完結ブリーフ、PR に正本を残す運用。
- `codex:codex-rescue` が分析タスクで自答する落とし穴。

## 検証
- `check-manifests`(6 OK)/ `check-injection`(13 files, no findings)pass。
- `build` が両 target に生成、`setup.sh` dry-run で両 home へ create 予定を確認。
- public-safe(secret / URL / local path / PII なし)。

## スコープ外
手置き `review-request` の agent-tools 移行は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)