### PR TITLE
directory asset 内の symlink / 特殊ファイルを reject する (#112)

### DIFF
--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -47,6 +47,10 @@ skill を directory 形式で持つときの配置・安全ルール (Phase 1):
 - `scripts/` (実行コード) を含む directory skill は **fail-closed** で拒否する。
   配る前に実行コードを安全検査する能力がまだ無いため、check-manifests が error にして
   gate を止める (黙ってスキップしない)。対応は external scanner 連携の後 (#43)。
+- directory asset に **symlink / 特殊ファイル** (regular file・directory 以外: FIFO /
+  socket / device 等) が含まれると **fail-closed** で拒否する。build の `cp_r` / build_id 計算が
+  symlink を辿り `shared/` の外の内容を generated/ へ脱出させうるため、check-manifests が
+  error にして gate を止める。
 
 asset 本体に frontmatter を埋め込まない理由:
 

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -210,7 +210,11 @@ module CheckManifests
 
       full = File.join(@root, source_path)
       if format == "directory"
-        error(path, "source.path #{source_path.inspect} is not a directory") unless File.directory?(full)
+        if File.directory?(full)
+          check_directory_no_symlinks(path, full)
+        else
+          error(path, "source.path #{source_path.inspect} is not a directory")
+        end
         expected_dir = File.dirname(path)
         unless source_path.chomp("/") == expected_dir
           error(path, "directory manifest must point at its own directory #{expected_dir.inspect}")
@@ -221,6 +225,24 @@ module CheckManifests
           error(path, "directory manifest requires source.format: directory")
         elsif File.dirname(source_path) != File.dirname(path)
           error(path, "sidecar manifest must sit next to its source file")
+        end
+      end
+    end
+
+    # directory asset 内に symlink / 特殊ファイルがあると build の cp_r が dereference し、
+    # build_id 計算 (File.file?) も symlink 先を読むため、shared/ の外へ脱出しうる。
+    # regular file / directory 以外を reject して fail-closed にする (gate 経由で build /
+    # register が止まる)。
+    def check_directory_no_symlinks(path, dir)
+      Dir.glob(File.join(dir, "**/*"), File::FNM_DOTMATCH).sort.each do |entry|
+        base = File.basename(entry)
+        next if base == "." || base == ".."
+
+        rel = entry.sub("#{@root}/", "")
+        if File.symlink?(entry)
+          error(path, "directory asset must not contain symlinks: #{rel}")
+        elsif !File.file?(entry) && !File.directory?(entry)
+          error(path, "directory asset must not contain special files: #{rel}")
         end
       end
     end

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -282,6 +282,39 @@ EOF
 "$check" --root "$tmp/evalskill" > "$tmp/out-evalskill" 2>&1 \
   || fail "directory skill with only evals/ should pass: $(cat "$tmp/out-evalskill")"
 
+# --- case 4f: directory asset 内の symlink は fail-closed (shared/ 脱出防止) ---
+mkdir -p "$tmp/symskill/shared/skills/personal-sym-skill"
+cat > "$tmp/symskill/shared/skills/personal-sym-skill/SKILL.md" <<'EOF'
+---
+name: personal-sym-skill
+description: skill with a symlink
+---
+
+# sym skill
+EOF
+# asset dir 内に shared/ 外を指す symlink を仕込む (cp_r / build_id が辿りうる)
+ln -s /etc/hosts "$tmp/symskill/shared/skills/personal-sym-skill/leak"
+cat > "$tmp/symskill/shared/skills/personal-sym-skill/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-sym-skill
+kind: skill
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-sym-skill
+  format: directory
+EOF
+
+if "$check" --root "$tmp/symskill" > "$tmp/out-symskill" 2>&1; then
+  fail "directory asset with a symlink should fail"
+fi
+grep -q "must not contain symlinks" "$tmp/out-symskill" \
+  || fail "expected symlink fail-closed reason: $(cat "$tmp/out-symskill")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -315,6 +315,38 @@ fi
 grep -q "must not contain symlinks" "$tmp/out-symskill" \
   || fail "expected symlink fail-closed reason: $(cat "$tmp/out-symskill")"
 
+# --- case 4g: directory asset 内の特殊ファイル (FIFO) も fail-closed ---
+mkdir -p "$tmp/fifoskill/shared/skills/personal-fifo-skill"
+cat > "$tmp/fifoskill/shared/skills/personal-fifo-skill/SKILL.md" <<'EOF'
+---
+name: personal-fifo-skill
+description: skill with a special file
+---
+
+# fifo skill
+EOF
+mkfifo "$tmp/fifoskill/shared/skills/personal-fifo-skill/pipe"
+cat > "$tmp/fifoskill/shared/skills/personal-fifo-skill/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-fifo-skill
+kind: skill
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-fifo-skill
+  format: directory
+EOF
+
+if "$check" --root "$tmp/fifoskill" > "$tmp/out-fifoskill" 2>&1; then
+  fail "directory asset with a special file should fail"
+fi
+grep -q "must not contain special files" "$tmp/out-fifoskill" \
+  || fail "expected special-file fail-closed reason: $(cat "$tmp/out-fifoskill")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \


### PR DESCRIPTION
Closes #112 (umbrella: #103)

## 概要 (🟡 medium)

directory 形式 asset の build で `copy_directory_asset` の `cp_r` は **root symlink を dereference** し、`Build.build_id_for` (directory) の `Dir.glob` + `File.file?` も symlink を辿る。このため asset 内の symlink が指す **shared/ 外の内容が `generated/` に脱出**しうる (untrusted PR で問題化)。manifest 検証側にも guard が無かった。Claude+Codex 相互検証で検出。

## 変更 (fail-closed・manifest validation で reject)

- `check_manifests` の `validate_source` (directory branch) に `check_directory_no_symlinks` を追加。asset directory を `Dir.glob("**/*", FNM_DOTMATCH)` で走査し、symlink / 特殊ファイル (regular file・directory 以外) があれば manifest error にする。
- これにより致命 gate (`gate.rb` = manifest validation error) 経由で **build / register が止まり**、脱出経路を fail-closed で塞ぐ。

## 検証

- 回帰テスト check-manifests **case 4f**: directory asset 内に `/etc/hosts` への symlink を置くと `must not contain symlinks` で error・exit 1。
- 既存 `shared/` に symlink は無く (`find shared -type l` 空)、repo の `check-manifests` も通過。self-test 9 本すべて pass。

## production-rail (ドッグフード)

generation lens で `existing-system-respect` (validate_source 局所・既存検証に追加・最小差分) と `ai-antipattern` (実在性=cp_r/File.file? の symlink 挙動・脱出経路を確認、fail-closed で塞ぐ) を適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)