### PR TITLE
refactor: 配置先 path 解決を ArtifactTargets.target_path に集約 (P3-03a, #129)

### DIFF
--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -49,6 +49,21 @@ module ArtifactTargets
     SUPPORTED_KINDS.include?(kind)
   end
 
+  # tool home 内の target-artifact 配置先 path を返す (path 解決の単一 source)。
+  # home は解決済みの tool home dir (例 ~/.claude / ~/.codex)。
+  # - instruction: tool 固有ファイル名 (INSTRUCTION_FILENAMES)。claude-code は
+  #   agent-tools/ subdir 配下に所有ファイルを置き、codex は home 直下。filename を
+  #   解決できない tool では nil。
+  # - それ以外 (skill 等): <home>/skills/<name>。
+  def self.target_path(home, tool, name, kind)
+    if kind == "instruction"
+      filename = INSTRUCTION_FILENAMES[tool]
+      filename && (tool == "claude-code" ? File.join(home, "agent-tools", filename) : File.join(home, filename))
+    else
+      File.join(home, "skills", name)
+    end
+  end
+
   # その tool 向けに artifact を build できるかを判定する (実 build はしない)。
   # register が「registered != buildable」のサイレント断裂を防ぐために使う。
   def self.buildable?(asset, tool)

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -107,7 +107,7 @@ module Connect
       gen = generated_instruction(tool, "CLAUDE.md")
       return [] unless gen # instruction artifact が無ければ connect 不要
 
-      owned = File.join(home, "agent-tools", "CLAUDE.md")
+      owned = ArtifactTargets.target_path(home, tool, nil, "instruction")
       import_file = File.join(home, "CLAUDE.md")
       reason = unconnectable_reason(tool, gen)
       return [Plan.new("skip", tool, "owned", owned, reason, gen)] if reason
@@ -122,7 +122,7 @@ module Connect
       gen = generated_instruction(tool, "AGENTS.md")
       return [] unless gen
 
-      owned = File.join(home, "AGENTS.md")
+      owned = ArtifactTargets.target_path(home, tool, nil, "instruction")
       reason = unconnectable_reason(tool, gen)
       return [Plan.new("skip", tool, "owned", owned, reason, gen)] if reason
 

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -98,17 +98,13 @@ module Sync
     end
 
     # registered でない entry の skip 表示に使う target path。
+    # path 解決は ArtifactTargets.target_path が単一 source (skill / instruction 共通)。
     def target_path(tool, name, kind)
-      if kind == "instruction"
-        filename = ArtifactTargets::INSTRUCTION_FILENAMES[tool]
-        filename && instruction_target(tool, filename)
-      else
-        File.join(@homes.fetch(tool), "skills", name)
-      end
+      ArtifactTargets.target_path(@homes.fetch(tool), tool, name, kind)
     end
 
     def plan_skill(tool, name, expected_build_id)
-      target = File.join(@homes.fetch(tool), "skills", name)
+      target = target_path(tool, name, "skill")
       gen = File.join(@root, "generated", tool, "skills", name)
 
       unless name.start_with?("personal-")
@@ -159,7 +155,7 @@ module Sync
         return Plan.new("skip", tool, name, nil, "instruction unsupported for #{tool}", "instruction", nil)
       end
       gen = File.join(@root, "generated", tool, "instructions", filename)
-      target = instruction_target(tool, filename)
+      target = target_path(tool, name, "instruction")
 
       gen_marker = File.file?(gen) ? InstructionMarker.parse(File.read(gen)) : nil
       # generated が catalog entry と一致するか (target + name + build_id)。
@@ -191,11 +187,6 @@ module Sync
       else
         Plan.new("update", tool, name, target, nil, "instruction", gen)
       end
-    end
-
-    def instruction_target(tool, filename)
-      home = @homes.fetch(tool)
-      tool == "claude-code" ? File.join(home, "agent-tools", filename) : File.join(home, filename)
     end
 
     def read_marker(dir)


### PR DESCRIPTION
## 概要

Phase 3 (#129) の **P3-03a**。target-artifact の配置先 path 計算が sync.rb / connect.rb に分散
していたのを `ArtifactTargets.target_path(home, tool, name, kind)` の単一 source に集約する
**純 refactor (振る舞い不変)**。P3-03b で `script` kind をこの 1 箇所に足せるようにする土台。

## 変更

- `artifact_targets.rb`: `target_path` を追加。現 `Sync#target_path` のロジックをそのまま移植
  (instruction = tool 固有ファイル名・claude-code は `agent-tools/` 配下 / それ以外 = `<home>/skills/<name>`)。
- `sync.rb`: `target_path` を `ArtifactTargets.target_path` へ委譲化。`plan_skill` / `plan_instruction`
  で利用。重複していた `instruction_target` を削除。
- `connect.rb`: claude / codex の owned instruction path を `ArtifactTargets.target_path` 経由に。

## 検証

- self-test 9 本すべて PASS (sync / connect / status / doctor 含む)。
- `check-manifests` OK、`check-injection` は既存ベースライン (exit 3) のみ。
- `build` / `register` (exit 0) / `doctor` OK。生成物への stray な差分なし。
- 実 home に対する `sync` / `connect` dry-run で target path が refactor 前と同一
  (`~/.claude/agent-tools/CLAUDE.md` / `~/.codex/AGENTS.md` / `~/.claude/skills/...` が managed) を確認。

## レビュー

author = Claude のため reviewer = **Codex** (author ≠ reviewer)。挙動変更を意図しない refactor
なので behavior drift を重点に。