### PR TITLE
docs: dotfiles からの status.sh --json 参照例を追記 (#5)

### DIFF
--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -89,6 +89,38 @@ git pull
 
 どちらも read-only で、state を一切変更しません。
 
+### dotfiles から参照する(report-only)
+
+`dotfiles` は `agent-tools` を自動 clone / pull / sync しません。連携は
+**`status.sh --json` を read-only で読むだけ**(presence + health の表示)です。
+読んでよい情報・読まない情報の境界は
+[status-manifest-contract.md](status-manifest-contract.md) と
+[boundary-with-dotfiles.md](boundary-with-dotfiles.md) が正本です。
+
+最小の参照例(dotfiles 側に置く想定。illustrative):
+
+```sh
+# 1. expected path に agent-tools があるか(presence)
+AGENT_TOOLS="${AGENT_TOOLS:-$HOME/dev/agent-tools}"
+[ -d "$AGENT_TOOLS" ] || { echo "agent-tools: absent"; exit 0; }
+
+# 2. status を read-only で読む(health)
+status=$("$AGENT_TOOLS/scripts/status.sh" --json) \
+  || { echo "agent-tools: status unavailable"; exit 0; }
+
+# 3. contract が許可した field だけ拾って表示(例: jq)
+echo "$status" | jq -r '
+  "agent-tools: " +
+  (if .repo.clean then "clean" else "dirty" end) +
+  " / injection=" + .checks.prompt_injection_static +
+  " / stale=" + (.generated.stale | tostring)'
+```
+
+- 読むのは contract が許可した field(`repo` / `checks` / 各 target の `state` など)だけ。
+- agent-tools の state は変更しない(書き込み・`sync` をしない)。
+- agent-tools が無い環境は `absent` を report して正常終了する(報告のみで、呼び出し側を
+  止めない)。
+
 ### asset を追加する
 
 1. `shared/<category>/` に source と sidecar manifest(`<name>.asset.yml`)を置く。
@@ -116,3 +148,4 @@ git pull
 - コマンド別の詳細 usage: [../scripts/README.md](../scripts/README.md)
 - 配置の安全則: [sync-policy.md](sync-policy.md)
 - instruction の所有モデル: [instruction-artifact-kind.md](instruction-artifact-kind.md)
+- dotfiles との境界・status 参照契約: [boundary-with-dotfiles.md](boundary-with-dotfiles.md) / [status-manifest-contract.md](status-manifest-contract.md)


### PR DESCRIPTION
## 概要

#5(dotfiles 連携)の agent-tools 側 scope を明文化する docs 追記。`dotfiles` が `agent-tools` を **report-only で参照する最小例**(presence + health)を `docs/install-and-usage.md` の「状態を見る」に追加し、関連ドキュメントへのリンクを足した。

#5 の完了条件は agent-tools 側で既に充足済み(status.sh --json / contract_version 2 / `--apply` gate / conflict policy / injection 結果を status に含む)。本 PR はその「消費方法」を運用ガイドに明文化するもので、挙動変更はなし。

## 変更

- `docs/install-and-usage.md`:
  - 「dotfiles から参照する(report-only)」サブセクションを追加(jq での最小参照例)。
  - 関連ドキュメントに boundary-with-dotfiles / status-manifest-contract を追加。

## scope / 境界

- 例で使う field は実 `status.sh --json` 出力(`repo.clean` / `checks.prompt_injection_static` / `generated.stale`)に限定。読んでよい field の正本は status-manifest-contract / boundary-with-dotfiles。
- **dotfiles 側の実装(report-only check 本体)は含めない**。これは別 repo・別 project tracking なので dotfiles 側 Issue で進める(boundary doc の方針)。

## production-rail(ドッグフード)

generation lens で `existing-system-respect`(最小差分・追記のみ・差分分類)と `ai-antipattern`(実在性=例の field が実出力と一致)を適用。docs のみのため proportional に軽く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)