### PR TITLE
Phase 1 / PR2: レビュー skill を production-rail の review lens に配線

### DIFF
--- a/shared/skills/personal-codex-review/SKILL.md
+++ b/shared/skills/personal-codex-review/SKILL.md
@@ -54,6 +54,9 @@ codex exec --skip-git-repo-check \
    diff は `git diff <base>...HEAD` や `gh pr diff <番号>` で取得して同梱する。
    実装と突き合わせてほしいなら「リポジトリ内の該当ファイルを読んで検証せよ」と明記する
    (`-s read-only` なので読める)。
+   - production レール(本番反映・PR 前提)のコードをレビューするなら、`personal-production-rail`
+     の **review lens**(索引が指すポリシー観点)も観点に含める。観点の実体は production-rail /
+     索引が単一の正本なので、**ここに観点を書き写さず参照する**(コピーすると drift する)。
 2. **出力形式を指定する。** 冒頭に判定 (merge 可 / 要対応)、各指摘に 3 段階ランクと
    `file:行` を付けさせる:
    - 🔴 must: 放置して merge すると実害が出るもの (バグ・データ破壊・セキュリティ・挙動退行)。

--- a/shared/skills/personal-review-request/SKILL.md
+++ b/shared/skills/personal-review-request/SKILL.md
@@ -97,6 +97,10 @@ gh pr comment <番号> --body "..."
 レビュアーへの指示には必ず次を含める: 対象（repo / branch / base / diff の取り方）、重点観点、
 **3 段階ランクで分類し各指摘に `file:line` を付けること**、must の定義（上の表のとおり）。
 
+production レール（本番反映・PR 前提）のコードをレビューするなら、重点観点に
+`personal-production-rail` の **review lens**（索引が指すポリシー観点）を含める。観点の実体は
+production-rail / 索引が単一の正本なので、**ここに書き写さず参照する**（コピーすると drift する）。
+
 - **Codex がレビュアーのとき**: `personal-codex-review` skill の手順で実行する(安定形の
   `codex exec` に自己完結ブリーフを渡す。具体的な flag はその skill を参照)。
   `codex:codex-rescue` サブエージェント経由は、コード読み書きを伴わない分析タスクで Codex に


### PR DESCRIPTION
## 概要

production レールのコードレビューで、品質ポリシー観点を**単一正本(`personal-production-rail` / 索引)から参照**させる。Refs #93。Phase 1 の仕上げ。

**観点はコピーしない**(コピーすると review 側と production-rail 側で drift する)。ポインタを1〜2行足すだけ。

## 変更

- **`personal-codex-review`**: ブリーフ作成(手順1)に「production レール(本番反映・PR 前提)のコードなら、`personal-production-rail` の **review lens**(索引が指すポリシー観点)も観点に含める。観点は書き写さず参照する」を追記。
- **`personal-review-request`**: レビュー実行(手順3)に同趣旨を追記。

観点の実体は production-rail / 索引が単一正本として持ち、常時 on の core rule(operating-rules)で production-rail は既に呼ばれるため、**ポインタ追記だけで繋がる**。

## 検証

- check-manifests / build / register green、catalog 24 registered / 0 human review required。
- 両 review skill に新規 injection findings なし。

相互レビュー契約により Claude 著 → **Codex がレビュー**。これで Phase 1(司書 + 本棚 + core rule + review 配線)が揃う。Phase 2(共有 policy kind #24)はポリシーが増えて drift が痛くなってから。

🤖 Generated with [Claude Code](https://claude.com/claude-code)