### PR TITLE
setup-test: --apply で dry-run hint を出さないことを検証 (#120)

### DIFF
--- a/scripts/tests/setup-test.sh
+++ b/scripts/tests/setup-test.sh
@@ -61,6 +61,8 @@ out=$("$setup" --apply --root "$tmp" --codex-home "$tmp/codex" --claude-home "$t
   || fail "apply exited non-zero: $out"
 [ -f "$tmp/codex/skills/personal-demo-skill/SKILL.md" ] || fail "apply did not place codex skill"
 [ -f "$tmp/claude/skills/personal-demo-skill/SKILL.md" ] || fail "apply did not place claude skill"
+# --apply では dry-run hint を出さない (setup.sh:76 の gate 反転を検出する negative coverage)
+echo "$out" | grep -q "dry-run のみ" && fail "--apply must not print the dry-run hint: $out" || true
 
 # --- case 3: 未知オプションは usage を出して exit 2 ---
 rc=0


### PR DESCRIPTION
Closes #120 (umbrella: #103)

## 概要 (⚪ low / test coverage)

`setup-test.sh` の case 2 (--apply) が skill 配置だけを確認し、dry-run hint (`dry-run のみ`) の**不在**を assert していなかった。`setup.sh:76` の `[ -z "$apply" ]` gate が反転しても検出できない negative coverage の穴。

## 変更 (test only)

- case 2 に `echo "$out" | grep -q "dry-run のみ" && fail` を追加し、--apply で hint が出ないことを検証。

## 検証

- self-test 9 本すべて pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)