### PR TITLE
sync: skill 所有先の親 dir が symlink でも conflict にする (#110)

### DIFF
--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -129,7 +129,9 @@ module Sync
         return Plan.new("skip", tool, name, target, "run build first", "skill", gen)
       end
       # symlink は実体の所在によらず unmanaged target として扱い、決して触らない。
-      if File.symlink?(target)
+      # 親 dir (<home>/skills) が symlink の場合も、rm_rf / cp_r が外へ追従しないよう
+      # conflict にする (plan_instruction と同じ防御)。
+      if File.symlink?(target) || File.symlink?(File.dirname(target))
         return Plan.new("conflict", tool, name, target, "existing target is a symlink", "skill", gen)
       end
       unless File.exist?(target)

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -238,4 +238,38 @@ grep -q "skip: \[codex\].*run build first" "$tmp/out-skstale" \
 "$sync" --root "$tmp/srepo" --codex-home "$tmp/scodex" --claude-home "$tmp/sclaude" --apply --quiet > /dev/null
 [ -f "$tmp/scodex/skills/personal-sk/SKILL.md" ] || fail "rebuilt skill should deploy"
 
+# --- case 14: skill 所有先の親 dir (<home>/skills) が symlink なら conflict (素通りさせない) ---
+# (D3: plan_instruction の親 dir 防御と対称。rm_rf / cp_r が symlink を辿らない)
+mkdir -p "$tmp/repo14/shared/skills/personal-sk" "$tmp/claude14" "$tmp/realskills"
+cat > "$tmp/repo14/shared/skills/personal-sk/SKILL.md" <<'EOF'
+---
+name: personal-sk
+description: demo skill
+---
+body
+EOF
+cat > "$tmp/repo14/shared/skills/personal-sk/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-sk
+kind: skill
+visibility: public
+targets:
+  - codex
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-sk
+  format: directory
+EOF
+"$build" --root "$tmp/repo14" --quiet > /dev/null
+"$register" --root "$tmp/repo14" --quiet > /dev/null
+mkdir -p "$tmp/codex14"
+ln -s "$tmp/realskills" "$tmp/codex14/skills"   # <home>/skills 自体を symlink にする
+status=0
+"$sync" --root "$tmp/repo14" --codex-home "$tmp/codex14" --claude-home "$tmp/claude14" --apply > "$tmp/out-skparent" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlinked skills parent should conflict (exit 1): $(cat "$tmp/out-skparent")"
+grep -q "conflict: \[codex\].*symlink" "$tmp/out-skparent" || fail "missing skills-parent symlink conflict: $(cat "$tmp/out-skparent")"
+[ ! -e "$tmp/realskills/personal-sk" ] || fail "must not write through a symlinked skills parent"
+
 echo "ok: sync self-test passed"


### PR DESCRIPTION
Closes #110 (umbrella: #103)

## 概要 (🟡 medium)

`plan_skill` は leaf target (`<home>/skills/<name>`) の `File.symlink?` だけを確認し、親 dir (`<home>/skills`) の symlink を見ていなかった。`plan_instruction` は `File.symlink?(File.dirname(target))` で親 dir も確認しており**非対称**。`<home>/skills` が symlink だと `apply` の `rm_rf` / `cp_r` が symlink を辿って外へ書き込みうる (defense-in-depth)。Claude+Codex 相互検証で検出。

## 変更 (sync.rb 局所・instruction と対称化)

- `plan_skill` で leaf target に加え `File.symlink?(File.dirname(target))` (= `<home>/skills`) も conflict として扱う (`plan_instruction` と同じ防御)。

## 検証

- 回帰テスト sync **case 14**: `<home>/skills` を symlink にした状態で sync が conflict・exit 1・symlink 先に書き込まないことを検証。
- self-test 9 本すべて pass。

## production-rail (ドッグフード)

generation lens で `existing-system-respect` (sync.rb 局所・最小差分・既存 instruction 防御に揃える) と `ai-antipattern` (実在性=plan_instruction の親 dir 防御をコードで確認・非対称解消) を適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)