### PR TITLE
sync の skill も catalog build_id を照合する (#108)

### DIFF
--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -90,7 +90,7 @@ module Sync
       end
 
       case kind
-      when "skill" then plan_skill(tool, name)
+      when "skill" then plan_skill(tool, name, entry["build_id"])
       when "instruction" then plan_instruction(tool, name, entry["build_id"])
       else
         Plan.new("skip", tool, name, nil, "unsupported artifact_kind #{kind.inspect}", kind, nil)
@@ -107,7 +107,7 @@ module Sync
       end
     end
 
-    def plan_skill(tool, name)
+    def plan_skill(tool, name, expected_build_id)
       target = File.join(@homes.fetch(tool), "skills", name)
       gen = File.join(@root, "generated", tool, "skills", name)
 
@@ -121,6 +121,12 @@ module Sync
       source_marker = read_marker(gen)
       unless managed?(source_marker, tool, name)
         return Plan.new("conflict", tool, name, target, "generated artifact is missing a valid marker", "skill", gen)
+      end
+      # generated が catalog entry と一致するか (build_id)。不一致 = register 後に build して
+      # いない (stale generated)。instruction (plan_instruction) と同じく "run build first" で
+      # skip し、古い generated を配置しない。
+      if source_marker["build_id"] != expected_build_id
+        return Plan.new("skip", tool, name, target, "run build first", "skill", gen)
       end
       # symlink は実体の所在によらず unmanaged target として扱い、決して触らない。
       if File.symlink?(target)

--- a/scripts/tests/status-test.sh
+++ b/scripts/tests/status-test.sh
@@ -81,6 +81,7 @@ EOF
 run_status > "$tmp/s4" 2>&1
 [ "$(jget "$tmp/s4" generated stale)" = "2" ] || fail "generated should be stale after source change"
 "$build" --root "$tmp/repo" --quiet > /dev/null
+"$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null   # sync は catalog build_id を照合するため rebuild 後は register まで
 run_status > "$tmp/s4b" 2>&1
 [ "$(jget "$tmp/s4b" generated stale)" = "0" ] || fail "rebuild should clear stale"
 [ "$(jget "$tmp/s4b" sync_targets 0 state)" = '"stale"' ] || fail "target should be stale after rebuild"

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -73,6 +73,7 @@ cat > "$tmp/repo/shared/workflows/personal-demo.md" <<'EOF'
 # demo v2
 EOF
 "$build" --root "$tmp/repo" --quiet > /dev/null
+"$register" --root "$tmp/repo" --quiet > /dev/null   # skill も catalog build_id を照合するため register まで通す
 run_sync > "$tmp/out-update" 2>&1 || fail "update dry-run should succeed"
 grep -q "update: \[claude-code\]" "$tmp/out-update" || fail "missing update plan"
 run_sync --apply --quiet > /dev/null 2>&1
@@ -196,5 +197,45 @@ grep -q "skip: \[codex\].*run connect first" "$tmp/out-empty" \
   || fail "empty instruction owned file should say run connect first: $(cat "$tmp/out-empty")"
 ! grep -q "conflict: \[codex\]" "$tmp/out-empty" \
   || fail "empty owned file must not be reported as a conflict: $(cat "$tmp/out-empty")"
+
+# --- case 13: skill も catalog build_id を照合する (stale generated は run build first) ---
+# (D2: plan_instruction と対称。register 後に build せず sync しても stale skill を配置しない)
+mkdir -p "$tmp/srepo/shared/skills/personal-sk" "$tmp/scodex" "$tmp/sclaude"
+cat > "$tmp/srepo/shared/skills/personal-sk/SKILL.md" <<'EOF'
+---
+name: personal-sk
+description: demo skill
+---
+v1
+EOF
+cat > "$tmp/srepo/shared/skills/personal-sk/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-sk
+kind: skill
+visibility: public
+targets:
+  - codex
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-sk
+  format: directory
+EOF
+"$build" --root "$tmp/srepo" --quiet > /dev/null
+"$register" --root "$tmp/srepo" --quiet > /dev/null   # catalog build_id = generated build_id
+# source を変更して build せず register だけ (catalog build_id が generated より新しくなる)
+echo "v2" >> "$tmp/srepo/shared/skills/personal-sk/SKILL.md"
+"$register" --root "$tmp/srepo" --quiet > /dev/null
+"$sync" --root "$tmp/srepo" --codex-home "$tmp/scodex" --claude-home "$tmp/sclaude" > "$tmp/out-skstale" 2>&1
+grep -q "skip: \[codex\].*run build first" "$tmp/out-skstale" \
+  || fail "stale skill generated vs catalog should skip with run build first: $(cat "$tmp/out-skstale")"
+# --apply しても stale skill は配置されない
+"$sync" --root "$tmp/srepo" --codex-home "$tmp/scodex" --claude-home "$tmp/sclaude" --apply --quiet > /dev/null 2>&1 || true
+[ ! -e "$tmp/scodex/skills/personal-sk" ] || fail "stale skill must not be deployed before rebuild"
+# rebuild すれば配置される (gate が正常系を塞がない)
+"$build" --root "$tmp/srepo" --quiet > /dev/null
+"$sync" --root "$tmp/srepo" --codex-home "$tmp/scodex" --claude-home "$tmp/sclaude" --apply --quiet > /dev/null
+[ -f "$tmp/scodex/skills/personal-sk/SKILL.md" ] || fail "rebuilt skill should deploy"
 
 echo "ok: sync self-test passed"


### PR DESCRIPTION
Closes #108 (umbrella: #103)

## 概要 (🟡 medium)

`sync` の `plan_instruction` は catalog の `expected_build_id` と generated marker を照合し、不一致を `run build first` で skip する。一方 `plan_skill` は **catalog build_id を受け取らず** generated と target だけ比較していた (非対称)。このため **register 後に build せず sync** すると、stale な generated skill が配置される / up-to-date と誤判定されえた。Claude+Codex 相互検証で検出。

## 変更 (sync.rb 局所・instruction と対称化)

- `plan_for_entry` が `plan_skill` にも `entry["build_id"]` を渡す。
- `plan_skill` は generated marker の `build_id` が catalog の expected と一致しなければ `run build first` で skip し、stale generated を配置しない (`plan_instruction` と同じ契約)。
- これで skill も instruction と同じく **build → register → sync** が前提になる。

## 検証

- 回帰テスト sync **case 13**: source 変更 → register のみ (build せず) → sync が stale skill を配置せず `run build first` で skip、`--apply` でも配置しない、rebuild すれば配置 (gate が正常系を塞がない)。
- 契約変更の波及: rebuild 後に register していなかった **sync case 4** / **status case 4b** に register を追加し、instruction 既存フロー (case 9: build → register → sync) と揃えた。テスト期待値の緩和ではなく、新契約 (skill も catalog 照合) に合わせた setup の修正。
- self-test 9 本すべて pass。

## production-rail (ドッグフード)

generation lens で `existing-system-respect` (sync.rb 局所・最小差分・既存 instruction 契約に揃える) と `ai-antipattern` (実在性=plan_instruction の既存契約をコードで確認、非対称の解消、テストは新契約に合わせるだけで実装追随の緩和ではない) を適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)