### PR TITLE
docs: 推奨 clone 先を ~/src/agent/agent-tools に正本化する (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ instruction templates を管理するための個人用 AI agent asset repositor
 各 script は macOS 標準の Ruby だけで動きます(追加依存なし・ネットワーク不要)。clone / pull には git を使います。
 
 ```sh
-git clone <this-repo> agent-tools && cd agent-tools
+# 推奨 clone 先は ~/src/agent/agent-tools(理由は下記)。任意のパスでも動きます。
+git clone <this-repo> ~/src/agent/agent-tools && cd ~/src/agent/agent-tools
 ./scripts/setup.sh           # dry-run: 何が起きるか plan を表示(書き込まない)
 ./scripts/setup.sh --apply   # build → register → connect → sync を通しで実環境に反映
 ```
+
+配置先は `~/src/agent/agent-tools` を推奨します(`dotfiles` の directory convention と
+doctor の既定期待パスに一致)。任意のパスでも動作しますが、`dotfiles` 連携を使うなら
+このパスに合わせるか `AGENT_TOOLS` env で実際の場所を指定してください。配置先の正本は
+[docs/boundary-with-dotfiles.md](docs/boundary-with-dotfiles.md) で定義します。
 
 `setup.sh` は初回 install と更新の両方に使えます(`git pull` 後に再実行するだけ)。
 既定は dry-run で、`--apply` のときだけ実環境へ書き込みます。build / register /

--- a/docs/boundary-with-dotfiles.md
+++ b/docs/boundary-with-dotfiles.md
@@ -42,3 +42,18 @@
 
 `dotfiles` が report-only で読める status の形式は
 [Status / Manifest Contract](status-manifest-contract.md) で定義します。
+
+## expected path(配置先の正本)
+
+`agent-tools` の配置先(clone 先)の正本はここで定義します。`dotfiles` 側はこれを
+**参照するだけ**で、独自に別パスを正としません。
+
+- **既定の expected path**: `~/src/agent/agent-tools`
+- **根拠**: `dotfiles` の directory convention(`~/src/agent/<repo>`)と、`dotfiles` doctor の
+  既定期待パス(`AGENT_TOOLS` env が未設定のときに見る場所)に一致させるため。
+- **override**: 別の場所に置く場合は `AGENT_TOOLS` env で実際のパスを指定する。`dotfiles` の
+  report-only check / doctor はこの env を尊重する。
+
+`agent-tools` 自体はどのパスに clone しても動作します(script は自分の位置からの相対で動く)。
+この expected path は「`dotfiles` 連携(presence / health の report-only check)を成立させる
+ための合意パス」であり、配置の強制ではありません。

--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -10,6 +10,8 @@
 - 各 script はネットワーク不要・外部依存ゼロで、手元だけで完結します。
 - `gh`(GitHub CLI)は asset の利用には不要です。repository へ変更を出す
   (Issue / PR)ときだけ使います。
+- この repo に commit / push する場合、配置先ディレクトリに応じた git identity の出し分けは
+  各自の git 設定(`dotfiles` 等)側で行います(本 repo の管理対象外)。
 
 配置先となる tool home(既定):
 
@@ -29,11 +31,17 @@ skill は隔離 directory なので `sync` が直接置けますが、instructio
 
 ## 初回インストール
 
+**配置先(推奨)**: `~/src/agent/agent-tools`。これは `dotfiles` の directory convention
+(`~/src/agent/<repo>`)と `dotfiles` doctor の既定期待パスに一致する**配置先の正本**です
+([boundary-with-dotfiles.md](boundary-with-dotfiles.md) で定義)。任意のパスでも動作しますが、
+`dotfiles` 連携(presence / health の report-only check)を使うなら、このパスに置くか
+`AGENT_TOOLS` env で実際の場所を指定してください。
+
 ### 一発で通す(推奨)
 
 ```sh
-git clone <this-repo> agent-tools
-cd agent-tools
+git clone <this-repo> ~/src/agent/agent-tools
+cd ~/src/agent/agent-tools
 
 ./scripts/setup.sh           # dry-run: build → register → connect → sync の plan を表示
 ./scripts/setup.sh --apply   # 確認できたら実環境へ反映
@@ -101,7 +109,7 @@ git pull
 
 ```sh
 # 1. expected path に agent-tools があるか(presence)
-AGENT_TOOLS="${AGENT_TOOLS:-$HOME/dev/agent-tools}"
+AGENT_TOOLS="${AGENT_TOOLS:-$HOME/src/agent/agent-tools}"
 [ -d "$AGENT_TOOLS" ] || { echo "agent-tools: absent"; exit 0; }
 
 # 2. status を read-only で読む(health)


### PR DESCRIPTION
Closes #122

## 背景

2026-06-22 の work machine setup で agent-tools の clone が `~/src/agent-tools` に落ち、
`~/src/agent/agent-tools` へ手動移動して整合させた。この配置先は両 repo にまたがる契約
(`dotfiles` の directory convention `~/src/agent/<repo>` + dotfiles doctor の既定期待パス、
`AGENT_TOOLS` env で override 可)。正本を **agent-tools 側に明文化**する(案①)。

摩擦の実体は「配置先の文書化漏れ」+「既存の既定例が新 convention と不一致」の 2 点。

## 変更(docs のみ)

- `docs/boundary-with-dotfiles.md`: 抽象的だった「expected path」を
  `~/src/agent/agent-tools`(根拠・`AGENT_TOOLS` override 込み)として pin = **契約の正本**に。
- `README.md` / `docs/install-and-usage.md`: 推奨 clone 先を明記し boundary を参照。
- `docs/install-and-usage.md`: stale な既定例 `AGENT_TOOLS:-$HOME/dev/agent-tools` を
  `$HOME/src/agent/agent-tools` に修正(これを直さないと正本が新 convention と矛盾したまま)。
- `docs/install-and-usage.md`: commit/push 時の git identity 出し分けは各自環境(`dotfiles`)側、
  という一行を前提条件に追記。

## 変更しないもの

- `setup.sh` のロジック(今回 idempotent に通った。clone は手動前提で従来どおり)。
- `dotfiles` doctor の既定パス(既に `~/src/agent/agent-tools` に一致)。

## 検証

- `grep` で `dev/agent-tools` の残存ゼロを確認。新規参照はすべて `src/agent/agent-tools`。
- `./scripts/check-manifests.sh` ok(12 manifests)。`check-injection` の finding は既存 skill 由来で
  本 PR の docs 変更とは無関係(shared/ asset に変更なし)。

## レビュー

author=Claude → reviewer=**Codex**(author ≠ reviewer)。
