### PR TITLE
CI: human_review:approved な medium finding を許容する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Check repository assets
         run: |
           scripts/check-manifests.sh
-          scripts/check-injection.sh
+          # high (exit 1) / usage (exit 2) は fail。medium (exit 3) は human_review:approved
+          # を register が gate するため、ここでは許容する (照合は register step が担う)。
+          scripts/check-injection.sh || { rc=$?; [ "$rc" -eq 3 ] || exit "$rc"; }
 
       - name: Build, register, and report status
         run: |

--- a/scripts/tests/check-injection-test.sh
+++ b/scripts/tests/check-injection-test.sh
@@ -65,10 +65,20 @@ grep -q "\[medium\] hidden: contains invisible zero-width characters" "$tmp/out-
 grep -q "human review required" "$tmp/out-medium" \
   || fail "missing human review notice in: $(cat "$tmp/out-medium")"
 
-# --- case 4: repository 本体の shared assets が pass する ---
+# --- case 4: repository 本体の shared assets に high finding が無い ---
+# medium (runtime-state 等) は manifest の human_review:approved で register が承認を
+# gate するため repo に存在し得る (exit 3)。ここでの invariant は「high (registration
+# fail) が無いこと」= exit 1/2 にならないこと。medium↔承認の照合は register が担う。
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
-"$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \
-  || fail "repository shared assets should pass: $(cat "$tmp/out-repo")"
+status=0
+"$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 || status=$?
+case "$status" in
+  0|3) : ;;  # clean / low only、または human-review 対象の medium のみ
+  *) fail "repository shared assets must have no high-risk findings (exit $status): $(cat "$tmp/out-repo")" ;;
+esac
+if grep -q "\[high\]" "$tmp/out-repo"; then
+  fail "repository shared assets must have no high-risk findings: $(cat "$tmp/out-repo")"
+fi
 
 # --- case 5: user-specific absolute path は high (exit 1) ---
 mkdir -p "$tmp/abspath/shared/workflows"


### PR DESCRIPTION
## 概要

`#87`(personal-asset-miner)merge 後、main の `test` workflow が失敗(run 27761601558)。Closes #89。

## 真因

`check-injection.sh` は medium finding で **exit 3** を返す純粋スキャナで、medium↔manifest の `human_review` 照合は **`register.rb`** が担う(approved→registered=exit 0、未承認→pending=exit 3)。CI は2箇所で register より厳しく「medium があれば fail」と判定していた:

1. `scripts/tests/check-injection-test.sh` case 4 — repo 本体に対し **exit 0 を期待**。
2. `.github/workflows/test.yml` `Check repository assets` step — bare `check-injection.sh`(exit 3 で fail)。

`personal-asset-miner` は `~/.claude`/`~/.codex` 参照(runtime-state, medium)を持つ**初の human-approved medium 資産**。これで「repo に medium は無い」旧前提が崩れた。

## 修正

正しい不変条件に是正:
- **high (exit 1) / usage (exit 2)** は CI で fail。
- **medium (exit 3)** は `register` が `human_review:approved` を gate するため scan 段階では許容(照合は register step に委ねる)。

- test case 4: 「high finding が無いこと(exit 1/2 でない & `[high]` を含まない)」に変更。
- workflow: `check-injection.sh || { rc=$?; [ "$rc" -eq 3 ] || exit "$rc"; }`。

## 検証

ローカルで CI 全シーケンス(self-tests / check-manifests / check-injection / build / register / status / doctor)が緑を確認:
- self-tests 9 本 pass、register `22 registered / 0 pending`、doctor `ok`(`prompt_injection_static=human_review` は warn=非致命)。
- このPR の CI run でも検証される。

## レビュー観点

- 不変条件の是正(high=fail / 承認済み medium=許容、照合は register)が妥当か。
- 未承認 medium が**すり抜けない**こと(register step が pending>0 で exit 3 → CI fail する経路が残っているか)。
- bash `set -e` 下で `|| { rc=$?; [ "$rc" -eq 3 ] || exit "$rc"; }` が high/usage を確実に fail させるか。

相互レビュー契約により Claude 著 → **Codex がレビュー**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)