### PR TITLE
docs: runtime injection 防御を別レイヤー(dotfiles)と境界明記する

### DIFF
--- a/docs/boundary-with-dotfiles.md
+++ b/docs/boundary-with-dotfiles.md
@@ -8,6 +8,8 @@
 - capability declarations。
 - directory conventions。
 - local machine setup の safety gates。
+- runtime に流入する外部入力 (GitHub の Issue / PR / comment、外部 URL、添付など) の
+  prompt injection 防御 (safe reader / `PreToolUse` hook / scoped token)。
 - optional companion repositories が存在するかどうかの report-only checks。
 
 ## agent-tools が持つ責務
@@ -18,7 +20,9 @@
 - agent definitions。
 - instruction templates。
 - tool-specific generated artifacts。
-- registered assets 向け prompt injection review policy。
+- registered assets 向け prompt injection review policy (supply-side: 配布する asset 自体に
+  injection が仕込まれていないかを register / sync 前に検査する。runtime の外部入力防御とは
+  別レイヤー)。
 
 ## どちらの repository も持たないもの
 

--- a/docs/prompt-injection-check.md
+++ b/docs/prompt-injection-check.md
@@ -3,6 +3,18 @@
 registered asset は、register / sync される前に prompt injection review を通します。
 review 対象 asset の metadata は [Asset Manifest Schema](asset-manifest-schema.md) に従います。
 
+## 適用範囲 (supply-side のみ)
+
+この gate が守るのは **配布する asset の supply-side** です。register / sync される前に、
+asset 自体 (skill / instruction など) に injection が仕込まれていないかを静的検査します。
+
+agent が **実行時に読み込む外部入力** (GitHub の Issue / PR / comment、外部 URL、貼られた
+ログや添付など) に第三者が混入させた指示で agent が誤誘導される runtime injection は、
+**別レイヤー**の防御です。攻撃面が逆向き (配布物の中身 ⇔ 実行時に流入するデータ) なので
+混同しません。runtime 入力の防御 (safe reader / `PreToolUse` hook / scoped token) は
+実行環境の責務で、この repository の scope には含めません
+([dotfiles との境界](boundary-with-dotfiles.md))。
+
 ## 対象範囲
 
 以下の registered asset types をすべて check します。


### PR DESCRIPTION
## 概要

Issue #124 の PR-a (docs)。agent が実行時に読み込む外部入力 (GitHub Issue/PR/comment 等) の prompt injection が、既存の supply-side gate (`check-injection.sh`) とは別レイヤーであることを docs に明記する。

## 変更

- `docs/prompt-injection-check.md`: 「適用範囲 (supply-side のみ)」節を追加。この gate は配布 asset 自体の検査が対象で、runtime の外部入力 injection 防御は実行環境 (dotfiles) の責務・scope 外であることを明示。
- `docs/boundary-with-dotfiles.md`: dotfiles 責務に「runtime 外部入力の injection 防御 (safe reader / PreToolUse hook / scoped token)」を追加。agent-tools 側の injection review が supply-side であることも併記。

## 範囲

- docs のみ。配備影響なし (scripts / asset / generated は不変)。
- runtime 防御の実装本体 (safe-gh wrapper / hook / token 分離) は dotfiles 側へ hand-off (Issue #124 参照)。

## レビュー

相互レビュー: author=Claude → reviewer=**Codex**。

Refs #124