### PR TITLE
feat: script artifact の build/sync 配布を実装 (P3-04, #129)

### DIFF
--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -96,8 +96,9 @@ rules:
 
 asset の種類を表す意味ラベルです。**用途に応じて選びます**。配置のされ方は kind ごとに
 下表の「配置挙動」のとおりで、配備対象は skill 系 (`skill` / `prompt` / `workflow` /
-`template` → skill target) と `instruction` (→ tool 別の `CLAUDE.md` / `AGENTS.md`) の
-2 系統です。`agent` は現状どの target にも解決されず未対応 (unsupported) です。kind が
+`template` → skill target)、`instruction` (→ tool 別の `CLAUDE.md` / `AGENTS.md`)、
+`script` (→ `<tool home>/agent-tools/scripts/personal-<name>` の単一実行ファイル) の
+3 系統です。`agent` は現状どの target にも解決されず未対応 (unsupported) です。kind が
 どの artifact に解決されるかの仕組みは [compatibility / artifact_kind](#compatibility)
 を参照してください。
 
@@ -108,6 +109,7 @@ asset の種類を表す意味ラベルです。**用途に応じて選びます
 | `workflow` | 複数ステップの再利用可能な作業手順。 | `skill` |
 | `template` | 出力フォーマットなどの雛形。 | `skill` |
 | `instruction` | 常時読まれる運用ルール。tool 別の `CLAUDE.md` / `AGENTS.md` として生成。詳細は [Instruction Artifact Kind](instruction-artifact-kind.md)。 | `instruction` |
+| `script` | tool home に配る実行可能な script body (hook / wrapper 等)。単一ファイルのみ。 | `script` |
 | `agent` | サブエージェント定義。**現状は配備未対応** (各 tool の agent 形式へのマッピングが未設計)。register では `unsupported` になる。 | 未対応 |
 
 補足:
@@ -229,14 +231,18 @@ target tool ごとの変換 hint です。
 
 `compatibility.<tool>.artifact_kind` で、その tool 向けに生成する artifact の種類を
 明示できます。未指定なら asset の `kind` から既定値が導出されます (`instruction` kind は
-instruction、`skill` / `prompt` / `workflow` / `template` は skill)。
+instruction、`script` kind は script、`skill` / `prompt` / `workflow` / `template` は skill)。
 
-build が対応する artifact_kind は `skill` と `instruction` です。どちらも build →
+build が対応する artifact_kind は `skill` / `instruction` / `script` です。いずれも build →
 register → sync で配置されます (instruction の所有確立は connect が担当)。
 
 - `skill`: `<tool home>/skills/personal-<name>/` に directory として配る。
 - `instruction`: tool 別の単一ファイル (claude-code は `CLAUDE.md`、codex は `AGENTS.md`)
   として生成する。詳細は [Instruction Artifact Kind](instruction-artifact-kind.md)。
+- `script`: `<tool home>/agent-tools/scripts/personal-<name>` に単一実行ファイル (mode 0755)
+  + sidecar marker として配る。**単一ファイルのみ対応** (source.format が directory の script は
+  unsupported)。本体は byte 単位で保持する。配置先と marker は
+  [Sync Policy](sync-policy.md) / [Status / Manifest Contract](status-manifest-contract.md)。
 
 この field の他の用途は adapter 実装が読むための optional metadata で、strict validation
 しません。

--- a/docs/status-manifest-contract.md
+++ b/docs/status-manifest-contract.md
@@ -98,8 +98,24 @@ file 先頭に 1 行の HTML コメント marker を埋め込みます。markdow
 ```
 
 生成・解析は `scripts/lib/instruction_marker.rb` に集約し、build (生成) と
-connect / sync (所有判定) が同じ format を共有します。comment 記法を持たない
-format (json など) では、sidecar marker file を使います。
+connect / sync (所有判定) が同じ format を共有します。
+
+### Single-file artifact (script): sidecar marker
+
+script のように本体を改変できない (任意の interpreter / shebang を壊さない) 単一ファイルは、
+本体の隣に `<artifact name>.agent-tools-managed.yml` を置きます。本体は byte 単位で保持し、
+所有情報は sidecar file 側に持たせます。中身は directory artifact の marker と同じ YAML です。
+
+```yaml
+repo: agent-tools
+name: personal-example
+target: claude-code
+source: shared/scripts/personal-example.sh
+build_id: sha256:...
+```
+
+配置先は `<tool home>/agent-tools/scripts/<name>` (本体) と同 `<name>.agent-tools-managed.yml`
+(sidecar)。本体は実行可能 (mode 0755) で配置します。
 
 ### Directory artifact
 

--- a/docs/sync-policy.md
+++ b/docs/sync-policy.md
@@ -20,6 +20,11 @@ default は必ず conservative にします。
   - instruction: connect が確立した所有ファイル。instruction の所有確立は connect の
     役割で、sync は create に落ちず未接続なら connect を促す
     ([Instruction Artifact Kind](instruction-artifact-kind.md))。
+  - script: `<tool home>/agent-tools/scripts/personal-<name>` (単一実行ファイル) と
+    その隣の `<name>.agent-tools-managed.yml` (sidecar marker)。本体は byte 保持・mode 0755。
+    instruction と違い人間ファイルを介さないため connect 不要で、未配置なら sync が直接
+    create する。配置先本体・`agent-tools/scripts`・`agent-tools` のいずれかが symlink なら
+    conflict として停止する。
 
 ## v1 Codex targets
 
@@ -27,7 +32,8 @@ default は必ず conservative にします。
 
 ```text
 ~/.codex/skills/personal-*
-~/.codex/AGENTS.md          (instruction、connect が所有を確立)
+~/.codex/AGENTS.md                       (instruction、connect が所有を確立)
+~/.codex/agent-tools/scripts/personal-*  (script、sync が直接配置)
 ```
 
 禁止する targets:
@@ -47,7 +53,8 @@ default は必ず conservative にします。
 
 ```text
 ~/.claude/skills/personal-*
-~/.claude/agent-tools/CLAUDE.md   (instruction、connect が所有を確立)
+~/.claude/agent-tools/CLAUDE.md            (instruction、connect が所有を確立)
+~/.claude/agent-tools/scripts/personal-*   (script、sync が直接配置)
 ```
 
 禁止する targets:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,7 +99,9 @@ usage: sync.sh [--root DIR] [--apply] [--codex-home DIR] [--claude-home DIR] [--
 - 更新するのは agent-tools management marker を持つ target のみ。
   unmanaged な同名 target / symlink は conflict として exit 1 で停止し、何も書き込まない。
 - 書き込み先は skill が `<tool home>/skills/personal-*`、instruction が connect 確立済みの
-  所有ファイル (`~/.codex/AGENTS.md` / `~/.claude/agent-tools/CLAUDE.md`)。それ以外の path は構成しない。
+  所有ファイル (`~/.codex/AGENTS.md` / `~/.claude/agent-tools/CLAUDE.md`)、script が
+  `<tool home>/agent-tools/scripts/personal-*` (単一実行ファイル + sidecar marker)。
+  それ以外の path は構成しない。
 - `--codex-home` / `--claude-home` は inspection / test 用の override。
 - self-test: `tests/sync-test.sh` (fake home のみを使い、実際の tool homes には触れない)
 

--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -11,7 +11,12 @@ module ArtifactTargets
   CATALOG_VERSION = 2
 
   # build が扱える artifact_kind。
-  SUPPORTED_KINDS = %w[skill instruction].freeze
+  SUPPORTED_KINDS = %w[skill instruction script].freeze
+
+  # management marker の basename。directory artifact (skill) は dir 直下にこの名前で
+  # 置き、単一ファイル artifact (script) は <artifact path> + この名前の sidecar file に
+  # 置く。build が書き、sync / status / doctor が所有判定に読む単一 source。
+  MARKER_BASENAME = ".agent-tools-managed.yml"
 
   # asset.kind から導出する既定の artifact_kind。
   # compatibility.<tool>.artifact_kind が明示されればそちらを優先する。
@@ -50,6 +55,13 @@ module ArtifactTargets
     SUPPORTED_KINDS.include?(kind)
   end
 
+  # 単一ファイル artifact (script) の sidecar management marker file path。
+  # 本体を改変せず所有を示すため、本体の隣に <artifact path>.agent-tools-managed.yml を置く
+  # (docs/status-manifest-contract.md)。build (生成) と sync / status (所有判定) が共有する。
+  def self.sidecar_marker_path(artifact_path)
+    "#{artifact_path}#{MARKER_BASENAME}"
+  end
+
   # tool home 内の target-artifact 配置先 path を返す (path 解決の単一 source)。
   # home は解決済みの tool home dir (例 ~/.claude / ~/.codex)。
   # - instruction: tool 固有ファイル名 (INSTRUCTION_FILENAMES)。claude-code は
@@ -64,7 +76,7 @@ module ArtifactTargets
       filename && (tool == "claude-code" ? File.join(home, "agent-tools", filename) : File.join(home, filename))
     when "script"
       # script body は tool home の agent-tools/scripts/ subdir に配る (配置先の正本は
-      # docs/runtime-injection-defense.md)。実際の build / sync 配布は P3-04。
+      # docs/runtime-injection-defense.md)。
       File.join(home, "agent-tools", "scripts", name)
     else
       File.join(home, "skills", name)
@@ -84,10 +96,12 @@ module ArtifactTargets
       format = source.is_a?(Hash) ? source["format"] : nil
       format != "directory"
     when "script"
-      # script kind は P3-03b では認識・検証・配置先解決まで。build / sync 配布と marker 戦略は
-      # P3-04 で入る。それまで buildable でない → register が "unsupported" にし、registered だが
-      # 配布されないサイレント断裂を防ぐ (registered != buildable を作らない)。
-      false
+      # script body は単一実行ファイルとして配る (sidecar marker)。directory 形式は
+      # 配置先 (<home>/agent-tools/scripts/<name>) が単一ファイルなので buildable でない
+      # → register が "unsupported" にし、registered != buildable のサイレント断裂を防ぐ。
+      source = asset[:source]
+      format = source.is_a?(Hash) ? source["format"] : nil
+      format != "directory"
     else
       false
     end

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -38,6 +38,8 @@ module Build
             build_skill(tool, asset)
           when "instruction"
             build_instruction(tool, asset)
+          when "script"
+            build_script(tool, asset)
           else
             @skipped << "#{asset[:manifest_path]}: unsupported artifact_kind " \
                         "#{artifact_kind.inspect} for #{tool}"
@@ -95,6 +97,29 @@ module Build
       @built << rel(out)
     end
 
+    # script asset を単一の実行ファイルとして生成し、sidecar marker を添える。
+    # 本体は byte 単位で保持する (任意の interpreter / shebang を壊さない)。所有 marker は
+    # 本体を改変しないよう sidecar file に置く (docs/status-manifest-contract.md)。
+    # 配置先 (<home>/agent-tools/scripts/<name>) が単一ファイルなので directory 形式は弾く。
+    def build_script(tool, asset)
+      name = asset[:name]
+      source = asset[:source]["path"]
+      format = asset[:source]["format"]
+      if format == "directory"
+        @skipped << "#{asset[:manifest_path]}: script must be a single file, not a directory"
+        return
+      end
+
+      out_dir = File.join(@root, "generated", tool, "scripts")
+      FileUtils.mkdir_p(out_dir)
+      out = File.join(out_dir, name)
+      FileUtils.cp(File.join(@root, source), out)
+      File.chmod(0o755, out) # script は配置先で実行されるため実行可能にする
+      build_id = Build.build_id_for(@root, source, format)
+      File.write(ArtifactTargets.sidecar_marker_path(out), marker_yaml(name, tool, source, build_id))
+      @built << rel(out)
+    end
+
     # instruction 本体の先頭に管理 marker (HTML コメント) を 1 行入れる。
     # marker format は InstructionMarker に集約し、connect / sync が同じ解析を使う。
     def instruction_with_marker(content, name, tool, source, build_id)
@@ -125,15 +150,21 @@ module Build
       "#{frontmatter}---\n\n#{content}"
     end
 
+    # directory artifact (skill) の管理 marker を dir 直下に書く。
     def write_marker(out_dir, name, tool, source, build_id)
-      marker = {
+      File.write(File.join(out_dir, ArtifactTargets::MARKER_BASENAME),
+                 marker_yaml(name, tool, source, build_id))
+    end
+
+    # YAML marker の本文。directory marker (skill) と sidecar marker (script) が共有する。
+    def marker_yaml(name, tool, source, build_id)
+      YAML.dump(
         "repo" => "agent-tools",
         "name" => name,
         "target" => tool,
         "source" => source,
         "build_id" => build_id,
-      }
-      File.write(File.join(out_dir, ".agent-tools-managed.yml"), YAML.dump(marker))
+      )
     end
 
     def rel(path)
@@ -147,13 +178,14 @@ module Build
     # marker のない directory は warning として返し、残す。
     def prune
       expected = Hash.new { |h, k| h[k] = [] }
+      script_expected = Hash.new { |h, k| h[k] = [] }
       instruction_expected = Hash.new(false)
       Assets.load_all(@root).each do |asset|
         (asset[:targets] || []).each do |tool|
-          if ArtifactTargets.resolve(asset, tool) == "instruction"
-            instruction_expected[tool] = true
-          else
-            expected[tool] << asset[:name]
+          case ArtifactTargets.resolve(asset, tool)
+          when "instruction" then instruction_expected[tool] = true
+          when "script" then script_expected[tool] << asset[:name]
+          else expected[tool] << asset[:name]
           end
         end
       end
@@ -172,6 +204,22 @@ module Build
             pruned << rel(dir)
           else
             kept << rel(dir)
+          end
+        end
+
+        # script: manifest に対応しない managed script (と sidecar marker) を削除する。
+        # sidecar marker file 自体は本体と一緒に処理するため列挙対象から外す。
+        Dir.glob(File.join(@root, "generated", tool, "scripts", "*")).sort.each do |path|
+          next unless File.file?(path)
+          next if path.end_with?(ArtifactTargets::MARKER_BASENAME)
+          next if script_expected[tool].include?(File.basename(path))
+
+          if script_managed_marker?(path)
+            FileUtils.rm_f(path)
+            FileUtils.rm_f(ArtifactTargets.sidecar_marker_path(path))
+            pruned << rel(path)
+          else
+            kept << rel(path)
           end
         end
 
@@ -195,11 +243,21 @@ module Build
 
     private
 
+    # directory artifact (skill) の marker が agent-tools 管理を示すか。
     def managed_marker?(dir)
-      path = File.join(dir, ".agent-tools-managed.yml")
-      return false unless File.file?(path)
+      marker_present?(File.join(dir, ArtifactTargets::MARKER_BASENAME))
+    end
 
-      data = YamlUtil.load(File.read(path), path)
+    # 単一ファイル artifact (script) の sidecar marker が agent-tools 管理を示すか。
+    def script_managed_marker?(artifact_path)
+      marker_present?(ArtifactTargets.sidecar_marker_path(artifact_path))
+    end
+
+    # marker file が存在し agent-tools repo を示すか (本文 YAML を読む)。
+    def marker_present?(marker_path)
+      return false unless File.file?(marker_path)
+
+      data = YamlUtil.load(File.read(marker_path), marker_path)
       data.is_a?(Hash) && data["repo"] == "agent-tools"
     rescue Psych::Exception
       false

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -220,7 +220,15 @@ module CheckManifests
           error(path, "directory manifest must point at its own directory #{expected_dir.inspect}")
         end
       else
-        error(path, "source.path #{source_path.inspect} does not exist") unless File.file?(full)
+        # single-file source も symlink を fail-closed で reject する (directory asset の
+        # check_directory_no_symlinks と同じ境界)。symlink を許すと build の FileUtils.cp /
+        # build_id_for が shared/ の外を読み、特に script は byte 保持の実行ファイルとして
+        # 配布されるため、任意ファイルの内容を配布物に取り込めてしまう。
+        if File.symlink?(full)
+          error(path, "source.path must not be a symlink: #{source_path.inspect}")
+        elsif !File.file?(full)
+          error(path, "source.path #{source_path.inspect} does not exist")
+        end
         if File.basename(path) == "asset.yml"
           error(path, "directory manifest requires source.format: directory")
         elsif File.dirname(source_path) != File.dirname(path)

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -73,7 +73,7 @@ module Status
     end
 
     # generated artifacts の数と、source より古い (build_id 不一致) artifact の数。
-    # skill (directory) と instruction (単一ファイル) の両方を数える。
+    # skill (directory) / instruction (単一ファイル) / script (単一ファイル + sidecar) を数える。
     def generated_state
       sources = safe_sources_by_name
       total = 0
@@ -91,6 +91,13 @@ module Status
           total += 1
           stale += 1 unless fresh_instruction?(artifact, sources)
         end
+        Dir.glob(File.join(@root, "generated", tool, "scripts", "*")).sort.each do |artifact|
+          next unless File.file?(artifact)
+          next if artifact.end_with?(ArtifactTargets::MARKER_BASENAME) # sidecar marker は本体と一緒に数える
+
+          total += 1
+          stale += 1 unless fresh_script?(artifact, sources)
+        end
       end
       [total, stale]
     end
@@ -104,8 +111,18 @@ module Status
       {}
     end
 
+    # skill (directory) の鮮度判定。dir 直下の marker を読む。
     def fresh?(artifact, sources)
-      marker_path = File.join(artifact, Sync::MARKER_FILE)
+      fresh_by_marker_file?(File.join(artifact, Sync::MARKER_FILE), sources)
+    end
+
+    # script (単一ファイル) の鮮度判定。sidecar marker を読む。
+    def fresh_script?(artifact, sources)
+      fresh_by_marker_file?(ArtifactTargets.sidecar_marker_path(artifact), sources)
+    end
+
+    # YAML marker file (skill の dir 直下 / script の sidecar) から鮮度を判定する。
+    def fresh_by_marker_file?(marker_path, sources)
       return false unless File.file?(marker_path)
 
       marker = YamlUtil.load(File.read(marker_path), marker_path)

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -8,7 +8,9 @@
 # - 対象は `personal-` で始まる generated assets のみ。
 # - 更新してよいのは agent-tools management marker を持つ target のみ。
 # - 同名 unmanaged target は conflict として停止する。
-# - 許可 target は <tool home>/skills/personal-* のみ。それ以外の path は構成しない。
+# - 許可 target は artifact_kind 別: skill = <tool home>/skills/personal-*、
+#   instruction = connect 確立済みの所有ファイル、script = <tool home>/agent-tools/scripts/
+#   personal-* (sidecar marker つき)。それ以外の path は構成しない (docs/sync-policy.md)。
 
 require "yaml"
 require "json"
@@ -19,7 +21,7 @@ require_relative "artifact_targets"
 require_relative "instruction_marker"
 
 module Sync
-  MARKER_FILE = ".agent-tools-managed.yml"
+  MARKER_FILE = ArtifactTargets::MARKER_BASENAME
   CATALOG_PATH = "generated/catalog.json"
   TOOLS = %w[codex claude-code].freeze
 
@@ -65,10 +67,17 @@ module Sync
       plans.each do |p|
         next unless %w[create update].include?(p.action)
 
-        if p.kind == "instruction"
+        case p.kind
+        when "instruction"
           # instruction は単一ファイル。所有先は connect が確立済み (sync は update)。
           FileUtils.mkdir_p(File.dirname(p.target))
           FileUtils.cp(p.gen, p.target)
+        when "script"
+          # script は単一実行ファイル + sidecar marker。本体を実行可能にして配置する。
+          FileUtils.mkdir_p(File.dirname(p.target))
+          FileUtils.cp(p.gen, p.target)
+          File.chmod(0o755, p.target)
+          FileUtils.cp(ArtifactTargets.sidecar_marker_path(p.gen), ArtifactTargets.sidecar_marker_path(p.target))
         else
           FileUtils.rm_rf(p.target)
           FileUtils.mkdir_p(File.dirname(p.target))
@@ -92,6 +101,7 @@ module Sync
       case kind
       when "skill" then plan_skill(tool, name, entry["build_id"])
       when "instruction" then plan_instruction(tool, name, entry["build_id"])
+      when "script" then plan_script(tool, name, entry["build_id"])
       else
         Plan.new("skip", tool, name, nil, "unsupported artifact_kind #{kind.inspect}", kind, nil)
       end
@@ -189,8 +199,67 @@ module Sync
       end
     end
 
+    # script は単一実行ファイル + sidecar marker。skill (plan_skill) と同じ marker ベースの
+    # 所有 / stale / symlink 防御を、単一ファイルと 2 階層の配置先
+    # (<home>/agent-tools/scripts/<name>) にあわせて適用する。instruction と違い人間ファイルを
+    # 介さないため connect は不要で、未配置なら直接 create する。
+    def plan_script(tool, name, expected_build_id)
+      target = target_path(tool, name, "script")
+      gen = File.join(@root, "generated", tool, "scripts", name)
+
+      unless name.start_with?("personal-")
+        return Plan.new("conflict", tool, name, target, "generated asset without personal- prefix", "script", gen)
+      end
+      unless File.file?(gen)
+        return Plan.new("skip", tool, name, target, "run build first", "script", gen)
+      end
+
+      source_marker = read_marker_file(ArtifactTargets.sidecar_marker_path(gen))
+      unless managed?(source_marker, tool, name)
+        return Plan.new("conflict", tool, name, target, "generated artifact is missing a valid marker", "script", gen)
+      end
+      # generated が catalog entry と一致するか (build_id)。不一致 = register 後に build して
+      # いない (stale generated)。plan_skill / plan_instruction と同じく run build first で skip。
+      if source_marker["build_id"] != expected_build_id
+        return Plan.new("skip", tool, name, target, "run build first", "script", gen)
+      end
+      # 配置先本体・その親 (agent-tools/scripts)・さらにその親 (agent-tools) のいずれかが
+      # symlink なら、cp / chmod が home の外へ追従しうるため触らない (plan_skill の親 dir
+      # 防御を、sync が作成する 2 階層に広げる)。
+      if script_target_symlink?(target)
+        return Plan.new("conflict", tool, name, target, "existing target is a symlink", "script", gen)
+      end
+      unless File.exist?(target)
+        return Plan.new("create", tool, name, target, nil, "script", gen)
+      end
+
+      target_marker = File.file?(target) ? read_marker_file(ArtifactTargets.sidecar_marker_path(target)) : nil
+      unless managed?(target_marker, tool, name)
+        return Plan.new("conflict", tool, name, target, "existing target is unmanaged", "script", gen)
+      end
+
+      if target_marker["build_id"] == source_marker["build_id"]
+        Plan.new("skip", tool, name, target, "up-to-date", "script", gen)
+      else
+        Plan.new("update", tool, name, target, nil, "script", gen)
+      end
+    end
+
+    # script 配置先本体と、sync が作成する 2 階層 (agent-tools/scripts と agent-tools) の
+    # いずれかが symlink かを判定する。
+    def script_target_symlink?(target)
+      scripts_dir = File.dirname(target)          # <home>/agent-tools/scripts
+      agent_tools_dir = File.dirname(scripts_dir) # <home>/agent-tools
+      File.symlink?(target) || File.symlink?(scripts_dir) || File.symlink?(agent_tools_dir)
+    end
+
+    # directory artifact (skill) の dir 直下 marker を読む。
     def read_marker(dir)
-      path = File.join(dir, MARKER_FILE)
+      read_marker_file(File.join(dir, MARKER_FILE))
+    end
+
+    # marker file を読んで Hash を返す。不在 / 型不正 / parse 失敗は nil。
+    def read_marker_file(path)
       return nil unless File.file?(path)
 
       data = YamlUtil.load(File.read(path), path)

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -223,9 +223,9 @@ module Sync
       if source_marker["build_id"] != expected_build_id
         return Plan.new("skip", tool, name, target, "run build first", "script", gen)
       end
-      # 配置先本体・その親 (agent-tools/scripts)・さらにその親 (agent-tools) のいずれかが
-      # symlink なら、cp / chmod が home の外へ追従しうるため触らない (plan_skill の親 dir
-      # 防御を、sync が作成する 2 階層に広げる)。
+      # 配置先本体・sidecar marker・その親 (agent-tools/scripts)・さらにその親
+      # (agent-tools) のいずれかが symlink なら、cp / chmod が home の外へ追従しうるため
+      # 触らない (plan_skill の親 dir 防御を、sync が書き込む 2 ファイル + 2 階層に広げる)。
       if script_target_symlink?(target)
         return Plan.new("conflict", tool, name, target, "existing target is a symlink", "script", gen)
       end
@@ -245,12 +245,15 @@ module Sync
       end
     end
 
-    # script 配置先本体と、sync が作成する 2 階層 (agent-tools/scripts と agent-tools) の
-    # いずれかが symlink かを判定する。
+    # sync が script で書き込む経路 (本体 / sidecar marker / 配置先 dir 2 階層) のいずれかが
+    # symlink かを判定する。1 つでも symlink なら cp / chmod が home の外へ追従しうる。
     def script_target_symlink?(target)
       scripts_dir = File.dirname(target)          # <home>/agent-tools/scripts
       agent_tools_dir = File.dirname(scripts_dir) # <home>/agent-tools
-      File.symlink?(target) || File.symlink?(scripts_dir) || File.symlink?(agent_tools_dir)
+      File.symlink?(target) ||
+        File.symlink?(ArtifactTargets.sidecar_marker_path(target)) ||
+        File.symlink?(scripts_dir) ||
+        File.symlink?(agent_tools_dir)
     end
 
     # directory artifact (skill) の dir 直下 marker を読む。

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -388,6 +388,90 @@ grep -q "must not contain scripts/" "$tmp/out-scripts" \
   || fail "missing scripts fail-closed reason: $(cat "$tmp/out-scripts")"
 [ ! -d "$tmp/scripts/generated" ] || fail "nothing should be generated when scripts/ is rejected"
 
+# --- case 4h: script asset は単一実行ファイル + sidecar marker として生成される ---
+mkdir -p "$tmp/scriptasset/shared/scripts"
+printf '#!/bin/sh\necho "hello from wrap"\n' > "$tmp/scriptasset/shared/scripts/personal-wrap.sh"
+cat > "$tmp/scriptasset/shared/scripts/personal-wrap.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-wrap
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-wrap.sh
+  format: text
+EOF
+
+"$build" --root "$tmp/scriptasset" > "$tmp/out-script" 2>&1 \
+  || fail "script build should pass: $(cat "$tmp/out-script")"
+grep -q "ok: 2 artifact(s) built" "$tmp/out-script" \
+  || fail "expected 2 script artifacts: $(cat "$tmp/out-script")"
+
+gen_script="$tmp/scriptasset/generated/claude-code/scripts/personal-wrap"
+[ -f "$gen_script" ] || fail "missing generated script body"
+[ -x "$gen_script" ] || fail "generated script must be executable"
+# 本体は byte 単位で保持される (frontmatter 等を前置しない)
+printf '#!/bin/sh\necho "hello from wrap"\n' > "$tmp/expected-wrap"
+cmp -s "$gen_script" "$tmp/expected-wrap" || fail "script body must be byte-identical to source"
+[ ! -e "$tmp/scriptasset/generated/claude-code/skills/personal-wrap" ] \
+  || fail "script must not be generated as a skill"
+
+sidecar="$tmp/scriptasset/generated/claude-code/scripts/personal-wrap.agent-tools-managed.yml"
+[ -f "$sidecar" ] || fail "missing script sidecar marker"
+for expected in \
+  "repo: agent-tools" \
+  "name: personal-wrap" \
+  "target: claude-code" \
+  "source: shared/scripts/personal-wrap.sh" \
+  "build_id: sha256:"
+do
+  grep -q "$expected" "$sidecar" || fail "sidecar marker missing '$expected': $(cat "$sidecar")"
+done
+[ -f "$tmp/scriptasset/generated/codex/scripts/personal-wrap" ] || fail "missing codex script artifact"
+
+# --- case 4h-2: script の directory 形式は単一ファイルでないため skip される (gate では止めない) ---
+mkdir -p "$tmp/scriptdir/shared/scripts/personal-dir-script"
+echo "x" > "$tmp/scriptdir/shared/scripts/personal-dir-script/run"
+cat > "$tmp/scriptdir/shared/scripts/personal-dir-script/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-dir-script
+kind: script
+visibility: personal
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-dir-script
+  format: directory
+EOF
+"$build" --root "$tmp/scriptdir" > "$tmp/out-scriptdir" 2>&1 \
+  || fail "directory script build should still exit 0 (skipped, not gated): $(cat "$tmp/out-scriptdir")"
+grep -q "script must be a single file" "$tmp/out-scriptdir" \
+  || fail "directory script should be skipped with reason: $(cat "$tmp/out-scriptdir")"
+[ ! -e "$tmp/scriptdir/generated/claude-code/scripts/personal-dir-script" ] \
+  || fail "directory script must not be generated"
+
+# --- case 4h-3: --prune は manifest の消えた managed script (と sidecar) を削除する ---
+rm -f "$tmp/scriptasset/shared/scripts/personal-wrap.sh" "$tmp/scriptasset/shared/scripts/personal-wrap.asset.yml"
+echo "user script" > "$tmp/scriptasset/generated/codex/scripts/personal-stray-script"
+"$build" --root "$tmp/scriptasset" --prune > "$tmp/out-sprune" 2>&1 \
+  || fail "script prune build should pass: $(cat "$tmp/out-sprune")"
+grep -q "pruned: generated/claude-code/scripts/personal-wrap" "$tmp/out-sprune" \
+  || fail "orphan script not pruned: $(cat "$tmp/out-sprune")"
+[ ! -e "$gen_script" ] || fail "orphan script body should be removed"
+[ ! -e "$sidecar" ] || fail "orphan script sidecar should be removed"
+grep -q "kept (unmanaged, no agent-tools marker): generated/codex/scripts/personal-stray-script" "$tmp/out-sprune" \
+  || fail "unmanaged script should be kept with warning: $(cat "$tmp/out-sprune")"
+[ -f "$tmp/scriptasset/generated/codex/scripts/personal-stray-script" ] \
+  || fail "unmanaged script must not be pruned"
+
 # --- case 5: repository 本体が build できる ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$build" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -367,6 +367,30 @@ EOF
 "$check" --root "$tmp/scriptkind" > "$tmp/out-scriptkind" 2>&1 \
   || fail "script kind manifest should validate: $(cat "$tmp/out-scriptkind")"
 
+# --- case: single-file source が symlink なら reject (shared/ の外を byte 保持で配らない) ---
+mkdir -p "$tmp/symsrc/shared/scripts"
+printf '#!/bin/sh\necho real\n' > "$tmp/symsrc/outside.sh"
+ln -s "$tmp/symsrc/outside.sh" "$tmp/symsrc/shared/scripts/personal-sym-script.sh"
+cat > "$tmp/symsrc/shared/scripts/personal-sym-script.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-sym-script
+kind: script
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-sym-script.sh
+  format: text
+EOF
+if "$check" --root "$tmp/symsrc" > "$tmp/out-symsrc" 2>&1; then
+  fail "check-manifests must reject a symlinked single-file source"
+fi
+grep -q "must not be a symlink" "$tmp/out-symsrc" \
+  || fail "expected single-file symlink rejection reason: $(cat "$tmp/out-symsrc")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/register-test.sh
+++ b/scripts/tests/register-test.sh
@@ -149,7 +149,7 @@ status=0
 grep -q "rejected asset" "$tmp/r10" || fail "missing rejected message"
 [ ! -e "$tmp/drej/generated/catalog.json" ] || fail "catalog must not be written on rejected"
 
-# --- case 12: script kind は認識・検証されるが配布前なので unsupported (P3-03b) ---
+# --- case 12: 単一ファイルの script kind は配布可能なので registered (P3-04) ---
 mkdir -p "$tmp/script/shared/scripts"
 printf '#!/bin/sh\necho hi\n' > "$tmp/script/shared/scripts/personal-demo-script.sh"
 cat > "$tmp/script/shared/scripts/personal-demo-script.asset.yml" <<'EOF'
@@ -167,12 +167,35 @@ source:
   format: text
 EOF
 "$register" --root "$tmp/script" > "$tmp/r12" 2>&1 \
-  || fail "script register should not fail (unsupported is exit 0): $(cat "$tmp/r12")"
+  || fail "script register should not fail: $(cat "$tmp/r12")"
 sc="$tmp/script/generated/catalog.json"
 [ "$(jget "$sc" assets 0 artifact_kind)" = '"script"' ] \
   || fail "script asset should resolve to artifact_kind script"
-[ "$(jget "$sc" assets 0 registration)" = '"unsupported"' ] \
-  || fail "script should be unsupported until P3-04 (no silent registered != buildable)"
+[ "$(jget "$sc" assets 0 registration)" = '"registered"' ] \
+  || fail "single-file script should be registered (buildable) after P3-04"
+
+# --- case 12b: directory 形式の script は単一ファイルでないため unsupported ---
+# (registered != buildable のサイレント断裂を作らない)
+mkdir -p "$tmp/scriptdir/shared/scripts/personal-dir-script"
+echo "x" > "$tmp/scriptdir/shared/scripts/personal-dir-script/run"
+cat > "$tmp/scriptdir/shared/scripts/personal-dir-script/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-dir-script
+kind: script
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-dir-script
+  format: directory
+EOF
+"$register" --root "$tmp/scriptdir" > "$tmp/r12b" 2>&1 \
+  || fail "directory script register should not fail: $(cat "$tmp/r12b")"
+[ "$(jget "$tmp/scriptdir/generated/catalog.json" assets 0 registration)" = '"unsupported"' ] \
+  || fail "directory script should be unsupported (not single-file buildable)"
 
 # --- case 11: repository 本体が register できる ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)

--- a/scripts/tests/status-test.sh
+++ b/scripts/tests/status-test.sh
@@ -194,4 +194,33 @@ rm -f "$tmp/irepo/shared/instructions/personal-ops.md"
   || fail "status must not crash when an instruction source file is missing: $(cat "$tmp/s12")"
 [ "$(jget "$tmp/s12" generated stale)" = "2" ] || fail "missing source should make instruction stale, not crash: $(cat "$tmp/s12")"
 
+# --- case 13: script の generated も generated.total に数え、sync_target を報告する ---
+mkdir -p "$tmp/screpo/shared/scripts" "$tmp/sccodex" "$tmp/scclaude"
+printf '#!/bin/sh\necho hi\n' > "$tmp/screpo/shared/scripts/personal-wrap.sh"
+cat > "$tmp/screpo/shared/scripts/personal-wrap.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-wrap
+kind: script
+visibility: personal
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-wrap.sh
+  format: text
+EOF
+"$build" --root "$tmp/screpo" --quiet > /dev/null
+"$script_dir/../register.sh" --root "$tmp/screpo" --quiet > /dev/null
+"$status_sh" --root "$tmp/screpo" --codex-home "$tmp/sccodex" --claude-home "$tmp/scclaude" --json > "$tmp/sc13" 2>&1
+# generated は本体 1 つだけ数える (sidecar marker は含めない)
+[ "$(jget "$tmp/sc13" generated total)" = "1" ] || fail "script generated should count body only (not sidecar): $(cat "$tmp/sc13")"
+[ "$(jget "$tmp/sc13" generated stale)" = "0" ] || fail "fresh script should not be stale"
+[ "$(jget "$tmp/sc13" sync_targets 0 state)" = '"missing"' ] || fail "script target should be missing before sync: $(cat "$tmp/sc13")"
+# source 変更で script も stale になる
+printf '#!/bin/sh\necho changed\n' > "$tmp/screpo/shared/scripts/personal-wrap.sh"
+"$status_sh" --root "$tmp/screpo" --codex-home "$tmp/sccodex" --claude-home "$tmp/scclaude" --json > "$tmp/sc13b" 2>&1
+[ "$(jget "$tmp/sc13b" generated stale)" = "1" ] || fail "changed script source should be stale: $(cat "$tmp/sc13b")"
+
 echo "ok: status self-test passed"

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -351,4 +351,16 @@ run15 --apply > "$tmp/out18" 2>&1 || status=$?
 grep -q "conflict: \[claude-code\].*symlink" "$tmp/out18" || fail "missing script parent symlink conflict: $(cat "$tmp/out18")"
 [ ! -e "$tmp/realat/scripts/personal-wrap" ] || fail "must not write through symlinked agent-tools parent"
 
+# --- case 19: 本体未存在でも sidecar marker が symlink なら conflict (素通りさせない) ---
+# (apply は sidecar も書き込む。create 分岐で sidecar の symlink を見逃すと home 外へ追従する)
+rm -rf "$tmp/sclaude15/agent-tools"
+mkdir -p "$tmp/sclaude15/agent-tools/scripts" "$tmp/realmarker"
+ln -s "$tmp/realmarker/stolen.yml" "$deployed.agent-tools-managed.yml"
+status=0
+run15 --apply > "$tmp/out19" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlinked sidecar should exit 1: $(cat "$tmp/out19")"
+grep -q "conflict: \[claude-code\].*symlink" "$tmp/out19" || fail "missing sidecar symlink conflict: $(cat "$tmp/out19")"
+[ ! -e "$tmp/realmarker/stolen.yml" ] || fail "must not write through symlinked sidecar marker"
+[ ! -e "$deployed" ] || fail "script body must not be created when sidecar is unsafe"
+
 echo "ok: sync self-test passed"

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -272,4 +272,83 @@ status=0
 grep -q "conflict: \[codex\].*symlink" "$tmp/out-skparent" || fail "missing skills-parent symlink conflict: $(cat "$tmp/out-skparent")"
 [ ! -e "$tmp/realskills/personal-sk" ] || fail "must not write through a symlinked skills parent"
 
+# --- case 15: script artifact を <home>/agent-tools/scripts/ に配置する ---
+mkdir -p "$tmp/srepo15/shared/scripts" "$tmp/scodex15" "$tmp/sclaude15"
+printf '#!/bin/sh\necho v1\n' > "$tmp/srepo15/shared/scripts/personal-wrap.sh"
+cat > "$tmp/srepo15/shared/scripts/personal-wrap.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-wrap
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-wrap.sh
+  format: text
+EOF
+run15() { "$sync" --root "$tmp/srepo15" --codex-home "$tmp/scodex15" --claude-home "$tmp/sclaude15" "$@"; }
+"$build" --root "$tmp/srepo15" --quiet > /dev/null
+"$register" --root "$tmp/srepo15" --quiet > /dev/null
+
+# dry-run は書き込まない
+run15 > "$tmp/out15-dry" 2>&1 || fail "script dry-run should succeed: $(cat "$tmp/out15-dry")"
+grep -q "create: \[claude-code\]" "$tmp/out15-dry" || fail "missing script create plan: $(cat "$tmp/out15-dry")"
+[ ! -e "$tmp/sclaude15/agent-tools/scripts/personal-wrap" ] || fail "dry-run must not write script"
+
+# --apply で本体 + sidecar marker が配置され、実行可能になる
+run15 --apply > "$tmp/out15-apply" 2>&1 || fail "script apply should succeed: $(cat "$tmp/out15-apply")"
+deployed="$tmp/sclaude15/agent-tools/scripts/personal-wrap"
+[ -f "$deployed" ] || fail "script not deployed"
+[ -x "$deployed" ] || fail "deployed script must be executable"
+grep -q "echo v1" "$deployed" || fail "deployed script body wrong"
+[ -f "$deployed.agent-tools-managed.yml" ] || fail "deployed script sidecar marker missing"
+[ -f "$tmp/scodex15/agent-tools/scripts/personal-wrap" ] || fail "codex script not deployed"
+
+# 変更なしなら skip (up-to-date)
+run15 > "$tmp/out15-skip" 2>&1 || fail "script skip run should succeed"
+grep -q "skip: \[claude-code\].*up-to-date" "$tmp/out15-skip" || fail "missing script up-to-date skip: $(cat "$tmp/out15-skip")"
+
+# source 変更で update → apply で反映
+printf '#!/bin/sh\necho v2\n' > "$tmp/srepo15/shared/scripts/personal-wrap.sh"
+"$build" --root "$tmp/srepo15" --quiet > /dev/null
+"$register" --root "$tmp/srepo15" --quiet > /dev/null
+run15 > "$tmp/out15-upd" 2>&1 || fail "script update dry-run should succeed"
+grep -q "update: \[claude-code\]" "$tmp/out15-upd" || fail "missing script update plan: $(cat "$tmp/out15-upd")"
+run15 --apply --quiet > /dev/null 2>&1
+grep -q "echo v2" "$deployed" || fail "script update not applied"
+
+# --- case 16: catalog の build_id と generated が不一致なら run build first (stale generated) ---
+printf '#!/bin/sh\necho v3\n' > "$tmp/srepo15/shared/scripts/personal-wrap.sh"
+"$register" --root "$tmp/srepo15" --quiet > /dev/null   # build せず register だけ
+run15 > "$tmp/out16" 2>&1 || fail "stale script dry-run should succeed"
+grep -q "skip: \[claude-code\].*run build first" "$tmp/out16" \
+  || fail "stale generated script should skip with run build first: $(cat "$tmp/out16")"
+# 整合を戻す (以降の case は v3 を配置済みにする)
+"$build" --root "$tmp/srepo15" --quiet > /dev/null
+"$register" --root "$tmp/srepo15" --quiet > /dev/null
+run15 --apply --quiet > /dev/null 2>&1
+
+# --- case 17: unmanaged な同名 script は conflict で停止し、--apply でも上書きしない ---
+rm -f "$deployed" "$deployed.agent-tools-managed.yml"
+echo "user-owned script" > "$deployed"   # marker なし
+status=0
+run15 --apply > "$tmp/out17" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "unmanaged script should exit 1, got $status: $(cat "$tmp/out17")"
+grep -q "conflict: \[claude-code\].*unmanaged" "$tmp/out17" || fail "missing script unmanaged conflict: $(cat "$tmp/out17")"
+grep -q "user-owned script" "$deployed" || fail "unmanaged script must not be overwritten"
+
+# --- case 18: 配置先の親 (agent-tools) が symlink なら conflict (素通りさせない) ---
+rm -rf "$tmp/sclaude15/agent-tools"
+mkdir -p "$tmp/realat"
+ln -s "$tmp/realat" "$tmp/sclaude15/agent-tools"
+status=0
+run15 --apply > "$tmp/out18" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlinked agent-tools parent should exit 1: $(cat "$tmp/out18")"
+grep -q "conflict: \[claude-code\].*symlink" "$tmp/out18" || fail "missing script parent symlink conflict: $(cat "$tmp/out18")"
+[ ! -e "$tmp/realat/scripts/personal-wrap" ] || fail "must not write through symlinked agent-tools parent"
+
 echo "ok: sync self-test passed"


### PR DESCRIPTION
## 概要

Phase 3 (#129) の P3-04。P3-03b で認識・検証・配置先解決まで入った `script` artifact kind を、実際に build / sync が配布できるようにする。これで safe-gh wrapper (P3-07) 等の script body がこの機構の上に乗る。

## 変更点

- **buildable?(script)** を単一ファイルなら `true` に切替。directory 形式は配置先が単一ファイルなので `unsupported` のまま (registered != buildable のサイレント断裂を防ぐ)。
- **build**: `build_script` が `generated/<tool>/scripts/<name>` に本体を byte 保持で出力し (mode 0755)、隣に sidecar marker `<name>.agent-tools-managed.yml` を書く。本体を改変しない marker 戦略は `docs/status-manifest-contract.md` の「comment 記法を持たない format は sidecar」契約に準拠。
- **sync**: `plan_script` が skill と同じ marker ベースの所有 / stale / symlink 防御を、単一ファイル + 2 階層の配置先 (`<home>/agent-tools/scripts/<name>`) にあわせて適用。instruction と違い人間ファイルを介さないため **connect 非依存**で直接 create する。symlink 防御は本体・`agent-tools/scripts`・`agent-tools` の 3 階層に広げ、home 外への書込追従を断つ。
- **prune / status** も script を扱い、registered/buildable/deployed の整合を保つ。
- marker basename を `ArtifactTargets::MARKER_BASENAME` に集約し build/sync の literal 重複を解消。marker 本文 / 鮮度判定 / sidecar path も共通ヘルパに括り出す (DRY)。

## スコープ / 検証

- 実 script asset は同梱しない (**dead-render 回避**、実 asset は P3-07)。機構は fixture test で検証。
- build / sync / register / status に script ケースを追加。**9 self-test すべて PASS**。
- real repo の build / register は**挙動不変** (26 artifact のまま、catalog 不変)。
- docs (sync-policy / status-manifest-contract / scripts README) に配置先と sidecar marker を正本化。

## レビュー

author = Claude。相互レビュー規約により reviewer = Codex (author ≠ reviewer)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)