### PR TITLE
code コメントの version drift と doctor の asset 件数誤表示を是正 (#116)

### DIFF
--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -10,7 +10,7 @@ module ArtifactTargets
   # これと一致しない catalog を古いものとして無視する。
   CATALOG_VERSION = 2
 
-  # build が扱える artifact_kind (sync の instruction 配置は後続対応)。
+  # build が扱える artifact_kind。
   SUPPORTED_KINDS = %w[skill instruction].freeze
 
   # asset.kind から導出する既定の artifact_kind。

--- a/scripts/lib/check_injection.rb
+++ b/scripts/lib/check_injection.rb
@@ -83,8 +83,8 @@ module CheckInjection
     Pattern.new("pii", "high",
                 /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
                 "contains an email address (possible PII)"),
-    # external URL は検知するが現状 low (gate を通す)。artifact_kind 別 policy
-    # (instruction=strict で high に昇格) は後続の artifact kind 対応で導入する。
+    # external URL は検知するが skill では low (gate を通す)。instruction の source では
+    # strict_instruction が high に昇格する (artifact_kind 別 policy)。
     Pattern.new("external-url", "low",
                 %r{https?://[^\s)>"'\]]+}i,
                 "contains an external URL"),

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -171,7 +171,9 @@ module Doctor
       (by_name.keys - manifests.keys).each { |name| stale << "#{name}: manifest removed" }
 
       if stale.empty?
-        report("ok", "catalog", "present, #{entries.size} asset(s), fresh")
+        # entries は target-artifact 単位なので、asset 数は unique name で数える。
+        asset_count = entries.map { |e| e["name"] }.uniq.size
+        report("ok", "catalog", "present, #{asset_count} asset(s), fresh")
       else
         report("warn", "catalog", "stale (#{stale.join('; ')})")
       end

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # register: shared assets を検証し、catalog に登録状態を記録する。
-# Spec: docs/register-catalog.md (catalog_version 1)
+# Spec: docs/register-catalog.md (catalog_version 2)
 #
 # - 副作用は generated/catalog.json の書き込みのみ。
 # - gate は build と同じ: manifest error / high finding で fail し、catalog を更新しない。

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Report-only status。dotfiles が読める contract JSON を出力する。
-# Spec: docs/status-manifest-contract.md (contract_version 1)
+# Spec: docs/status-manifest-contract.md (contract_version 2)
 #
 # - いかなる state も変更しない (read-only inspection のみ)。
 # - secrets / absolute local paths を出力しない。

--- a/scripts/tests/doctor-test.sh
+++ b/scripts/tests/doctor-test.sh
@@ -91,12 +91,12 @@ rm -rf "$tmp/codex/skills/personal-demo"
 "$sync" --root "$tmp/repo" --codex-home "$tmp/codex" --claude-home "$tmp/claude" --apply --quiet > /dev/null
 "$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null
 run_doctor > "$tmp/d5" 2>&1 || fail "doctor with catalog should pass: $(cat "$tmp/d5")"
-grep -q "ok: catalog: present, 2 asset(s), fresh" "$tmp/d5" || fail "missing catalog ok line: $(cat "$tmp/d5")"
+grep -q "ok: catalog: present, 1 asset(s), fresh" "$tmp/d5" || fail "missing catalog ok line: $(cat "$tmp/d5")"
 
 # mtime だけが変わっても stale にならない
 touch "$tmp/repo/shared/workflows/personal-demo.asset.yml" "$tmp/repo/shared/workflows/personal-demo.md"
 run_doctor > "$tmp/d5a" 2>&1 || fail "touched files should not be stale"
-grep -q "ok: catalog: present, 2 asset(s), fresh" "$tmp/d5a" || fail "mtime change must not cause stale: $(cat "$tmp/d5a")"
+grep -q "ok: catalog: present, 1 asset(s), fresh" "$tmp/d5a" || fail "mtime change must not cause stale: $(cat "$tmp/d5a")"
 
 # source content の変更は stale になる
 echo "changed" >> "$tmp/repo/shared/workflows/personal-demo.md"


### PR DESCRIPTION
Closes #116 (umbrella: #103)

## 概要 (⚪ low / 🟡 一部 medium = doctor 件数)

監査の E 群: code コメントの version drift と doctor の件数ラベル誤りをまとめて修正。

## 変更

- **E2/E3** `status.rb:5` / `register.rb:5` の header コメント version を実値に (`contract_version 2` / `catalog_version 2`)。
- **E4** `artifact_targets.rb:13` 「(sync の instruction 配置は後続対応)」を削除 (実装済み)。
- **E5** `check_injection.rb` のコメント「後続の artifact kind 対応で導入」→ 現挙動 (`strict_instruction` で instruction の external-url を high 昇格) に。
- **E6** `doctor.rb` `check_catalog` が catalog の target-artifact 件数 (24) を `asset(s)` と誤表示 → unique name 数 (= 実 asset 数 12) に是正。`doctor-test` の期待値も 2→1 (1 asset / 2 target) に更新。

## 検証

- self-test 9 本すべて pass。doctor 実出力が `present, 12 asset(s), fresh` になることを確認 (was 24)。
- `check-manifests` ok / `check-injection` exit 3 (既知 medium のみ)。

## production-rail (ドッグフード)

generation lens で `existing-system-respect` (コメント/表示の最小是正・挙動は doctor 件数のみ) と `ai-antipattern` (実在性=各 version 定数・strict_instruction・catalog 件数をコードで照合) を適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)