### PR TITLE
connect が instruction の review gate を素通りする件を修正 (#102)

### DIFF
--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -14,13 +14,16 @@
 # - symlink / 非通常ファイルは決して触らない。
 # - 外部依存ゼロ、network access なし。
 
+require "json"
 require "fileutils"
 
+require_relative "artifact_targets"
 require_relative "instruction_marker"
 
 module Connect
   # 人間の CLAUDE.md から所有ファイルを取り込む import 行。
   CLAUDE_IMPORT = "@agent-tools/CLAUDE.md"
+  CATALOG_PATH = "generated/catalog.json"
 
   Plan = Struct.new(:action, :tool, :kind, :path, :reason, :gen) do
     def to_s
@@ -33,6 +36,25 @@ module Connect
     def initialize(root, homes)
       @root = File.expand_path(root)
       @homes = homes
+      load_catalog
+    end
+
+    # catalog を source of truth として読む (catalog_version check は sync/status/doctor と
+    # 同じ)。connect は registered な instruction だけを所有確立する (review gate)。
+    def load_catalog
+      @catalog_present = false
+      @entries = []
+      path = File.join(@root, CATALOG_PATH)
+      return unless File.file?(path)
+
+      data = JSON.parse(File.read(path))
+      # version の一致しない catalog は古いものとして無視する (re-run register)。
+      return unless data["catalog_version"] == ArtifactTargets::CATALOG_VERSION
+
+      @catalog_present = true
+      @entries = data.fetch("assets", [])
+    rescue JSON::ParserError
+      @catalog_present = false
     end
 
     def plan
@@ -55,6 +77,19 @@ module Connect
       File.file?(path) ? path : nil
     end
 
+    # instruction の review gate を connect でも enforce する (sync と同じ契約)。
+    # catalog の instruction entry が registered なら nil、そうでなければ skip 理由を返す。
+    # catalog 不在 / 未登録 / human_review_required の instruction は所有ファイルに配置しない。
+    def unregistered_reason(tool)
+      return "no catalog; run scripts/register.sh first" unless @catalog_present
+
+      entry = @entries.find { |e| e["target"] == tool && e["artifact_kind"] == "instruction" }
+      return "not in catalog; run scripts/register.sh first" unless entry
+      return nil if entry["registration"] == "registered"
+
+      "instruction not registered (#{entry["registration"]})"
+    end
+
     # claude-code: 所有ファイル (agent-tools/CLAUDE.md) と人間の CLAUDE.md への import。
     def claude_plans
       tool = "claude-code"
@@ -64,6 +99,9 @@ module Connect
 
       owned = File.join(home, "agent-tools", "CLAUDE.md")
       import_file = File.join(home, "CLAUDE.md")
+      reason = unregistered_reason(tool)
+      return [Plan.new("skip", tool, "owned", owned, reason, gen)] if reason
+
       [owned_plan(tool, gen, owned), claude_import_plan(tool, import_file)]
     end
 
@@ -75,6 +113,9 @@ module Connect
       return [] unless gen
 
       owned = File.join(home, "AGENTS.md")
+      reason = unregistered_reason(tool)
+      return [Plan.new("skip", tool, "owned", owned, reason, gen)] if reason
+
       [owned_plan(tool, gen, owned)]
     end
 

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -77,17 +77,27 @@ module Connect
       File.file?(path) ? path : nil
     end
 
-    # instruction の review gate を connect でも enforce する (sync と同じ契約)。
-    # catalog の instruction entry が registered なら nil、そうでなければ skip 理由を返す。
-    # catalog 不在 / 未登録 / human_review_required の instruction は所有ファイルに配置しない。
-    def unregistered_reason(tool)
+    # instruction の gate を connect でも enforce する (sync の plan_instruction と同じ契約)。
+    # 配置してよいなら nil、不可なら skip 理由を返す。catalog 不在 / 未登録 /
+    # human_review_required は配置しない。さらに、配置する generated 物が catalog entry と
+    # 一致する (target + name + build_id) ことも確認する。不一致は source 変更後に register
+    # していない (古い registered のまま未レビュー content を配置する) ことを意味するので塞ぐ。
+    def unconnectable_reason(tool, gen)
       return "no catalog; run scripts/register.sh first" unless @catalog_present
 
       entry = @entries.find { |e| e["target"] == tool && e["artifact_kind"] == "instruction" }
       return "not in catalog; run scripts/register.sh first" unless entry
-      return nil if entry["registration"] == "registered"
+      unless entry["registration"] == "registered"
+        return "instruction not registered (#{entry["registration"]})"
+      end
 
-      "instruction not registered (#{entry["registration"]})"
+      marker = InstructionMarker.parse(File.read(gen))
+      unless marker && marker["target"] == tool &&
+             marker["name"] == entry["name"] && marker["build_id"] == entry["build_id"]
+        return "generated instruction is stale; run scripts/build.sh && scripts/register.sh first"
+      end
+
+      nil
     end
 
     # claude-code: 所有ファイル (agent-tools/CLAUDE.md) と人間の CLAUDE.md への import。
@@ -99,7 +109,7 @@ module Connect
 
       owned = File.join(home, "agent-tools", "CLAUDE.md")
       import_file = File.join(home, "CLAUDE.md")
-      reason = unregistered_reason(tool)
+      reason = unconnectable_reason(tool, gen)
       return [Plan.new("skip", tool, "owned", owned, reason, gen)] if reason
 
       [owned_plan(tool, gen, owned), claude_import_plan(tool, import_file)]
@@ -113,7 +123,7 @@ module Connect
       return [] unless gen
 
       owned = File.join(home, "AGENTS.md")
-      reason = unregistered_reason(tool)
+      reason = unconnectable_reason(tool, gen)
       return [Plan.new("skip", tool, "owned", owned, reason, gen)] if reason
 
       [owned_plan(tool, gen, owned)]

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -207,7 +207,9 @@ printf '\n追記: catalog 未更新の変更。\n' >> "$tmp/repo3/shared/instruc
   || fail "connect should not error on stale build: $(cat "$tmp/c12")"
 grep -q "skip: \[claude-code\] owned.*stale" "$tmp/c12" || fail "claude owned should skip when generated build_id != catalog: $(cat "$tmp/c12")"
 grep -q "skip: \[codex\] owned.*stale" "$tmp/c12" || fail "codex owned should skip when generated build_id != catalog: $(cat "$tmp/c12")"
+grep -q "0 change(s)" "$tmp/c12" || fail "stale connect should apply 0 changes: $(cat "$tmp/c12")"
 [ ! -e "$tmp/claude10/agent-tools/CLAUDE.md" ] || fail "stale generated instruction must not create owned file"
+[ ! -e "$tmp/claude10/CLAUDE.md" ] || fail "stale generated instruction must not add import"
 [ ! -e "$tmp/codex10/AGENTS.md" ] || fail "stale generated instruction must not create owned codex file"
 
 echo "ok: connect self-test passed"

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -175,4 +175,39 @@ grep -q "0 change(s)" "$tmp/c11" || fail "unregistered instruction connect shoul
 [ ! -e "$tmp/claude9/CLAUDE.md" ] || fail "unregistered instruction must not add import"
 [ ! -e "$tmp/codex9/AGENTS.md" ] || fail "unregistered instruction must not create owned codex file"
 
+# --- case 12: registered な catalog のまま source を変えて build だけ再実行したら connect は skip ---
+# (古い registered catalog で未レビュー content を配置しないこと = build_id 照合の回帰)
+mkdir -p "$tmp/repo3/shared/instructions" "$tmp/codex10" "$tmp/claude10"
+cat > "$tmp/repo3/shared/instructions/personal-ops.md" <<'EOF'
+# operating rules
+
+ドキュメントは日本語を既定にする。
+EOF
+cat > "$tmp/repo3/shared/instructions/personal-ops.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-ops
+kind: instruction
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/instructions/personal-ops.md
+  format: markdown
+EOF
+"$build" --root "$tmp/repo3" --quiet > /dev/null
+"$register" --root "$tmp/repo3" --quiet > /dev/null
+# source を変更 (build_id が変わる) して build だけ再実行 (register しない → catalog は古い registered)
+printf '\n追記: catalog 未更新の変更。\n' >> "$tmp/repo3/shared/instructions/personal-ops.md"
+"$build" --root "$tmp/repo3" --quiet > /dev/null
+"$connect" --root "$tmp/repo3" --codex-home "$tmp/codex10" --claude-home "$tmp/claude10" --apply > "$tmp/c12" 2>&1 \
+  || fail "connect should not error on stale build: $(cat "$tmp/c12")"
+grep -q "skip: \[claude-code\] owned.*stale" "$tmp/c12" || fail "claude owned should skip when generated build_id != catalog: $(cat "$tmp/c12")"
+grep -q "skip: \[codex\] owned.*stale" "$tmp/c12" || fail "codex owned should skip when generated build_id != catalog: $(cat "$tmp/c12")"
+[ ! -e "$tmp/claude10/agent-tools/CLAUDE.md" ] || fail "stale generated instruction must not create owned file"
+[ ! -e "$tmp/codex10/AGENTS.md" ] || fail "stale generated instruction must not create owned codex file"
+
 echo "ok: connect self-test passed"

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -6,6 +6,7 @@ set -eu
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 build="$script_dir/../build.sh"
+register="$script_dir/../register.sh"
 connect="$script_dir/../connect.sh"
 
 tmp=$(mktemp -d)
@@ -48,6 +49,9 @@ run_connect > "$tmp/c0" 2>&1 || fail "connect without artifacts should succeed: 
 grep -q "no instruction artifacts to connect" "$tmp/c0" || fail "missing no-artifacts notice: $(cat "$tmp/c0")"
 
 "$build" --root "$tmp/repo" --quiet > /dev/null
+# connect は catalog の registration を gate にするため register まで通す
+# (low risk fixture は registered になり exit 0)。
+"$register" --root "$tmp/repo" --quiet > /dev/null
 
 # --- case 1: dry-run は plan を出すが書き込まない ---
 run_connect > "$tmp/c1" 2>&1 || fail "dry-run should succeed: $(cat "$tmp/c1")"
@@ -134,5 +138,41 @@ status=0
 [ "$status" -eq 1 ] || fail "symlinked owned parent should conflict: $(cat "$tmp/c10")"
 grep -q "conflict: \[claude-code\] owned.*symlink" "$tmp/c10" || fail "missing parent symlink conflict: $(cat "$tmp/c10")"
 [ ! -e "$tmp/realdir/CLAUDE.md" ] || fail "must not write through a symlinked parent"
+
+# --- case 11: 未登録 (human_review_required) の instruction は connect しない (review gate) ---
+mkdir -p "$tmp/repo2/shared/instructions" "$tmp/codex9" "$tmp/claude9"
+cat > "$tmp/repo2/shared/instructions/personal-pending.md" <<'EOF'
+# pending rules
+
+レビュー待ちの instruction。
+EOF
+cat > "$tmp/repo2/shared/instructions/personal-pending.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-pending
+kind: instruction
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: medium
+  privacy: low
+source:
+  path: shared/instructions/personal-pending.md
+  format: markdown
+EOF
+"$build" --root "$tmp/repo2" --quiet > /dev/null
+# 宣言 medium + 未承認 → register は human_review_required (exit 3, 非致命) になる
+status=0
+"$register" --root "$tmp/repo2" --quiet > /dev/null || status=$?
+[ "$status" -eq 3 ] || fail "pending instruction should register as human_review_required (exit 3), got $status"
+"$connect" --root "$tmp/repo2" --codex-home "$tmp/codex9" --claude-home "$tmp/claude9" --apply > "$tmp/c11" 2>&1 \
+  || fail "connect should not error on unregistered instruction: $(cat "$tmp/c11")"
+grep -q "skip: \[claude-code\] owned.*not registered" "$tmp/c11" || fail "claude owned should skip when not registered: $(cat "$tmp/c11")"
+grep -q "skip: \[codex\] owned.*not registered" "$tmp/c11" || fail "codex owned should skip when not registered: $(cat "$tmp/c11")"
+grep -q "0 change(s)" "$tmp/c11" || fail "unregistered instruction connect should apply 0 changes: $(cat "$tmp/c11")"
+[ ! -e "$tmp/claude9/agent-tools/CLAUDE.md" ] || fail "unregistered instruction must not create owned claude file"
+[ ! -e "$tmp/claude9/CLAUDE.md" ] || fail "unregistered instruction must not add import"
+[ ! -e "$tmp/codex9/AGENTS.md" ] || fail "unregistered instruction must not create owned codex file"
 
 echo "ok: connect self-test passed"


### PR DESCRIPTION
Closes #102 (umbrella: #103)

## 概要 (🔴 high)

`connect` は generated 物の存在 (`File.file?`) だけで所有ファイルを確立し、**catalog の `registration` を見ていなかった**。`setup.sh` は `register` の exit 3 (human_review 待ち) を非致命で継続するため、`human_review_required` な instruction が `connect --apply` (= `setup.sh --apply`) で人間の所有ファイル (`~/.claude/agent-tools/CLAUDE.md` / `~/.codex/AGENTS.md`) に配置されえた。skill/instruction の `sync` が enforce する catalog gate を **connect だけが回避**していた (非対称)。

Claude 5観点 fan-out + Codex 独立監査の双方向クロス検証で両モデルが独立に検出した high。

## 変更 (最小差分・sync と同じ契約に揃える)

- `scripts/lib/connect.rb`:
  - catalog (`generated/catalog.json`、`catalog_version` check は sync/status/doctor と同じ) を読む `load_catalog` を追加。
  - `unregistered_reason(tool)`: instruction の catalog entry (`target` + `artifact_kind == instruction`) が `registration: registered` のときだけ所有確立。catalog 不在 / 未登録 / `human_review_required` は理由つき **skip** (配置しない)。
  - `claude_plans` / `codex_plans` の両エントリポイントに gate を配線。
- `scripts/tests/connect-test.sh`:
  - 旧テストは `build` のみで `register` せず gate 無し挙動を前提にしていたので、`register` を足して新契約に揃えた (low risk fixture は registered → exit 0、既存 case 1-10 は不変)。
  - **case 11 追加**: 宣言 `prompt_injection: medium` + 未承認 → `register` が `human_review_required` (exit 3) → `connect --apply` が所有ファイルを作らず skip することを回帰検証。

## 検証

- `connect-test.sh` 含む **self-test 9 本すべて pass**。`check-manifests` ok / `build` ok。`check-injection` は既存の human_review:approved な medium (asset-miner) のみで本変更起因の新規 finding なし。
- working tree は変更 2 ファイルのみ (テストは tmp 隔離)。

## スコープ外 (別件)

- catalog reader が sync/status/doctor と同形に重複する DRY は既存パターン踏襲。共有化は #103 の DRY 項で扱う。
- instruction の build_id 鮮度は `sync` (`plan_instruction`) が担うため connect では registration gate に絞った。

## production-rail (ドッグフード)

generation lens で `existing-system-respect` (最小差分・既存契約維持・完了前の差分分類) と `ai-antipattern` (実在性=register/sync/catalog 挙動を読んで確認・配線確認・過剰実装回避) を適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)