### PR TITLE
build: frontmatter 検出を CRLF source 対応にする (#118)

### DIFF
--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -116,7 +116,9 @@ module Build
     # source が frontmatter を持たない場合のみ、manifest から frontmatter を生成する。
     # YAML dump を使い、特殊文字を含む summary でも frontmatter が壊れないようにする。
     def skill_markdown(content, asset)
-      return content if content.start_with?("---\n")
+      # LF / CRLF どちらの source でも既存 frontmatter を検出する (CRLF を取りこぼして
+      # manifest 由来 frontmatter を二重前置しないため)。
+      return content if content.start_with?("---\n", "---\r\n")
 
       description = asset[:summary] || asset[:description] || asset[:name]
       frontmatter = YAML.dump("name" => asset[:name], "description" => description)

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -395,4 +395,29 @@ repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 [ -f "$repo_root/generated/claude-code/skills/personal-project-operating-loop/SKILL.md" ] \
   || fail "repository artifact missing"
 
+# --- case 6: CRLF frontmatter の single-file source を build しても二重化しない (B4) ---
+mkdir -p "$tmp/crlf/shared/prompts"
+printf -- '---\r\nname: personal-crlf\r\ndescription: crlf\r\n---\r\nbody\r\n' \
+  > "$tmp/crlf/shared/prompts/personal-crlf.md"
+cat > "$tmp/crlf/shared/prompts/personal-crlf.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-crlf
+kind: prompt
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/prompts/personal-crlf.md
+  format: markdown
+EOF
+"$build" --root "$tmp/crlf" --quiet > /dev/null 2>&1 || fail "CRLF frontmatter source should build"
+crlf_skill="$tmp/crlf/generated/claude-code/skills/personal-crlf/SKILL.md"
+[ -f "$crlf_skill" ] || fail "CRLF skill not generated"
+# 既存 frontmatter を検出できれば --- 区切りは 2 本のまま (検出失敗で二重化すると 4 本)。
+fm_count=$(grep -c -- '^---' "$crlf_skill" || true)
+[ "$fm_count" = "2" ] || fail "CRLF frontmatter must not be duplicated (got $fm_count '---' lines): $(cat "$crlf_skill")"
+
 echo "ok: build self-test passed"


### PR DESCRIPTION
Closes #118 (umbrella: #103)

## 概要 (⚪ low / latent)

`skill_markdown` は既存 frontmatter を `content.start_with?("---\n")` のみで判定しており、CRLF (`---\r\n`) source では検出を外して manifest 由来 frontmatter を二重前置し YAML frontmatter が壊れる。現状 `shared/` は全 LF のため未発現の latent bug。Claude+Codex 相互検証で検出。

## 変更 (最小)

- `content.start_with?("---\n", "---\r\n")` で CRLF source の frontmatter も検出する。

## 検証

- 回帰テスト build **case 6**: CRLF frontmatter の single-file source を build → frontmatter が二重化しない (`---` 区切りが 2 本のまま。修正なしなら 4 本)。
- self-test 9 本すべて pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)