### PR TITLE
codex-review skill: stall の主因を background 実行に補正

### DIFF
--- a/shared/skills/personal-codex-review/SKILL.md
+++ b/shared/skills/personal-codex-review/SKILL.md
@@ -22,7 +22,7 @@ description: >-
 
 ## 安定した呼び方 (重要)
 
-`codex exec` を直接呼ぶ。承認待ちで固まらないよう、次の flag を必ず付ける:
+`codex exec` を直接呼ぶ。安定して返すために、次の2点を守る:
 
 ```sh
 codex exec --skip-git-repo-check \
@@ -32,10 +32,15 @@ codex exec --skip-git-repo-check \
   "$(cat /tmp/review-brief.md)"
 ```
 
-- `-c approval_policy="never"`: **これが無いと hang する。** ローカル設定が
-  `approval_policy = "on-request"` の場合、codex exec がファイル読取やコマンド実行で
-  承認を要求し、非対話/バックグラウンドでは誰も承認できず無限に待つ
-  (観測: 16 分以上 stall)。`never` に上書きすると同じ処理が十数秒で返る。
+- **foreground で実行する(detach / background しない)。** stall の主因はこれ。観測上、
+  codex exec の呼び出しが background 化・detach されると処理が無限に固まる
+  (16 分以上 stall)。同じ呼び出しを foreground で実行すると数秒〜数分で返る。
+  複合コマンドの末尾に埋めると wrapper に background 化されることがあるので、
+  **`codex exec` は単独コマンドで呼ぶ**。
+- **`-c approval_policy="never"` を付ける。** 併発要因の対策。ローカル設定が
+  `approval_policy = "on-request"` だと、codex がファイル読取/コマンド実行で承認を要求し、
+  非対話 / TTY なしでは誰も承認できず待ち続ける。`never` で override すると承認待ちで
+  止まらない。
 - `-s read-only`: repo を**読ませて**実装と突き合わせた検証レビューができる
   (書き込みはさせない)。
 - `-c model_reasoning_effort="medium"`: 既定の `xhigh` は遅い。review 用途は medium で十分。
@@ -55,8 +60,10 @@ codex exec --skip-git-repo-check \
    - 🟡 should: 推奨だが必須でない。
    - ⚪ nit: スタイル・好み・任意。
    「念のため直しては」を must に格上げさせない。
-3. **上の安定形コマンドで実行。** foreground でよい。返ってこない時間が普段の数倍なら
-   approval 待ちを疑い、`approval_policy="never"` が付いているか確認する。
+3. **上の安定形で foreground 実行する**(単独コマンドで。複合コマンドに混ぜない)。
+   普段の数倍返ってこないときは、まず background 化 / detach されていないかを疑い、次に
+   `approval_policy="never"` が付いているかを確認する。固まったら kill して foreground で
+   実行し直す。
 4. **結果を評価して扱う。** 明らかな誤検知は黙って消さず、転記したうえで「採用しない理由」を
    併記する。must は対応するまで merge しない。
 5. **やり取りの正本は PR に残す。** GitHub PR の文脈で使うときは、依頼・結果・再レビューを

--- a/shared/skills/personal-codex-review/SKILL.md
+++ b/shared/skills/personal-codex-review/SKILL.md
@@ -3,9 +3,9 @@ name: personal-codex-review
 description: >-
   別モデル (Codex / GPT-5.x) に diff や PR を実際にレビューさせ、安定して結果を得るための
   skill。「Codex にレビューさせて」「codex でこの差分/PR を見て」「second opinion を
-  Codex で」「codex review が固まる/返ってこない」のときに使う。codex exec を直接呼び、
-  承認待ちで hang しない flag を付けて回すのが要点。相互レビュー (author ≠ reviewer) の
-  どちら側を呼ぶかは運用ルールの「相互レビュー」節に従う。
+  Codex で」「codex review が固まる/返ってこない」のときに使う。codex exec を foreground で
+  単独実行するのが要点(background 化すると stall する)。承認待ち対策の flag も併用する。
+  相互レビュー (author ≠ reviewer) のどちら側を呼ぶかは運用ルールの「相互レビュー」節に従う。
 ---
 
 # personal-codex-review
@@ -33,8 +33,8 @@ codex exec --skip-git-repo-check \
 ```
 
 - **foreground で実行する(detach / background しない)。** stall の主因はこれ。観測上、
-  codex exec の呼び出しが background 化・detach されると処理が無限に固まる
-  (16 分以上 stall)。同じ呼び出しを foreground で実行すると数秒〜数分で返る。
+  codex exec の呼び出しが background 化・detach されると返らなくなる(観測では
+  16 分以上 stall した)。同じ呼び出しを foreground で実行すると数秒〜数分で返る。
   複合コマンドの末尾に埋めると wrapper に background 化されることがあるので、
   **`codex exec` は単独コマンドで呼ぶ**。
 - **`-c approval_policy="never"` を付ける。** 併発要因の対策。ローカル設定が


### PR DESCRIPTION
## 概要
`personal-codex-review` skill の stall 説明を実態に補正。

実運用で切り分けた結果、codex exec の stall の**主因は `approval_policy` ではなく「呼び出しが background 化 / detach されること」**だった(foreground 単独実行は毎回完走、background 化は `approval_policy=never` を付けても 16 分+ hang)。

## 変更(docs のみ)
- 安定の第一条件を「**foreground で単独実行(detach しない)**」に修正。
- `approval_policy=never` は併発要因(非対話での承認待ち hang)の対策として位置づけ直し。
- 手順3に「固まったら kill して foreground で実行し直す」を追記。

## 検証
- gates(check-manifests / check-injection)pass、self-test 全 9 本 OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)