### PR TITLE
feat: script artifact kind を認識・検証・配置先解決まで追加 (P3-03b, #129)

### DIFF
--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -21,6 +21,7 @@ module ArtifactTargets
     "workflow" => "skill",
     "instruction" => "instruction",
     "template" => "skill",
+    "script" => "script",
   }.freeze
 
   # instruction を配るときの tool 別ファイル名。
@@ -54,11 +55,17 @@ module ArtifactTargets
   # - instruction: tool 固有ファイル名 (INSTRUCTION_FILENAMES)。claude-code は
   #   agent-tools/ subdir 配下に所有ファイルを置き、codex は home 直下。filename を
   #   解決できない tool では nil。
+  # - script: <home>/agent-tools/scripts/<name> (配布は P3-04)。
   # - それ以外 (skill 等): <home>/skills/<name>。
   def self.target_path(home, tool, name, kind)
-    if kind == "instruction"
+    case kind
+    when "instruction"
       filename = INSTRUCTION_FILENAMES[tool]
       filename && (tool == "claude-code" ? File.join(home, "agent-tools", filename) : File.join(home, filename))
+    when "script"
+      # script body は tool home の agent-tools/scripts/ subdir に配る (配置先の正本は
+      # docs/runtime-injection-defense.md)。実際の build / sync 配布は P3-04。
+      File.join(home, "agent-tools", "scripts", name)
     else
       File.join(home, "skills", name)
     end
@@ -76,6 +83,11 @@ module ArtifactTargets
       source = asset[:source]
       format = source.is_a?(Hash) ? source["format"] : nil
       format != "directory"
+    when "script"
+      # script kind は P3-03b では認識・検証・配置先解決まで。build / sync 配布と marker 戦略は
+      # P3-04 で入る。それまで buildable でない → register が "unsupported" にし、registered だが
+      # 配布されないサイレント断裂を防ぐ (registered != buildable を作らない)。
+      false
     else
       false
     end

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -13,7 +13,7 @@ require_relative "assets"
 require_relative "artifact_targets"
 
 module CheckManifests
-  KINDS = %w[skill prompt workflow agent instruction template].freeze
+  KINDS = %w[skill prompt workflow agent instruction template script].freeze
   TRACKED_VISIBILITIES = %w[public personal].freeze
   FORBIDDEN_VISIBILITIES = %w[private work client secret].freeze
   TARGETS = %w[codex claude-code].freeze
@@ -28,7 +28,7 @@ module CheckManifests
     "human_review" => %w[pending approved rejected not_needed],
   }.freeze
   NAME_PATTERN = /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/.freeze
-  ASSET_CATEGORIES = %w[skills prompts workflows agents instructions].freeze
+  ASSET_CATEGORIES = %w[skills prompts workflows agents instructions scripts].freeze
   NON_ASSET_BASENAMES = %w[README.md].freeze
 
   class Runner

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -347,6 +347,26 @@ fi
 grep -q "must not contain special files" "$tmp/out-fifoskill" \
   || fail "expected special-file fail-closed reason: $(cat "$tmp/out-fifoskill")"
 
+# --- case: script kind の単一ファイル asset が validate する (P3-03b) ---
+mkdir -p "$tmp/scriptkind/shared/scripts"
+printf '#!/bin/sh\necho hi\n' > "$tmp/scriptkind/shared/scripts/personal-demo-script.sh"
+cat > "$tmp/scriptkind/shared/scripts/personal-demo-script.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-demo-script
+kind: script
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-demo-script.sh
+  format: text
+EOF
+"$check" --root "$tmp/scriptkind" > "$tmp/out-scriptkind" 2>&1 \
+  || fail "script kind manifest should validate: $(cat "$tmp/out-scriptkind")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/register-test.sh
+++ b/scripts/tests/register-test.sh
@@ -149,6 +149,31 @@ status=0
 grep -q "rejected asset" "$tmp/r10" || fail "missing rejected message"
 [ ! -e "$tmp/drej/generated/catalog.json" ] || fail "catalog must not be written on rejected"
 
+# --- case 12: script kind は認識・検証されるが配布前なので unsupported (P3-03b) ---
+mkdir -p "$tmp/script/shared/scripts"
+printf '#!/bin/sh\necho hi\n' > "$tmp/script/shared/scripts/personal-demo-script.sh"
+cat > "$tmp/script/shared/scripts/personal-demo-script.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-demo-script
+kind: script
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-demo-script.sh
+  format: text
+EOF
+"$register" --root "$tmp/script" > "$tmp/r12" 2>&1 \
+  || fail "script register should not fail (unsupported is exit 0): $(cat "$tmp/r12")"
+sc="$tmp/script/generated/catalog.json"
+[ "$(jget "$sc" assets 0 artifact_kind)" = '"script"' ] \
+  || fail "script asset should resolve to artifact_kind script"
+[ "$(jget "$sc" assets 0 registration)" = '"unsupported"' ] \
+  || fail "script should be unsupported until P3-04 (no silent registered != buildable)"
+
 # --- case 11: repository 本体が register できる ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$register" --root "$repo_root" --quiet > "$tmp/r8" 2>&1 \


### PR DESCRIPTION
## 概要

Phase 3 (#129) の **P3-03b**。script body (safe-gh / hook / 隔離 reader) を配るための
`script` artifact kind をパイプラインの**認識・検証・配置先解決**層に追加する。
**実配布はしない** — build / sync 配布と単一ファイルの marker 戦略は **P3-04**。

## なぜ配布まで入れないか (coherent な分割)

`register` は `buildable? ? review_registration : "unsupported"` で登録する。build / sync が
script を扱えない段階で `buildable?` を true にすると「registered だが配布されない」サイレント
断裂 (`registered != buildable`) を作る。そこで本 PR は **`buildable?(script)=false` を明示**し、
script asset は **`unsupported`** として扱う (認識・検証・配置先解決まで)。P3-04 で build/sync と
marker を入れて `buildable?` を true に上げる。

## 変更

- `artifact_targets.rb`: `DEFAULT_BY_KIND` に `script→script` (resolve が script を返す)。
  `target_path` に script 分岐 (`<home>/agent-tools/scripts/<name>`)。`buildable?` に明示的な
  `script→false` (コメントで P3-04 まで配布しない旨)。
- `check_manifests.rb`: `KINDS` に `script`、`ASSET_CATEGORIES` に `scripts` (kind: script の
  manifest を validate、`shared/scripts/` を category 認識)。manifest discovery は
  `assets.rb` の `shared/**/*.asset.yml` で再帰的なので変更不要。
- tests: register-test に「script → artifact_kind=script / registration=unsupported」、
  check-manifests-test に「script kind の単一ファイル asset が validate」。

## 検証

- self-test 9 本 PASS、`build`/`register` exit 0、`check-manifests` 13 manifest OK。
- 実 repo に script asset は無く **catalog 不変・配備影響ゼロ**。
- `check-injection` は既存ベースライン (exit 3) のみ。

## レビュー

author = Claude のため reviewer = **Codex** (author ≠ reviewer)。重点 = サイレント断裂
(registered != buildable) を作っていないか、target_path の配置先が canonical doc と一致するか、
新 kind 追加で既存 skill/instruction の挙動が変わらないか。