### PR TITLE
chore: `.agent-context.local.md` を .gitignore に追加 (follow-up #138)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules/
 # local handoff notes は machine-specific な planning context を含みうる。
 agent-tools-handoff.md
 .agent-tools.local.md
+# .agent-context.local.md: 各 repo 共通の private 参照正本 (read-only / user 所有)。
+.agent-context.local.md
 
 generated/**
 !generated/


### PR DESCRIPTION
#138 / #139 で導入した private 参照正本 `.agent-context.local.md`(read-only・user 所有)の固定名を、この repo 自身の `.gitignore` でも ignore する。

- 旧名 `.agent-tools.local.md` は移行中のため残す(両方 ignore)。
- `git check-ignore -v .agent-context.local.md` → `.gitignore:13` で ignore を確認済み。

**proportional effort**: 1 行の config 追加(logic なし・隣接エントリ `.agent-tools.local.md` と同形・挙動リスクなし)のため、手順を軽量化し author≠reviewer の独立レビューは省略する(品質バーは維持、手順のみ規模相応に)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)