### PR TITLE
docs: runtime injection 防御の body を agent-tools 責務に是正 (dotfiles は control plane)

### DIFF
--- a/docs/boundary-with-dotfiles.md
+++ b/docs/boundary-with-dotfiles.md
@@ -7,9 +7,11 @@
 - AI execution environment policy。
 - capability declarations。
 - directory conventions。
-- local machine setup の safety gates。
-- runtime に流入する外部入力 (GitHub の Issue / PR / comment、外部 URL、添付など) の
-  prompt injection 防御 (safe reader / `PreToolUse` hook / scoped token)。
+- local machine setup の safety gates (settings.json の permission deny floor / sandbox / MCP gate)。
+- runtime GitHub injection 防御の **control plane**: settings.json の permission / sandbox / hook
+  宣言 (参照)、capability gate、trust list / egress local の置き場規約、body 配布先の絶対 path 参照、
+  doctor の presence report、射程と限界の docs。**body (trust 判定 / safe reader / hook script /
+  token 隔離 / 隔離 reader) は持たない** (下記「runtime GitHub injection 防御の分担」)。
 - optional companion repositories が存在するかどうかの report-only checks。
 
 ## agent-tools が持つ責務
@@ -20,9 +22,32 @@
 - agent definitions。
 - instruction templates。
 - tool-specific generated artifacts。
+- runtime GitHub injection 防御の **body / 振る舞い**: provenance 3 軸の trust 判定ロジック、
+  `safe-gh` wrapper 本体、`PreToolUse` hook の script body と home 配布 (build / sync)、
+  隔離 reader workflow、policy data の single source (tool 別 render)、Codex hook 配線
+  (下記「runtime GitHub injection 防御の分担」)。
 - registered assets 向け prompt injection review policy (supply-side: 配布する asset 自体に
   injection が仕込まれていないかを register / sync 前に検査する。runtime の外部入力防御とは
   別レイヤー)。
+
+## runtime GitHub injection 防御の分担 (control plane ⇔ body)
+
+agent が実行時に読み込む untrusted な GitHub 入力 (Issue / PR / comment 等) に対する防御は、
+**dotfiles が control plane、agent-tools が body** を持つ。同じ "prompt injection" でも、配布 asset
+自体を検査する supply-side review (上記 agent-tools 責務の「registered assets 向け prompt injection
+review policy」) とは攻撃面が逆向きの別レイヤー。設計の spec 正本は外部 planning tool の設計メモ
+(確定オーナーシップ地図)。
+
+- **dotfiles (control plane)**: capability gate、settings.json の permission deny floor / sandbox /
+  MCP github gate / hook 宣言 (参照)、trust list・egress local の置き場規約、body 配布先の絶対 path
+  参照、doctor の presence report、射程と限界の docs。
+- **agent-tools (body)**: trust 判定ロジック (provenance 3 軸)、`safe-gh` wrapper 本体、hook の
+  script body とその home 配布 (build / sync)、隔離 reader workflow、policy data の single source、
+  Codex hook 配線。
+
+原則は「runtime / invocation に属するものは agent-tools、宣言 / 規約 / capability に属するものは
+dotfiles」。command-string allowlist / hook / provenance は enforcement boundary ではなく steering で
+ある (egress も hostname best-effort) 点は、過大評価しないよう spec と docs で honest に明記する。
 
 ## どちらの repository も持たないもの
 

--- a/docs/prompt-injection-check.md
+++ b/docs/prompt-injection-check.md
@@ -10,10 +10,12 @@ asset 自体 (skill / instruction など) に injection が仕込まれていな
 
 agent が **実行時に読み込む外部入力** (GitHub の Issue / PR / comment、外部 URL、貼られた
 ログや添付など) に第三者が混入させた指示で agent が誤誘導される runtime injection は、
-**別レイヤー**の防御です。攻撃面が逆向き (配布物の中身 ⇔ 実行時に流入するデータ) なので
-混同しません。runtime 入力の防御 (safe reader / `PreToolUse` hook / scoped token) は
-実行環境の責務で、この repository の scope には含めません
-([dotfiles との境界](boundary-with-dotfiles.md))。
+**別レイヤー**の防御で、この `check-injection` gate の対象外です。攻撃面が逆向き
+(配布物の中身 ⇔ 実行時に流入するデータ) なので混同しません。runtime 防御自体は
+agent-tools の scope 外ではなく、**body (safe reader / hook script / token 隔離 / 隔離 reader /
+trust 判定) は agent-tools、control plane (settings deny 床 / capability / 規約 / doctor) は
+dotfiles** という分担です (この gate がそれを担うわけではない)。詳細は
+[dotfiles との境界](boundary-with-dotfiles.md) の「runtime GitHub injection 防御の分担」。
 
 ## 対象範囲
 


### PR DESCRIPTION
## 概要

Issue #127。#119 の確定設計 (Phase 2 クローズ / dotfiles #131 ハンドオフ) でオーナーシップが反転したため、`docs/boundary-with-dotfiles.md` の古い責務記述を最新化する。

- **旧**: runtime injection 防御の実体 = dotfiles 責務。
- **新 (確定)**: body (safe-gh / hook script / token 隔離 / 隔離 reader / provenance trust 判定) = **agent-tools**。dotfiles は **control plane** (capability / settings deny floor / 接続規約 / 置き場規約 / doctor presence / 限界 docs) のみ。

古い記述のまま Phase 3 本体 (#131) に着手すると「自分の仕事でない」と誤読するため、着手前の最優先タスクとして是正する。

## 変更

- `docs/boundary-with-dotfiles.md`:
  - 「dotfiles が持つ責務」の runtime injection 行を control plane として書き直し、body は持たないと明記。
  - 「agent-tools が持つ責務」に runtime injection 防御の body を追加。
  - 「runtime GitHub injection 防御の分担 (control plane ⇔ body)」節を新設。原則・steering≠enforcement の honest-label・spec 正本参照を記載。

## 範囲

- docs のみ・配備影響なし (scripts / asset / generated 不変)。
- repo 外の stale 箇所 (Notion hub「次セッションの入口」/ ローカル handoff / memory) は本 PR 対象外で、Issue #127 のスコープとして別途直す。

## 検証

`check-manifests.sh` ok (12) / `check-injection.sh` rc=3 (既存 asset-miner medium のみ、本変更由来の finding なし)。

## レビュー

相互レビュー: author=Claude → reviewer=**Codex**。

Refs #127