### PR TITLE
feat: safe-gh wrapper body を script kind で配布 (P3-04 縦切り, #129)

### DIFF
--- a/docs/runtime-injection-defense.md
+++ b/docs/runtime-injection-defense.md
@@ -134,6 +134,23 @@ agent に渡すデータの trust 判定は 3 軸で行う (spec の防御層表
 **捏造可能**。よって best-effort。hook が provenance 無しの書き込み系 tool call を拒否するのも
 steering (fail-open で消える)。
 
+## safe-gh wrapper (実装: steering)
+
+`shared/scripts/personal-safe-gh.rb` が body。`script` artifact kind で build/sync が tool home
+(`<home>/agent-tools/scripts/personal-safe-gh`) に配る。生の `gh ... --comments` を agent に
+直接実行させる代わりにこれへ寄せ、untrusted content を data として扱わせる steering(迂回可・
+boundary でない)。
+
+- コマンド: `safe-gh [-R OWNER/REPO] <issue|pr> <view|comments> <number>`。出力は JSON。
+- 上の provenance 3 軸で author を `self` / `bot` / `other` に分類し、self を確定できなければ
+  全 `other` に倒す(fail-closed)。
+- **他人の Issue/PR**: metadata (number/state/author/labels) のみ。**title も body も親へ渡さない**
+  (title は attacker 制御の free-text = injection 面)。**自分の Issue/PR**: title/body を渡す。
+- **他人コメント**: count + 固定理由のみ。著者名・プレビュー・untrusted 由来の文字列を出力に
+  混ぜない。**自分のコメント**: body を渡す。
+- I/O(gh 呼び出し)と純粋な trust/render ロジックを分離。ロジックは `scripts/tests/safe-gh-test.sh`
+  で deterministic に検証し、gh の実挙動は実機手動(下記「検証境界」)。
+
 ## body ⇔ control plane 対応表
 
 | 関心事 | agent-tools (body) | dotfiles (control plane) |

--- a/scripts/tests/safe-gh-test.sh
+++ b/scripts/tests/safe-gh-test.sh
@@ -137,12 +137,21 @@ check("missing number", !SafeGh.valid_invocation?("issue", "view", nil))
 
 # ---- -R フラグ抽出 ----
 args = ["-R", "o/r", "issue", "view", "1"]
-repo = SafeGh.extract_repo_flag(args)
+repo, ok = SafeGh.extract_repo_flag(args)
 check("extract -R value", repo == "o/r")
+check("extract -R ok", ok == true)
 check("extract -R leaves args", args == ["issue", "view", "1"])
 args2 = ["issue", "view", "1"]
-check("no -R returns nil", SafeGh.extract_repo_flag(args2).nil?)
+repo2, ok2 = SafeGh.extract_repo_flag(args2)
+check("no -R returns nil repo", repo2.nil?)
+check("no -R is ok", ok2 == true)
 check("no -R leaves args", args2 == ["issue", "view", "1"])
+# 末尾 -R (値欠落) は malformed: 現在 repo へ黙って fallback させない
+args3 = ["issue", "view", "1", "-R"]
+repo3, ok3 = SafeGh.extract_repo_flag(args3)
+check("trailing -R is malformed", ok3 == false)
+check("trailing -R repo nil", repo3.nil?)
+check("trailing -R removes flag", args3 == ["issue", "view", "1"])
 
 exit(@failed.zero? ? 0 : 1)
 RUBY

--- a/scripts/tests/safe-gh-test.sh
+++ b/scripts/tests/safe-gh-test.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+# personal-safe-gh.rb の self-test。
+# I/O (gh 呼び出し) と分離した純粋 trust/render ロジックを fixture で検証する。
+# gh の実挙動は CI 外 (実機手動検証。docs/runtime-injection-defense.md「検証境界」)。
+# network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+src="$repo_root/shared/scripts/personal-safe-gh.rb"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+[ -f "$src" ] || { echo "FAIL: missing $src" >&2; exit 1; }
+
+# トラストファイル fixture (self_identity の file 優先パス検証用)。
+cat > "$tmp/trust.json" <<'EOF'
+{"login": "owner-login", "id": 4242}
+EOF
+
+ruby - "$src" "$tmp/trust.json" <<'RUBY'
+require ARGV[0]
+trust_file = ARGV[1]
+
+@failed = 0
+def check(name, cond)
+  if cond
+    # pass
+  else
+    warn "FAIL: #{name}"
+    @failed += 1
+  end
+end
+
+ME = { "login" => "me", "id" => 1 }
+
+# ---- classify ----
+check("self by id", SafeGh.classify({ "login" => "me", "id" => 1 }, ME) == "self")
+# id が一致すれば login 変更後でも self (numeric id 最優先)
+check("self by id despite login rename", SafeGh.classify({ "login" => "renamed", "id" => 1 }, ME) == "self")
+# id が無いときだけ login 照合
+check("self by login when no id", SafeGh.classify({ "login" => "me" }, { "login" => "me" }) == "self")
+check("other by different id", SafeGh.classify({ "login" => "me", "id" => 2 }, ME) == "other")
+check("other by different login no id", SafeGh.classify({ "login" => "x" }, { "login" => "me" }) == "other")
+check("bot by login suffix", SafeGh.classify({ "login" => "dependabot[bot]", "id" => 9 }, ME) == "bot")
+check("bot by type", SafeGh.classify({ "login" => "svc", "type" => "Bot", "id" => 9 }, ME) == "bot")
+# bot は self id と一致しても bot 優先 (association/self より先に評価)
+check("bot precedence over self", SafeGh.classify({ "login" => "x[bot]", "id" => 1 }, ME) == "bot")
+# self を確定できない (me=nil) なら全 untrusted (fail-closed)
+check("fail-closed when self unknown", SafeGh.classify({ "login" => "me", "id" => 1 }, nil) == "other")
+# ghost (user 欠落) は other
+check("nil user is other", SafeGh.classify(nil, ME) == "other")
+
+# ---- issue_envelope: self ----
+self_issue = {
+  "number" => 7, "state" => "open", "title" => "my title", "body" => "my body",
+  "user" => { "login" => "me", "id" => 1 }, "author_association" => "OWNER",
+  "labels" => [{ "name" => "bug" }, { "name" => "p1" }],
+}
+env = SafeGh.issue_envelope("issue", "o/r", self_issue, ME)
+check("self issue trust", env["author_trust"] == "self")
+check("self issue includes title", env["title"] == "my title")
+check("self issue includes body", env["body"] == "my body")
+check("self issue body_trust", env["body_trust"] == "self")
+check("self issue labels", env["labels"] == %w[bug p1])
+check("self issue no excluded flag", !env.key?("excluded_body"))
+
+# ---- issue_envelope: other (本文を渡さない・title すら渡さない) ----
+other_issue = {
+  "number" => 8, "state" => "open", "title" => "ATTACKER_TITLE_SENTINEL",
+  "body" => "ATTACKER_BODY_SENTINEL",
+  "user" => { "login" => "attacker", "id" => 999 }, "author_association" => "NONE",
+  "labels" => [{ "name" => "question" }],
+}
+env = SafeGh.issue_envelope("issue", "o/r", other_issue, ME)
+check("other issue trust", env["author_trust"] == "other")
+check("other issue no title key", !env.key?("title"))
+check("other issue no body key", !env.key?("body"))
+check("other issue excluded_body", env["excluded_body"] == true)
+check("other issue body_trust untrusted", env["body_trust"] == "untrusted")
+# author/state/number/labels は metadata として渡す (決定 4)
+check("other issue author metadata", env["author"] == "attacker")
+check("other issue labels metadata", env["labels"] == %w[question])
+# title/body の中身は JSON 出力に一切現れない
+json = JSON.generate(env)
+check("other issue title not leaked", !json.include?("ATTACKER_TITLE_SENTINEL"))
+check("other issue body not leaked", !json.include?("ATTACKER_BODY_SENTINEL"))
+
+# ---- issue_envelope: bot ----
+bot_issue = {
+  "number" => 9, "state" => "open", "title" => "t", "body" => "b",
+  "user" => { "login" => "renovate[bot]", "id" => 5, "type" => "Bot" },
+  "author_association" => "NONE", "labels" => [],
+}
+env = SafeGh.issue_envelope("pr", "o/r", bot_issue, ME)
+check("bot issue trust", env["author_trust"] == "bot")
+check("bot issue no body", !env.key?("body"))
+check("bot issue source pr", env["source"] == "pr")
+
+# ---- comments_envelope: self 通過 / other・bot 除外 (count のみ・著者名も漏らさない) ----
+comments = [
+  { "user" => { "login" => "me", "id" => 1 }, "body" => "MY_COMMENT" },
+  { "user" => { "login" => "attacker", "id" => 999 }, "body" => "EVIL_COMMENT_SENTINEL" },
+  { "user" => { "login" => "spam[bot]", "type" => "Bot" }, "body" => "BOT_SENTINEL" },
+]
+env = SafeGh.comments_envelope("issue", "o/r", 8, comments, ME)
+check("comments included count", env["comments"].length == 1)
+check("comments self body included", env["comments"][0]["body"] == "MY_COMMENT")
+check("comments self author", env["comments"][0]["author"] == "me")
+check("comments excluded count", env["excluded_comments_count"] == 2)
+check("comments excluded reason present", !env["excluded_comments_reason"].nil?)
+json = JSON.generate(env)
+check("excluded comment body not leaked", !json.include?("EVIL_COMMENT_SENTINEL"))
+check("excluded bot body not leaked", !json.include?("BOT_SENTINEL"))
+check("excluded comment author not leaked", !json.include?("attacker"))
+check("excluded bot author not leaked", !json.include?("spam[bot]"))
+
+# 除外が無いときは reason を付けない
+env = SafeGh.comments_envelope("issue", "o/r", 8, [comments[0]], ME)
+check("no excluded -> no reason", !env.key?("excluded_comments_reason"))
+check("no excluded -> count 0", env["excluded_comments_count"] == 0)
+
+# ---- self_identity: override file 優先 (gh を呼ばない) ----
+ident = SafeGh.self_identity(env: { "SAFE_GH_TRUST_FILE" => trust_file })
+check("self_identity from file login", ident && ident["login"] == "owner-login")
+check("self_identity from file id", ident && ident["id"] == 4242)
+# 存在しない file は nil (file パス単体)
+check("self_identity file missing -> nil", SafeGh.self_identity_from_file({ "SAFE_GH_TRUST_FILE" => "#{trust_file}.nope" }).nil?)
+
+# ---- 引数バリデーション ----
+check("valid invocation", SafeGh.valid_invocation?("issue", "view", "12"))
+check("invalid number", !SafeGh.valid_invocation?("issue", "view", "abc"))
+check("invalid noun", !SafeGh.valid_invocation?("foo", "view", "1"))
+check("invalid verb", !SafeGh.valid_invocation?("issue", "bogus", "1"))
+check("missing number", !SafeGh.valid_invocation?("issue", "view", nil))
+
+# ---- -R フラグ抽出 ----
+args = ["-R", "o/r", "issue", "view", "1"]
+repo = SafeGh.extract_repo_flag(args)
+check("extract -R value", repo == "o/r")
+check("extract -R leaves args", args == ["issue", "view", "1"])
+args2 = ["issue", "view", "1"]
+check("no -R returns nil", SafeGh.extract_repo_flag(args2).nil?)
+check("no -R leaves args", args2 == ["issue", "view", "1"])
+
+exit(@failed.zero? ? 0 : 1)
+RUBY
+
+echo "ok: safe-gh self-test passed"

--- a/shared/scripts/personal-safe-gh.asset.yml
+++ b/shared/scripts/personal-safe-gh.asset.yml
@@ -1,0 +1,17 @@
+schema_version: 1
+name: personal-safe-gh
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/scripts/personal-safe-gh.rb
+  format: text
+summary: >-
+  GitHub の Issue/PR/コメントを untrusted data として安全に読む steering wrapper。
+  他人の Issue/PR は metadata のみ、他人コメントは count のみを出力し、runtime prompt
+  injection 面を狭める。enforcement boundary ではない (docs/runtime-injection-defense.md)。

--- a/shared/scripts/personal-safe-gh.rb
+++ b/shared/scripts/personal-safe-gh.rb
@@ -1,0 +1,288 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# safe-gh: GitHub の Issue / PR / コメントを「untrusted data」として安全に読むための
+# steering wrapper。生の `gh ... --comments` を agent に直接実行させる代わりにこれへ寄せ、
+# 第三者が混入させた指示が agent の命令として解釈されるのを防ぐ (runtime prompt injection)。
+#
+# 正本: docs/runtime-injection-defense.md / 外部 planning tool の設計メモ (8 決定)。
+#
+# 強度ラベル (偽らない): これは **steering** であって enforcement boundary ではない。
+# `$(gh ...)` 直実行 / `gh api` / `curl` / MCP github tool などで容易に迂回でき、PreToolUse
+# hook も subagent に不発・fail-open。hard な防御は床 (credential 隔離 + egress) が担う。
+# safe-gh が買うのは「安全な読み方を便利にし、untrusted content を data として扱わせる」こと。
+#
+# 設計 (決定 3/4/5 を実装):
+# - 他人の Issue/PR は metadata のみ (number/state/author/labels)。title すら親に渡さない
+#   (title は attacker 制御の free-text = injection 面)。本文も渡さない。
+# - 他人コメントは count + 固定理由のみ。著者名・プレビュー・untrusted 由来の文字列を
+#   出力に一切混ぜない。
+# - bot は全 untrusted。is_bot を association より先に評価する (bot は association が NONE に
+#   化けるため)。
+# - 自分 (is_self) の Issue/PR 本文・自分のコメントだけ trusted として本文を渡す。
+# - self を確定できなければ全 untrusted に倒す (fail-closed)。
+#
+# I/O (gh 呼び出し) と純粋な trust/render ロジックを分離し、ロジックは fixture で test する
+# (gh の実挙動は CI 外 = 実機手動検証。docs/runtime-injection-defense.md「検証境界」)。
+#
+# 外部依存ゼロ (ruby 標準ライブラリと gh CLI のみ)。
+
+require "json"
+require "open3"
+
+module SafeGh
+  # 出力に埋める safe reader version。出力契約が変わったら上げる。
+  VERSION = "1"
+
+  # self identity の任意 override file。dotfiles が非コミットで置く場合に優先して読む
+  # (実値は public repo にハードコードしない)。env で path を上書きできる。
+  SELF_TRUST_FILE_ENV = "SAFE_GH_TRUST_FILE"
+  DEFAULT_SELF_TRUST_FILE = File.join(Dir.home, ".config", "dotfiles", "github-trust.local")
+
+  # 除外理由は固定文字列にする。untrusted 由来の文字列を出力へ混ぜない (決定 5)。
+  EXCLUDED_BODY_REASON =
+    "author is not the trusted self; title and body withheld to avoid runtime injection"
+  EXCLUDED_COMMENTS_REASON =
+    "non-self comments withheld (count only) to avoid runtime injection"
+
+  class Error < StandardError; end
+
+  module_function
+
+  # ---- 純粋ロジック: trust 判定 ----------------------------------------------
+
+  # user (GitHub REST の user object: {"login","id","type"}) の trust を判定する。
+  # me = self identity {"login","id"} か、確定できないとき nil。
+  # bot を最初に評価する (決定 3)。self を確定できなければ self になり得ない (fail-closed)。
+  def classify(user, me)
+    user ||= {}
+    return "bot" if bot?(user)
+    return "self" if me && self_authored?(user, me)
+
+    "other"
+  end
+
+  def bot?(user)
+    user["login"].to_s.end_with?("[bot]") || user["type"].to_s == "Bot"
+  end
+
+  # numeric id を最優先で照合する (login rename に強い・最堅信号)。両者に id があれば
+  # id 一致のみを self とする。id が欠ける場合に限り login で照合する。
+  def self_authored?(user, me)
+    if me["id"] && user["id"]
+      user["id"] == me["id"]
+    else
+      !user["login"].to_s.empty? && user["login"] == me["login"]
+    end
+  end
+
+  # ---- 純粋ロジック: envelope rendering --------------------------------------
+
+  # Issue/PR 本体の envelope。self なら title/body を渡し、それ以外 (other/bot) は
+  # metadata のみで title/body を渡さない (決定 4)。
+  # kind は "issue" / "pr"。data は GitHub REST の issue/pr object。
+  def issue_envelope(kind, repo, data, me)
+    user = data["user"]
+    trust = classify(user, me)
+    env = {
+      "safe_reader_version" => VERSION,
+      "source" => kind,
+      "repo" => repo,
+      "number" => data["number"],
+      "state" => data["state"],
+      "author" => user && user["login"],
+      "author_trust" => trust,
+      # author_association は補助信号 (単体の許可ソースにしない)。GitHub の enum なので
+      # free-text injection 面ではない。
+      "author_association" => data["author_association"],
+      "labels" => label_names(data["labels"]),
+    }
+    if trust == "self"
+      env["title"] = data["title"]
+      env["body"] = data["body"]
+      env["body_trust"] = "self"
+    else
+      env["body_trust"] = "untrusted"
+      env["excluded_body"] = true
+      env["excluded_body_reason"] = EXCLUDED_BODY_REASON
+    end
+    env
+  end
+
+  # コメントの envelope。self コメントだけ body を渡し、それ以外は count + 固定理由のみ。
+  # 除外コメントの著者名・本文・プレビューは出力に一切含めない (決定 5)。
+  def comments_envelope(kind, repo, number, comments, me)
+    included = []
+    excluded = 0
+    (comments || []).each do |c|
+      if classify(c["user"], me) == "self"
+        included << {
+          "author" => c["user"]["login"],
+          "author_trust" => "self",
+          "body" => c["body"],
+        }
+      else
+        excluded += 1
+      end
+    end
+    env = {
+      "safe_reader_version" => VERSION,
+      "source" => "#{kind}_comments",
+      "repo" => repo,
+      "number" => number,
+      "comments" => included,
+      "excluded_comments_count" => excluded,
+    }
+    env["excluded_comments_reason"] = EXCLUDED_COMMENTS_REASON if excluded.positive?
+    env
+  end
+
+  def label_names(labels)
+    (labels || []).map { |l| l.is_a?(Hash) ? l["name"] : l }
+  end
+
+  # ---- I/O: gh 呼び出し ------------------------------------------------------
+
+  # self identity を取得する。任意 override file を優先し、無ければ `gh api user`。
+  # どちらも取れなければ nil (= 全 untrusted = fail-closed)。
+  def self_identity(env: ENV)
+    from_file = self_identity_from_file(env)
+    return from_file if from_file
+
+    out, ok = gh_capture(["api", "user", "--jq", "{login: .login, id: .id}"])
+    return nil unless ok
+
+    parsed = parse_json(out)
+    normalize_identity(parsed)
+  end
+
+  def self_identity_from_file(env)
+    path = env[SELF_TRUST_FILE_ENV]
+    path = DEFAULT_SELF_TRUST_FILE if path.nil? || path.empty?
+    return nil unless File.file?(path)
+
+    normalize_identity(parse_json(File.read(path)))
+  end
+
+  def normalize_identity(data)
+    return nil unless data.is_a?(Hash)
+    return nil if data["login"].nil? && data["id"].nil?
+
+    { "login" => data["login"], "id" => data["id"] }
+  end
+
+  def parse_json(text)
+    JSON.parse(text)
+  rescue JSON::ParserError
+    nil
+  end
+
+  def gh_capture(args)
+    out, _err, status = Open3.capture3("gh", *args)
+    [out, status.success?]
+  rescue SystemCallError
+    ["", false]
+  end
+
+  # gh REST を叩いて JSON を返す。失敗 (network/auth/not found) は Error。安全側に倒すため
+  # 部分的な envelope は作らず止める。
+  def gh_api(path)
+    out, ok = gh_capture(["api", path])
+    raise Error, "gh api #{path} failed (gh が未認証 / network / 対象が存在しない可能性)" unless ok
+
+    parse_json(out) || raise(Error, "gh api #{path} returned invalid JSON")
+  end
+
+  # owner/repo を解決する。-R で明示されていればそれを、無ければ現在の repo を gh から引く。
+  def resolve_repo(explicit)
+    return explicit if explicit && !explicit.empty?
+
+    out, ok = gh_capture(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+    raise Error, "repository を解決できない (-R OWNER/REPO で指定してください)" unless ok
+
+    name = out.strip
+    raise Error, "repository を解決できない (-R OWNER/REPO で指定してください)" if name.empty?
+
+    name
+  end
+
+  # PR の会話コメントは issue comments endpoint に乗る (PR は issue でもある)。
+  def fetch(kind, repo, number)
+    case kind
+    when "issue" then gh_api("repos/#{repo}/issues/#{number}")
+    when "pr" then gh_api("repos/#{repo}/pulls/#{number}")
+    end
+  end
+
+  def fetch_comments(repo, number)
+    gh_api("repos/#{repo}/issues/#{number}/comments")
+  end
+
+  # ---- entrypoint ------------------------------------------------------------
+
+  def run(noun, verb, number, repo, me)
+    case [noun, verb]
+    when %w[issue view]
+      issue_envelope("issue", repo, fetch("issue", repo, number), me)
+    when %w[pr view]
+      issue_envelope("pr", repo, fetch("pr", repo, number), me)
+    when %w[issue comments]
+      comments_envelope("issue", repo, number, fetch_comments(repo, number), me)
+    when %w[pr comments]
+      comments_envelope("pr", repo, number, fetch_comments(repo, number), me)
+    else
+      raise Error, "unknown command: #{noun} #{verb}"
+    end
+  end
+
+  def main(argv)
+    args = argv.dup
+    repo = extract_repo_flag(args)
+    if args.first == "-h" || args.first == "--help"
+      print_usage
+      return 0
+    end
+
+    noun, verb, number = args
+    unless valid_invocation?(noun, verb, number)
+      print_usage
+      return 2
+    end
+
+    me = self_identity
+    warn "warn: self identity を確定できないため全 author を untrusted として扱います" unless me
+
+    repo = resolve_repo(repo)
+    puts JSON.pretty_generate(run(noun, verb, number, repo, me))
+    0
+  rescue Error => e
+    warn "fail: #{e.message}"
+    1
+  end
+
+  # `-R OWNER/REPO` / `--repo OWNER/REPO` を args から取り除いて値を返す。
+  def extract_repo_flag(args)
+    idx = args.index { |a| a == "-R" || a == "--repo" }
+    return nil unless idx
+
+    args.delete_at(idx) # フラグ
+    args.delete_at(idx) # 値
+  end
+
+  def valid_invocation?(noun, verb, number)
+    %w[issue pr].include?(noun) &&
+      %w[view comments].include?(verb) &&
+      !number.nil? && number.match?(/\A\d+\z/)
+  end
+
+  def print_usage
+    warn <<~USAGE
+      usage: safe-gh [-R OWNER/REPO] <issue|pr> <view|comments> <number>
+
+      GitHub の Issue/PR/コメントを untrusted data として安全に読む steering wrapper。
+      他人の Issue/PR は metadata のみ、他人コメントは count のみを出力する。
+    USAGE
+  end
+end
+
+exit SafeGh.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/personal-safe-gh.rb
+++ b/shared/scripts/personal-safe-gh.rb
@@ -237,14 +237,14 @@ module SafeGh
 
   def main(argv)
     args = argv.dup
-    repo = extract_repo_flag(args)
-    if args.first == "-h" || args.first == "--help"
+    if args.include?("-h") || args.include?("--help")
       print_usage
       return 0
     end
 
+    repo, repo_ok = extract_repo_flag(args)
     noun, verb, number = args
-    unless valid_invocation?(noun, verb, number)
+    unless repo_ok && valid_invocation?(noun, verb, number)
       print_usage
       return 2
     end
@@ -260,13 +260,16 @@ module SafeGh
     1
   end
 
-  # `-R OWNER/REPO` / `--repo OWNER/REPO` を args から取り除いて値を返す。
+  # `-R OWNER/REPO` / `--repo OWNER/REPO` を args から取り除き、[repo, ok] を返す。
+  # -R 無し: [nil, true] (repo は後で resolve)。-R に値が無い (末尾フラグ): [nil, false]
+  # で malformed を示し、呼び出し側が usage exit に倒す (現在 repo へ黙って fallback しない)。
   def extract_repo_flag(args)
     idx = args.index { |a| a == "-R" || a == "--repo" }
-    return nil unless idx
+    return [nil, true] unless idx
 
-    args.delete_at(idx) # フラグ
-    args.delete_at(idx) # 値
+    args.delete_at(idx)         # フラグ
+    value = args.delete_at(idx) # 値 (末尾フラグなら nil)
+    [value, !value.nil?]
   end
 
   def valid_invocation?(noun, verb, number)


### PR DESCRIPTION
## 概要

Phase 3 (#129) の safe-gh wrapper body を、P3-04 の配布機構 (#134 merged) の上に載せる **end-to-end 縦切り**。GitHub の Issue/PR/コメントを **untrusted data として安全に読む steering wrapper** を agent-tools body として実装し、`script` artifact kind で build/sync が両 tool home に配る。最初の実 script asset。

**強度ラベル(偽らない)**: これは **steering**。enforcement boundary ではなく、`$(gh ...)` 直実行 / `gh api` / `curl` / MCP github tool で迂回でき、hook も fail-open。hard な防御は床(credential 隔離 + egress)が担う。safe-gh が買うのは「安全な読み方を便利にし、untrusted content を data として扱わせる」こと。

## 設計(設計メモの 8 決定を実装)

- コマンド: `safe-gh [-R OWNER/REPO] <issue|pr> <view|comments> <number>`、出力は **JSON**
- **provenance 3 軸**で author を `self` / `bot` / `other` に分類。**bot を association より先に**評価(決定3、bot は association=NONE に化ける)。**self を確定できなければ全 other**(fail-closed)
- **他人の Issue/PR は metadata のみ**(number/state/author/labels)。**title すら親へ渡さない**(決定4、title は attacker 制御の free-text = injection 面)。本文も渡さない
- **他人コメントは count + 固定理由のみ**。著者名・プレビュー・untrusted 由来の文字列を出力に**一切混ぜない**(決定5)
- **自分の Issue/PR 本文・自分のコメントだけ** trusted として渡す
- self identity = `gh api user` 主体 + 任意 local override(`~/.config/dotfiles/github-trust.local`)。**public repo に numeric id をハードコードしない**

## 検証

- I/O(gh 呼び出し)と純粋な trust/render ロジックを分離。後者を fixture で **deterministic に検証**: self/other/bot 分類、本文除外、コメント count のみ、**untrusted 非漏洩(sentinel 文字列が出力に出ないことを assert)**。`scripts/tests/safe-gh-test.sh`、**10 self-test PASS**
- gh の実挙動は実機手動(docs「検証境界」)。**実機 smoke 済み**: self issue → title/body 含む、他人 issue(cli/cli #1)→ metadata のみ・本文非漏洩、comments、nonexistent → exit 1、`--help`/不正引数
- check-manifests/build/register/status/doctor が script kind を通し **registered**(両 target)。real repo 挙動: generated.total 26→28(safe-gh 2 本)

## スコープ

- 配備(`sync --apply` で実 home へ)は実機手動の別ステップ
- instruction での tool 誘導は body 実在後の follow-up(#129 P3-12)なのでこの PR では行わない(「無い tool 名を instruction に先に書かない」)

## レビュー

author = Claude。相互レビュー規約により reviewer = Codex (author ≠ reviewer)。security-critical な trust gating なので、**untrusted content の非漏洩**・**fail-closed 方向**・**bot/self/other 分類の穴**を重点的に。

🤖 Generated with [Claude Code](https://claude.com/claude-code)