### PR TITLE
feat: catalog manifest_digest + 承認の build_id 紐づけ (#148)

### DIFF
--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -220,8 +220,12 @@ allowed values:
 - `static_check`: `pending`, `pass`, `fail`
 - `llm_review`: `allowed`, `blocked`, `not_needed`
 - `human_review`: `pending`, `approved`, `rejected`, `not_needed`
+- `approved_build_id`: build_id 文字列 (`sha256:` + 12 hex)。`human_review: approved` と
+  対で使う (単独はエラー)。
 
 `human_review` は人間が宣言する値で、register が medium finding の解決に参照します。
+承認は `approved_build_id` (承認時点の build_id) で **内容に紐づき**、現在の build_id と
+一致するときだけ効きます ([register-catalog.md](register-catalog.md) の #148 節)。
 `static_check` / `llm_review` は informational で、自動 check の結果は
 [catalog](register-catalog.md) 側を真実とします。
 

--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -143,7 +143,8 @@ echo "$status" | jq -r '
 | --- | --- | --- |
 | `skip ... (run build first)` | generated が無い / 古い | `./scripts/build.sh` を実行 |
 | `skip ... (run connect first)` | instruction の所有先が未確立(未接続 / 空ファイル) | `./scripts/connect.sh --apply` |
-| `skip ... (human_review_required)` | catalog で human review 待ち | manifest の `review.human_review` を解決して `register` し直す |
+| `skip ... (human_review_required)` | catalog で human review 待ち | manifest の `review.human_review: approved` と `review.approved_build_id`(現在の build_id)を設定して `register` し直す |
+| `skip ... (manifest changed; run scripts/register.sh first)` | register 後に manifest を変更した(登録判断が古い) | `./scripts/register.sh` で catalog を再生成 |
 | `conflict ... (existing target is unmanaged)` | 同名の手書き / 別管理ファイルがある | 中身を確認。agent-tools に委ねてよいなら退避してから再実行(無断上書きはしない) |
 | `conflict ... (existing target is a symlink)` | 所有先 / 親が symlink | symlink を解消するか、別 home を指定 |
 | `no catalog; run register first` | catalog 未生成 | `./scripts/register.sh` |

--- a/docs/prompt-injection-check.md
+++ b/docs/prompt-injection-check.md
@@ -88,10 +88,12 @@ human review 必須にします。
 ## Risk Outcomes
 
 - High risk: registration fail。
-- Medium risk: human review 必須。`review.human_review: approved` を manifest で宣言すると
-  `registered` になり配置される (medium↔承認の照合は register が担う)。read-only でログを
-  読む等、参照が設計上正当な skill (例 `personal-asset-miner` の runtime-state) はこの経路で
-  通す。詳細は [register-catalog](register-catalog.md)。
+- Medium risk: human review 必須。`review.human_review: approved` **かつ**
+  `review.approved_build_id` が現在の build_id と一致すると `registered` になり配置される
+  (medium↔承認の照合は register が担う)。承認は内容に紐づくので、source を変えたら
+  再レビューして `approved_build_id` を更新する (#148)。read-only でログを読む等、参照が
+  設計上正当な skill (例 `personal-asset-miner` の runtime-state) はこの経路で通す。詳細は
+  [register-catalog](register-catalog.md)。
 - Low risk: registration 可。
 
 ## Static checker 実装

--- a/docs/register-catalog.md
+++ b/docs/register-catalog.md
@@ -18,13 +18,13 @@ catalog に記録する step です。
   いつでも再生成できる。
 - catalog は commit しない。tracked source は manifest だけが source of truth。
 
-catalog は **target-artifact 単位** (catalog_version 2) です。1 つの asset が複数 target を
+catalog は **target-artifact 単位** (catalog_version 3) です。1 つの asset が複数 target を
 持つ場合、target ごとに entry を 1 つずつ出します。各 entry は `target` と
 `artifact_kind` を持ち、sync はこれを見て配置先を分岐します。
 
 ```json
 {
-  "catalog_version": 2,
+  "catalog_version": 3,
   "assets": [
     {
       "name": "personal-example",
@@ -37,6 +37,8 @@ catalog は **target-artifact 単位** (catalog_version 2) です。1 つの ass
         "format": "markdown"
       },
       "build_id": "sha256:0123456789ab",
+      "manifest_path": "shared/workflows/personal-example.asset.yml",
+      "manifest_digest": "<sha256 hex of manifest bytes>",
       "checks": {
         "manifest_validation": "pass",
         "prompt_injection_static": "pass"
@@ -51,6 +53,14 @@ catalog は **target-artifact 単位** (catalog_version 2) です。1 つの ass
 
 source content の決定的 hash (build の marker と同じ計算)。doctor が catalog の
 鮮度判定に使う。mtime には依存しない。
+
+### `manifest_path` / `manifest_digest` (v3, #148)
+
+登録判断 (risk / review / targets) は manifest に依存する。register 時の manifest file
+bytes の SHA256 を entry に記録し、reader が「register 後に manifest が変わった catalog」を
+検出できるようにする。**sync は不一致の entry を配置せず** `manifest changed; run
+scripts/register.sh first` で skip し (fail-closed)、**doctor は stale として warn** する。
+digest 計算は `Assets.manifest_digest` に一元化 (register と reader で割れない)。
 
 ### `registration`
 
@@ -106,10 +116,19 @@ source format / output path の確認のみ)。build できない target-artifac
 medium finding は「human review 必須」を意味する。register は finding の path を
 asset の source path に対応づけ、manifest の `review.human_review` と突き合わせる。
 
-- `review.human_review: approved` → その asset は `registered`。
-- それ以外 (`pending` / 欠落) → その asset は `human_review_required`。
+- `review.human_review: approved` **かつ** `review.approved_build_id` が現在の build_id と
+  一致 → その asset は `registered`。
+- それ以外 (`pending` / 欠落 / approved_build_id 不一致) → その asset は
+  `human_review_required`。
 - `review.human_review: rejected` の asset は、finding の有無によらず register fail
   とする (reject 済み asset が shared/ に残っている状態は矛盾なので、修正か削除を促す)。
+
+### 承認は内容に紐づく (`approved_build_id`, #148)
+
+`approved` 単独の永続承認は「承認後に source が全面的に変わっても registered のまま」に
+なる穴。承認には `review.approved_build_id` (承認時点の build_id) を併記し、現在の
+build_id と一致するときだけ効かせる。source を変更したら register が不一致を警告する
+(現在の build_id を表示) ので、再レビューのうえ approved_build_id を更新する。
 
 ## 宣言 risk の enforce
 

--- a/docs/register-catalog.md
+++ b/docs/register-catalog.md
@@ -137,7 +137,8 @@ enforce する。static finding と宣言 risk の厳しい方が勝つ。
 
 - いずれかが `high` → register fail。catalog を更新しない。
 - いずれかが `medium` / `unknown` → human review 必須として扱う
-  (`approved` → `registered`、それ以外 → `human_review_required`)。
+  (承認が有効 = `approved` かつ `approved_build_id` 一致なら `registered`、それ以外は
+  `human_review_required`。下記「承認は内容に紐づく」参照)。
 - 両方 `low` → finding がなければ `registered`。
 
 ## script artifact は常に human review 必須
@@ -146,9 +147,10 @@ enforce する。static finding と宣言 risk の厳しい方が勝つ。
 static check が当てられるのは injection 文言 pattern のみ (コードの悪性は検査できない。
 [prompt-injection-check.md](prompt-injection-check.md) の honest-label 参照)。directory skill の
 `scripts/` を #43 まで fail-closed にしているのと対称に、宣言 risk / finding の有無によらず
-human review 必須として扱う (`approved` → `registered`、それ以外 → `human_review_required`)。
-判定は manifest の `kind` でなく **resolve 後の artifact_kind** で行う (`compatibility` の
-override で任意 kind を script 配布にできるため、kind 基準では迂回できる)。
+human review 必須として扱う (承認が有効 = `approved` かつ `approved_build_id` 一致なら
+`registered`、それ以外は `human_review_required`)。判定は manifest の `kind` でなく
+**resolve 後の artifact_kind** で行う (`compatibility` の override で任意 kind を script
+配布にできるため、kind 基準では迂回できる)。
 
 ## Check 結果の書き戻し方針
 

--- a/docs/sync-policy.md
+++ b/docs/sync-policy.md
@@ -13,6 +13,9 @@ default は必ず conservative にします。
   `registration: registered` の target-artifact だけを配置する。registered でない
   (`human_review_required` / `unsupported`) ものは理由つきで skip する。
 - catalog が無い / version 不一致なら何も配置せず register を促す。
+- register 後に manifest が変わった entry (catalog の `manifest_digest` と現在の manifest
+  が不一致) は、登録判断ごと stale なので配置せず `manifest changed; run
+  scripts/register.sh first` で skip する (fail-closed, #148)。
 - sync が更新してよいのは agent-tools management marker を含む targets のみ。
   同名の unmanaged targets は conflict として扱い、sync を停止する。
 - artifact_kind ごとに配置先が異なる:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -153,7 +153,8 @@ usage: register.sh [--root DIR] [--quiet]
 ```
 
 - gate は build と同じ。manifest error / high finding で fail し、catalog を更新しない。
-- medium finding は manifest の `review.human_review` と asset 単位で突き合わせる。
+- medium finding は manifest の `review.human_review` と asset 単位で突き合わせる。承認は
+  `review.approved_build_id` が現在の build_id と一致するときだけ効く (内容に紐づく承認, #148)。
 - exit code: 0 (全 registered) / 3 (human_review_required あり) / 1 (gate fail)。
 - 書き込みは `generated/catalog.json` のみ。
 - self-test: `tests/register-test.sh`

--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -8,7 +8,8 @@
 module ArtifactTargets
   # catalog (generated/catalog.json) の version。reader (sync / status / doctor) は
   # これと一致しない catalog を古いものとして無視する。
-  CATALOG_VERSION = 2
+  # v3: entry に manifest_path / manifest_digest を追加 (登録判断の鮮度検出, #148)。
+  CATALOG_VERSION = 3
 
   # build が扱える artifact_kind。
   SUPPORTED_KINDS = %w[skill instruction script].freeze

--- a/scripts/lib/assets.rb
+++ b/scripts/lib/assets.rb
@@ -7,11 +7,23 @@ require_relative "yaml_util"
 # shared asset の discovery と load を 1 箇所に集約する。
 # manifest glob / parse / 正規化を各 script で重複させない。
 module Assets
-  # manifest file bytes の SHA256。register が catalog に記録し、sync / doctor が現在の
+  # manifest file bytes の SHA256。register が catalog に記録し、reader が現在の
   # manifest と照合して「登録判断 (risk / review / targets) が古い catalog」を検出する
   # (docs/register-catalog.md)。register と読む側で計算が割れないようここに一元化する。
   def self.manifest_digest(root, manifest_rel)
     Digest::SHA256.hexdigest(File.read(File.join(File.expand_path(root), manifest_rel)))
+  end
+
+  # catalog entry の manifest_digest が現在の manifest と一致するか。manifest の欠落・
+  # 読めない・digest 未記録 (旧 catalog) はすべて false = fail-closed。
+  # 配置系 reader (sync / connect) と doctor で判定を共有する (#148)。
+  def self.manifest_fresh?(root, entry)
+    path = entry["manifest_path"]
+    return false unless path.is_a?(String)
+
+    entry["manifest_digest"] == manifest_digest(root, path)
+  rescue SystemCallError, IOError
+    false
   end
   # sidecar manifest と directory manifest を sort して返す (絶対 path)。
   def self.manifest_paths(root)

--- a/scripts/lib/assets.rb
+++ b/scripts/lib/assets.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
+require "digest"
+
 require_relative "yaml_util"
 
 # shared asset の discovery と load を 1 箇所に集約する。
 # manifest glob / parse / 正規化を各 script で重複させない。
 module Assets
+  # manifest file bytes の SHA256。register が catalog に記録し、sync / doctor が現在の
+  # manifest と照合して「登録判断 (risk / review / targets) が古い catalog」を検出する
+  # (docs/register-catalog.md)。register と読む側で計算が割れないようここに一元化する。
+  def self.manifest_digest(root, manifest_rel)
+    Digest::SHA256.hexdigest(File.read(File.join(File.expand_path(root), manifest_rel)))
+  end
   # sidecar manifest と directory manifest を sort して返す (絶対 path)。
   def self.manifest_paths(root)
     root = File.expand_path(root)
@@ -44,6 +52,7 @@ module Assets
       # parse 可能だが型不正な manifest (scalar の review / risk) でも落ちないよう、
       # Hash でなければ nil / [] に正規化する (検証は check-manifests が担う)。
       human_review: data["review"].is_a?(Hash) ? data["review"]["human_review"] : nil,
+      approved_build_id: data["review"].is_a?(Hash) ? data["review"]["approved_build_id"] : nil,
       declared_risks: data["risk"].is_a?(Hash) ? data["risk"].values : [],
       manifest_path: rel,
     }

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -27,6 +27,10 @@ module CheckManifests
     "llm_review" => %w[allowed blocked not_needed],
     "human_review" => %w[pending approved rejected not_needed],
   }.freeze
+  # 承認を内容に紐づける build_id (#148)。build.rb の build_id 形式 (sha256: + 先頭 12 hex)。
+  # human_review: approved と対で使う。
+  APPROVED_BUILD_ID_KEY = "approved_build_id"
+  APPROVED_BUILD_ID_PATTERN = /\Asha256:[0-9a-f]{12}\z/.freeze
   NAME_PATTERN = /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/.freeze
   ASSET_CATEGORIES = %w[skills prompts workflows agents instructions scripts].freeze
   NON_ASSET_BASENAMES = %w[README.md].freeze
@@ -260,12 +264,20 @@ module CheckManifests
         error(path, "review must be a mapping")
         return
       end
-      (value.keys - REVIEW_VALUES.keys).each { |key| error(path, "unknown review key: #{key}") }
+      (value.keys - REVIEW_VALUES.keys - [APPROVED_BUILD_ID_KEY]).each { |key| error(path, "unknown review key: #{key}") }
       REVIEW_VALUES.each do |key, allowed|
         next unless value.key?(key)
 
         unless allowed.include?(value[key])
           error(path, "review.#{key} must be one of #{allowed.join(', ')}, got #{value[key].inspect}")
+        end
+      end
+      if value.key?(APPROVED_BUILD_ID_KEY)
+        unless value[APPROVED_BUILD_ID_KEY].is_a?(String) && value[APPROVED_BUILD_ID_KEY] =~ APPROVED_BUILD_ID_PATTERN
+          error(path, "review.#{APPROVED_BUILD_ID_KEY} must be a build_id (sha256: + 12 hex chars)")
+        end
+        unless value["human_review"] == "approved"
+          error(path, "review.#{APPROVED_BUILD_ID_KEY} requires review.human_review: approved")
         end
       end
     end

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -19,6 +19,7 @@ require "fileutils"
 
 require_relative "artifact_targets"
 require_relative "instruction_marker"
+require_relative "assets"
 
 module Connect
   # 人間の CLAUDE.md から所有ファイルを取り込む import 行。
@@ -89,6 +90,12 @@ module Connect
       return "not in catalog; run scripts/register.sh first" unless entry
       unless entry["registration"] == "registered"
         return "instruction not registered (#{entry["registration"]})"
+      end
+      # 登録判断 (risk / review / targets) は manifest に依存する。register 後に manifest が
+      # 変わった entry で所有確立・コピーしない (sync と同じ fail-closed gate, #148)。
+      # connect は初回配置 (create) を担うため、ここを見ないと sync の gate を迂回できる。
+      unless Assets.manifest_fresh?(@root, entry)
+        return "manifest changed; run scripts/register.sh first"
       end
 
       marker = InstructionMarker.parse(File.read(gen))

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -166,7 +166,7 @@ module Doctor
           stale << "#{asset[:name]}: not in catalog"
         elsif !fresh_entry?(entry, asset[:source])
           stale << "#{asset[:name]}: content changed since register"
-        elsif !manifest_fresh?(entry, asset[:manifest_path])
+        elsif !Assets.manifest_fresh?(@root, entry)
           # 登録判断 (risk / review / targets) は manifest に依存する (#148)。
           stale << "#{asset[:name]}: manifest changed since register"
         end
@@ -189,16 +189,6 @@ module Doctor
     # 倒し、doctor 全体を落とさない (status の fresh? と同じ best-effort)。
     def fresh_entry?(entry, source)
       entry["build_id"] == Build.build_id_for(@root, source["path"], source["format"])
-    rescue StandardError
-      false
-    end
-
-    # catalog entry の manifest_digest と現在の manifest file を比較する。読めない /
-    # 未記録は検証不能 = stale (false) に倒す (fresh_entry? と同じ best-effort)。
-    def manifest_fresh?(entry, manifest_path)
-      return false unless manifest_path.is_a?(String)
-
-      entry["manifest_digest"] == Assets.manifest_digest(@root, manifest_path)
     rescue StandardError
       false
     end

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -148,27 +148,30 @@ module Doctor
       by_name = entries.each_with_object({}) { |e, h| h[e["name"]] = e }
       # 壊れた / 型不正な manifest があっても doctor を落とさない (status と同じ best-effort)。
       # source を読めなければ鮮度は検証不能とし、manifest の不正は check-manifests に委ねる。
-      manifests =
+      assets =
         begin
-          Assets.sources_by_name(@root)
+          Assets.load_all(@root).select { |a| a[:name] && a[:source].is_a?(Hash) }
         rescue StandardError
           nil
         end
-      if manifests.nil?
+      if assets.nil?
         report("warn", "catalog", "freshness 未検証 (manifest を読めない; check-manifests を参照)")
         return
       end
 
       stale = []
-      manifests.each do |name, source|
-        entry = by_name[name]
+      assets.each do |asset|
+        entry = by_name[asset[:name]]
         if entry.nil?
-          stale << "#{name}: not in catalog"
-        elsif !fresh_entry?(entry, source)
-          stale << "#{name}: content changed since register"
+          stale << "#{asset[:name]}: not in catalog"
+        elsif !fresh_entry?(entry, asset[:source])
+          stale << "#{asset[:name]}: content changed since register"
+        elsif !manifest_fresh?(entry, asset[:manifest_path])
+          # 登録判断 (risk / review / targets) は manifest に依存する (#148)。
+          stale << "#{asset[:name]}: manifest changed since register"
         end
       end
-      (by_name.keys - manifests.keys).each { |name| stale << "#{name}: manifest removed" }
+      (by_name.keys - assets.map { |a| a[:name] }).each { |name| stale << "#{name}: manifest removed" }
 
       if stale.empty?
         # entries は target-artifact 単位なので、asset 数は unique name で数える。
@@ -186,6 +189,16 @@ module Doctor
     # 倒し、doctor 全体を落とさない (status の fresh? と同じ best-effort)。
     def fresh_entry?(entry, source)
       entry["build_id"] == Build.build_id_for(@root, source["path"], source["format"])
+    rescue StandardError
+      false
+    end
+
+    # catalog entry の manifest_digest と現在の manifest file を比較する。読めない /
+    # 未記録は検証不能 = stale (false) に倒す (fresh_entry? と同じ best-effort)。
+    def manifest_fresh?(entry, manifest_path)
+      return false unless manifest_path.is_a?(String)
+
+      entry["manifest_digest"] == Assets.manifest_digest(@root, manifest_path)
     rescue StandardError
       false
     end

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # register: shared assets を検証し、catalog に登録状態を記録する。
-# Spec: docs/register-catalog.md (catalog_version 2)
+# Spec: docs/register-catalog.md (catalog_version 3)
 #
 # - 副作用は generated/catalog.json の書き込みのみ。
 # - gate は build と同じ: manifest error / high finding で fail し、catalog を更新しない。
@@ -92,16 +92,30 @@ module Register
       review_needed = asset[:flagged] ||
                       script_artifact ||
                       asset[:declared_risks].any? { |r| %w[medium unknown].include?(r) }
+      # source content の決定的 hash。target に依らない。doctor の鮮度判定に使う。
+      build_id = Build.build_id_for(@root, asset[:source]["path"], asset[:source]["format"])
+      # 承認は内容 (build_id) に紐づける。approved だけの永続承認は、承認後に source が
+      # 全面的に変わっても registered のまま残る穴になる (#148)。approved_build_id が
+      # 現在の build_id と一致するときだけ承認が効く。不一致は再レビューを促す。
+      approval_effective = asset[:human_review] == "approved" &&
+                           asset[:approved_build_id] == build_id
+      if review_needed && asset[:human_review] == "approved" && !approval_effective
+        warn "#{asset[:name]}: human_review is approved but review.approved_build_id does not " \
+             "match current build_id #{build_id}; re-review the content and update approved_build_id"
+      end
       review_registration =
         if !review_needed
           "registered"
-        elsif asset[:human_review] == "approved"
+        elsif approval_effective
           "registered"
         else
           "human_review_required"
         end
-      # source content の決定的 hash。target に依らない。doctor の鮮度判定に使う。
-      build_id = Build.build_id_for(@root, asset[:source]["path"], asset[:source]["format"])
+
+      # 登録判断 (risk / review / targets) は manifest に依存する。manifest の digest を
+      # entry に記録し、reader (sync / doctor) が register 後の manifest 変更を検出できる
+      # ようにする (#148)。
+      manifest_digest = Assets.manifest_digest(@root, asset[:manifest_path])
 
       (asset[:targets] || []).map do |tool|
         registration = ArtifactTargets.buildable?(asset, tool) ? review_registration : "unsupported"
@@ -113,6 +127,8 @@ module Register
           "visibility" => asset[:visibility],
           "source" => asset[:source],
           "build_id" => build_id,
+          "manifest_path" => asset[:manifest_path],
+          "manifest_digest" => manifest_digest,
           "checks" => {
             "manifest_validation" => "pass",
             "prompt_injection_static" => asset[:flagged] ? "human_review" : "pass",

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -188,12 +188,18 @@ module Status
 
     # Sync plan を contract の target state にマップする。
     # registered でない artifact は配置されないため、target は missing 扱い。
+    # manifest-stale (登録判断が古い) は配置済みでも再 register が要るので stale。
     def target_state(plan)
       case plan.action
       when "update" then "stale"
       when "conflict" then "conflict"
       when "create" then "missing"
-      when "skip" then plan.reason == "up-to-date" ? "managed" : "missing"
+      when "skip"
+        case plan.reason
+        when "up-to-date" then "managed"
+        when /\Amanifest changed/ then "stale"
+        else "missing"
+        end
       end
     end
 

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -100,7 +100,7 @@ module Sync
       end
       # 登録判断 (risk / review / targets) は manifest に依存する。register 後に manifest が
       # 変わった entry は判断ごと stale なので、配置せず register を促す (fail-closed, #148)。
-      unless manifest_fresh?(entry)
+      unless Assets.manifest_fresh?(@root, entry)
         return Plan.new("skip", tool, name, target_path(tool, name, kind),
                         "manifest changed; run scripts/register.sh first", kind, nil)
       end
@@ -118,17 +118,6 @@ module Sync
     # path 解決は ArtifactTargets.target_path が単一 source (skill / instruction 共通)。
     def target_path(tool, name, kind)
       ArtifactTargets.target_path(@homes.fetch(tool), tool, name, kind)
-    end
-
-    # catalog entry に記録された manifest digest が現在の manifest と一致するか。
-    # manifest の欠落・読めない・digest 未記録 (旧 catalog) はすべて false = fail-closed。
-    def manifest_fresh?(entry)
-      path = entry["manifest_path"]
-      return false unless path.is_a?(String)
-
-      entry["manifest_digest"] == Assets.manifest_digest(@root, path)
-    rescue SystemCallError, IOError
-      false
     end
 
     def plan_skill(tool, name, expected_build_id)

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -19,6 +19,7 @@ require "fileutils"
 require_relative "yaml_util"
 require_relative "artifact_targets"
 require_relative "instruction_marker"
+require_relative "assets"
 
 module Sync
   MARKER_FILE = ArtifactTargets::MARKER_BASENAME
@@ -39,7 +40,7 @@ module Sync
       load_catalog
     end
 
-    # catalog を source of truth として読む (catalog_version 2、target-artifact 単位)。
+    # catalog を source of truth として読む (ArtifactTargets::CATALOG_VERSION、target-artifact 単位)。
     def load_catalog
       @catalog_present = false
       @entries = []
@@ -97,6 +98,12 @@ module Sync
       if entry["registration"] != "registered"
         return Plan.new("skip", tool, name, target_path(tool, name, kind), entry["registration"], kind, nil)
       end
+      # 登録判断 (risk / review / targets) は manifest に依存する。register 後に manifest が
+      # 変わった entry は判断ごと stale なので、配置せず register を促す (fail-closed, #148)。
+      unless manifest_fresh?(entry)
+        return Plan.new("skip", tool, name, target_path(tool, name, kind),
+                        "manifest changed; run scripts/register.sh first", kind, nil)
+      end
 
       case kind
       when "skill" then plan_skill(tool, name, entry["build_id"])
@@ -111,6 +118,17 @@ module Sync
     # path 解決は ArtifactTargets.target_path が単一 source (skill / instruction 共通)。
     def target_path(tool, name, kind)
       ArtifactTargets.target_path(@homes.fetch(tool), tool, name, kind)
+    end
+
+    # catalog entry に記録された manifest digest が現在の manifest と一致するか。
+    # manifest の欠落・読めない・digest 未記録 (旧 catalog) はすべて false = fail-closed。
+    def manifest_fresh?(entry)
+      path = entry["manifest_path"]
+      return false unless path.is_a?(String)
+
+      entry["manifest_digest"] == Assets.manifest_digest(@root, path)
+    rescue SystemCallError, IOError
+      false
     end
 
     def plan_skill(tool, name, expected_build_id)

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -391,6 +391,34 @@ fi
 grep -q "must not be a symlink" "$tmp/out-symsrc" \
   || fail "expected single-file symlink rejection reason: $(cat "$tmp/out-symsrc")"
 
+# --- case: approved_build_id の検証 (#148)。形式不正と approved なし併用を reject ---
+mkdir -p "$tmp/abid/shared/workflows"
+echo "# demo" > "$tmp/abid/shared/workflows/personal-abid.md"
+cat > "$tmp/abid/shared/workflows/personal-abid.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-abid
+kind: workflow
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+review:
+  human_review: pending
+  approved_build_id: not-a-build-id
+source:
+  path: shared/workflows/personal-abid.md
+  format: markdown
+EOF
+if "$check" --root "$tmp/abid" > "$tmp/out-abid" 2>&1; then
+  fail "check-manifests must reject malformed approved_build_id"
+fi
+grep -q "approved_build_id must be a build_id" "$tmp/out-abid" \
+  || fail "expected approved_build_id format error: $(cat "$tmp/out-abid")"
+grep -q "approved_build_id requires review.human_review: approved" "$tmp/out-abid" \
+  || fail "expected approved-pairing error: $(cat "$tmp/out-abid")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -212,4 +212,41 @@ grep -q "0 change(s)" "$tmp/c12" || fail "stale connect should apply 0 changes: 
 [ ! -e "$tmp/claude10/CLAUDE.md" ] || fail "stale generated instruction must not add import"
 [ ! -e "$tmp/codex10/AGENTS.md" ] || fail "stale generated instruction must not create owned codex file"
 
+# --- case 13: register 後に manifest だけ変えたら connect は gate で止まる (#148) ---
+# (source は不変で build_id 一致でも、登録判断 (risk/review) が古い catalog は配置しない。
+#  connect は初回配置を担うので、ここを塞がないと sync の manifest gate を迂回できる)
+mkdir -p "$tmp/repo4/shared/instructions" "$tmp/codex11" "$tmp/claude11"
+cat > "$tmp/repo4/shared/instructions/personal-ops.md" <<'EOF'
+# operating rules
+
+ドキュメントは日本語を既定にする。
+EOF
+cat > "$tmp/repo4/shared/instructions/personal-ops.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-ops
+kind: instruction
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/instructions/personal-ops.md
+  format: markdown
+EOF
+"$build" --root "$tmp/repo4" --quiet > /dev/null
+"$register" --root "$tmp/repo4" --quiet > /dev/null
+# source は変えず manifest だけ変更 (build_id 不変・manifest_digest 変化)。register しない。
+printf '\n# reviewed comment (catalog 未更新)\n' >> "$tmp/repo4/shared/instructions/personal-ops.asset.yml"
+"$connect" --root "$tmp/repo4" --codex-home "$tmp/codex11" --claude-home "$tmp/claude11" --apply > "$tmp/c13" 2>&1 \
+  || fail "connect should not error on manifest-stale catalog: $(cat "$tmp/c13")"
+grep -q "skip: \[claude-code\] owned.*manifest changed" "$tmp/c13" \
+  || fail "claude owned should skip when manifest changed since register: $(cat "$tmp/c13")"
+grep -q "skip: \[codex\] owned.*manifest changed" "$tmp/c13" \
+  || fail "codex owned should skip when manifest changed since register: $(cat "$tmp/c13")"
+[ ! -e "$tmp/claude11/agent-tools/CLAUDE.md" ] || fail "manifest-stale instruction must not create owned file"
+[ ! -e "$tmp/codex11/AGENTS.md" ] || fail "manifest-stale instruction must not create owned codex file"
+
 echo "ok: connect self-test passed"

--- a/scripts/tests/doctor-test.sh
+++ b/scripts/tests/doctor-test.sh
@@ -104,8 +104,16 @@ run_doctor > "$tmp/d5b" 2>&1 || fail "stale catalog should still exit 0"
 grep -q "warn: catalog: stale (personal-demo: content changed since register)" "$tmp/d5b" \
   || fail "missing catalog stale warn: $(cat "$tmp/d5b")"
 
+# manifest (登録判断) の変更も stale になる (#148)
+"$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null
+echo "# reviewed comment" >> "$tmp/repo/shared/workflows/personal-demo.asset.yml"
+run_doctor > "$tmp/d5c" 2>&1 || fail "manifest-stale catalog should still exit 0"
+grep -q "warn: catalog: stale (personal-demo: manifest changed since register)" "$tmp/d5c" \
+  || fail "missing manifest stale warn: $(cat "$tmp/d5c")"
+"$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null
+
 # --- case 6: catalog_version 不一致は warn (re-run register) ---
-ruby -i -pe 'sub(/"catalog_version": 2/, "\"catalog_version\": 1")' "$tmp/repo/generated/catalog.json"
+ruby -i -pe 'sub(/"catalog_version": \d+/, "\"catalog_version\": 1")' "$tmp/repo/generated/catalog.json"
 run_doctor > "$tmp/d6" 2>&1 || fail "version mismatch should still exit 0: $(cat "$tmp/d6")"
 grep -q "warn: catalog: version mismatch" "$tmp/d6" \
   || fail "missing catalog version mismatch warn: $(cat "$tmp/d6")"

--- a/scripts/tests/register-test.sh
+++ b/scripts/tests/register-test.sh
@@ -19,6 +19,11 @@ jget() {
   ruby -rjson -e 'puts JSON.parse(File.read(ARGV[0])).dig(*ARGV[1..-1].map { |k| k =~ /\A\d+\z/ ? k.to_i : k }).inspect' "$@"
 }
 
+# 実装と同じ計算で build_id を得る (approved_build_id fixture 用)。
+bid() {
+  ruby -r"$script_dir/../lib/build" -e 'puts Build.build_id_for(ARGV[0], ARGV[1], ARGV[2])' "$@"
+}
+
 write_manifest() {
   # $1: dir, $2: human_review line (空なら review なし)
   cat > "$1/personal-demo.asset.yml" <<EOF
@@ -45,12 +50,17 @@ write_manifest "$tmp/ok/shared/workflows"
 "$register" --root "$tmp/ok" > "$tmp/r1" 2>&1 || fail "register should pass: $(cat "$tmp/r1")"
 catalog="$tmp/ok/generated/catalog.json"
 [ -f "$catalog" ] || fail "catalog not written"
-[ "$(jget "$catalog" catalog_version)" = "2" ] || fail "catalog_version should be 2"
+[ "$(jget "$catalog" catalog_version)" = "3" ] || fail "catalog_version should be 3"
 [ "$(jget "$catalog" assets 0 registration)" = '"registered"' ] || fail "asset should be registered"
 [ "$(jget "$catalog" assets 0 target)" = '"codex"' ] || fail "entry should carry target (target-artifact unit)"
 [ "$(jget "$catalog" assets 0 artifact_kind)" = '"skill"' ] || fail "entry should carry artifact_kind"
 [ "$(jget "$catalog" assets 0 checks prompt_injection_static)" = '"pass"' ] || fail "injection check should be pass"
 jget "$catalog" assets 0 build_id | grep -q '"sha256:' || fail "catalog entry should carry build_id"
+# 登録判断の鮮度検出用に manifest の path と digest も記録する (#148)
+[ "$(jget "$catalog" assets 0 manifest_path)" = '"shared/workflows/personal-demo.asset.yml"' ] \
+  || fail "catalog entry should carry manifest_path"
+jget "$catalog" assets 0 manifest_digest | grep -qE '"[0-9a-f]{64}"' \
+  || fail "catalog entry should carry manifest_digest (sha256 hex)"
 
 # --- case 2: status が register summary を返す (contract v2) ---
 "$status_sh" --root "$tmp/ok" --json > "$tmp/s2" 2>&1
@@ -71,11 +81,38 @@ catalog="$tmp/medium/generated/catalog.json"
 [ "$(jget "$catalog" assets 0 checks prompt_injection_static)" = '"human_review"' ] \
   || fail "injection check should be human_review"
 
-# --- case 4: medium finding + approved → registered, exit 0 ---
+# --- case 4: medium finding + approved (approved_build_id 一致) → registered, exit 0 ---
+bid_medium=$(bid "$tmp/medium" shared/workflows/personal-demo.md markdown)
 write_manifest "$tmp/medium/shared/workflows" "review:
-  human_review: approved"
+  human_review: approved
+  approved_build_id: $bid_medium"
 "$register" --root "$tmp/medium" > "$tmp/r4" 2>&1 || fail "approved should exit 0: $(cat "$tmp/r4")"
 [ "$(jget "$catalog" assets 0 registration)" = '"registered"' ] || fail "approved asset should be registered"
+
+# --- case 4b: approved でも approved_build_id が無ければ永続承認にならない (exit 3, #148) ---
+write_manifest "$tmp/medium/shared/workflows" "review:
+  human_review: approved"
+status=0
+"$register" --root "$tmp/medium" > "$tmp/r4b" 2>&1 || status=$?
+[ "$status" -eq 3 ] || fail "approved without approved_build_id should exit 3, got $status: $(cat "$tmp/r4b")"
+[ "$(jget "$catalog" assets 0 registration)" = '"human_review_required"' ] \
+  || fail "approval without content binding must not register"
+grep -q "approved_build_id does not match current build_id" "$tmp/r4b" \
+  || fail "missing re-review guidance: $(cat "$tmp/r4b")"
+
+# --- case 4c: 承認後に source が変わったら承認は失効する (stale approved_build_id → exit 3) ---
+write_manifest "$tmp/medium/shared/workflows" "review:
+  human_review: approved
+  approved_build_id: $bid_medium"
+printf '# demo with hidden\xe2\x80\x8bmarker\nedited after approval\n' \
+  > "$tmp/medium/shared/workflows/personal-demo.md"
+status=0
+"$register" --root "$tmp/medium" > "$tmp/r4c" 2>&1 || status=$?
+[ "$status" -eq 3 ] || fail "stale approval should exit 3, got $status: $(cat "$tmp/r4c")"
+[ "$(jget "$catalog" assets 0 registration)" = '"human_review_required"' ] \
+  || fail "content change must invalidate approval"
+# 後続 case のために元の内容へ戻す
+printf '# demo with hidden\xe2\x80\x8bmarker\n' > "$tmp/medium/shared/workflows/personal-demo.md"
 
 # --- case 5: medium finding + rejected → fail, catalog 未更新 ---
 write_manifest "$tmp/medium/shared/workflows" "review:
@@ -130,8 +167,10 @@ status=0
 [ "$(jget "$tmp/dunk/generated/catalog.json" assets 0 registration)" = '"human_review_required"' ] \
   || fail "declared unknown should require human review"
 
+bid_dunk=$(bid "$tmp/dunk" shared/workflows/personal-demo.md markdown)
 write_manifest "$tmp/dunk/shared/workflows" "review:
-  human_review: approved"
+  human_review: approved
+  approved_build_id: $bid_dunk"
 ruby -i -pe 'sub("privacy: low", "privacy: unknown")' \
   "$tmp/dunk/shared/workflows/personal-demo.asset.yml"
 "$register" --root "$tmp/dunk" > "$tmp/r9b" 2>&1 || fail "approved unknown should exit 0: $(cat "$tmp/r9b")"
@@ -177,8 +216,9 @@ sc="$tmp/script/generated/catalog.json"
 [ "$(jget "$sc" assets 0 registration)" = '"human_review_required"' ] \
   || fail "script without approval should be human_review_required (#147)"
 
-# --- case 12c: script kind + human_review: approved → registered (exit 0) ---
-cat > "$tmp/script/shared/scripts/personal-demo-script.asset.yml" <<'EOF'
+# --- case 12c: script kind + human_review: approved (approved_build_id 一致) → registered (exit 0) ---
+bid_script=$(bid "$tmp/script" shared/scripts/personal-demo-script.sh text)
+cat > "$tmp/script/shared/scripts/personal-demo-script.asset.yml" <<EOF
 schema_version: 1
 name: personal-demo-script
 kind: script
@@ -190,6 +230,7 @@ risk:
   privacy: low
 review:
   human_review: approved
+  approved_build_id: $bid_script
 source:
   path: shared/scripts/personal-demo-script.sh
   format: text

--- a/scripts/tests/status-test.sh
+++ b/scripts/tests/status-test.sh
@@ -63,7 +63,7 @@ run_status > "$tmp/s1" 2>&1 || fail "status should succeed: $(cat "$tmp/s1")"
 run_status > "$tmp/s2" 2>&1
 [ "$(jget "$tmp/s2" generated total)" = "2" ] || fail "generated.total should be 2"
 [ "$(jget "$tmp/s2" generated stale)" = "0" ] || fail "generated.stale should be 0"
-# catalog は target-artifact 単位 (catalog_version 2)。2 target なので registered=2。
+# catalog は target-artifact 単位 (catalog_version 3)。2 target なので registered=2。
 [ "$(jget "$tmp/s2" register registered)" = "2" ] || fail "register.registered should be 2 (target-artifact unit)"
 [ "$(jget "$tmp/s2" register unsupported)" = "0" ] || fail "register.unsupported should be present and 0"
 [ "$(jget "$tmp/s2" sync_targets 0 state)" = '"missing"' ] || fail "target should be missing"
@@ -73,6 +73,17 @@ run_status > "$tmp/s2" 2>&1
 run_status > "$tmp/s3" 2>&1
 [ "$(jget "$tmp/s3" sync_targets 0 state)" = '"managed"' ] || fail "target should be managed"
 [ "$(jget "$tmp/s3" sync_targets 1 state)" = '"managed"' ] || fail "both targets should be managed"
+
+# --- case 3b: managed でも register 後に manifest を変えたら target は stale (#148) ---
+# (source 不変で managed のままでも、登録判断が古いと再 register が要る = stale 表示)
+printf '\nsummary: demo workflow (edited)\n' >> "$tmp/repo/shared/workflows/personal-demo.asset.yml"
+run_status > "$tmp/s3b" 2>&1
+[ "$(jget "$tmp/s3b" sync_targets 0 state)" = '"stale"' ] \
+  || fail "manifest change should make managed target stale: $(cat "$tmp/s3b")"
+"$script_dir/../register.sh" --root "$tmp/repo" --quiet > /dev/null   # 元の状態へ (再 register で fresh)
+run_status > "$tmp/s3c" 2>&1
+[ "$(jget "$tmp/s3c" sync_targets 0 state)" = '"managed"' ] \
+  || fail "re-register should restore managed: $(cat "$tmp/s3c")"
 
 # --- case 4: source 変更で generated.stale と target stale が出る ---
 cat > "$tmp/repo/shared/workflows/personal-demo.md" <<'EOF'

--- a/scripts/tests/status-test.sh
+++ b/scripts/tests/status-test.sh
@@ -197,7 +197,10 @@ rm -f "$tmp/irepo/shared/instructions/personal-ops.md"
 # --- case 13: script の generated も generated.total に数え、sync_target を報告する ---
 mkdir -p "$tmp/screpo/shared/scripts" "$tmp/sccodex" "$tmp/scclaude"
 printf '#!/bin/sh\necho hi\n' > "$tmp/screpo/shared/scripts/personal-wrap.sh"
-cat > "$tmp/screpo/shared/scripts/personal-wrap.asset.yml" <<'EOF'
+# script kind は human review 必須 (#147) + 承認は内容に紐づく (#148)。
+scbid=$(ruby -r"$script_dir/../lib/build" \
+  -e 'puts Build.build_id_for(ARGV[0], "shared/scripts/personal-wrap.sh", "text")' "$tmp/screpo")
+cat > "$tmp/screpo/shared/scripts/personal-wrap.asset.yml" <<EOF
 schema_version: 1
 name: personal-wrap
 kind: script
@@ -207,9 +210,9 @@ targets:
 risk:
   prompt_injection: low
   privacy: low
-# script kind は human review 必須 (#147)。fixture は approved 前提で registered を得る。
 review:
   human_review: approved
+  approved_build_id: $scbid
 source:
   path: shared/scripts/personal-wrap.sh
   format: text

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -275,7 +275,12 @@ grep -q "conflict: \[codex\].*symlink" "$tmp/out-skparent" || fail "missing skil
 # --- case 15: script artifact を <home>/agent-tools/scripts/ に配置する ---
 mkdir -p "$tmp/srepo15/shared/scripts" "$tmp/scodex15" "$tmp/sclaude15"
 printf '#!/bin/sh\necho v1\n' > "$tmp/srepo15/shared/scripts/personal-wrap.sh"
-cat > "$tmp/srepo15/shared/scripts/personal-wrap.asset.yml" <<'EOF'
+# script kind は human review 必須 (#147) + 承認は内容に紐づく (#148)。
+# source を書き換える case (v2/v3) の前に呼び直し、現内容で approved を焼き直す。
+write_wrap_manifest() {
+  wrapbid=$(ruby -r"$script_dir/../lib/build" \
+    -e 'puts Build.build_id_for(ARGV[0], "shared/scripts/personal-wrap.sh", "text")' "$tmp/srepo15")
+  cat > "$tmp/srepo15/shared/scripts/personal-wrap.asset.yml" <<EOF
 schema_version: 1
 name: personal-wrap
 kind: script
@@ -286,13 +291,15 @@ targets:
 risk:
   prompt_injection: low
   privacy: low
-# script kind は human review 必須 (#147)。fixture は approved 前提で registered を得る。
 review:
   human_review: approved
+  approved_build_id: $wrapbid
 source:
   path: shared/scripts/personal-wrap.sh
   format: text
 EOF
+}
+write_wrap_manifest
 run15() { "$sync" --root "$tmp/srepo15" --codex-home "$tmp/scodex15" --claude-home "$tmp/sclaude15" "$@"; }
 "$build" --root "$tmp/srepo15" --quiet > /dev/null
 "$register" --root "$tmp/srepo15" --quiet > /dev/null
@@ -315,8 +322,9 @@ grep -q "echo v1" "$deployed" || fail "deployed script body wrong"
 run15 > "$tmp/out15-skip" 2>&1 || fail "script skip run should succeed"
 grep -q "skip: \[claude-code\].*up-to-date" "$tmp/out15-skip" || fail "missing script up-to-date skip: $(cat "$tmp/out15-skip")"
 
-# source 変更で update → apply で反映
+# source 変更で update → apply で反映 (内容変更につき approved_build_id も焼き直す)
 printf '#!/bin/sh\necho v2\n' > "$tmp/srepo15/shared/scripts/personal-wrap.sh"
+write_wrap_manifest
 "$build" --root "$tmp/srepo15" --quiet > /dev/null
 "$register" --root "$tmp/srepo15" --quiet > /dev/null
 run15 > "$tmp/out15-upd" 2>&1 || fail "script update dry-run should succeed"
@@ -326,6 +334,7 @@ grep -q "echo v2" "$deployed" || fail "script update not applied"
 
 # --- case 16: catalog の build_id と generated が不一致なら run build first (stale generated) ---
 printf '#!/bin/sh\necho v3\n' > "$tmp/srepo15/shared/scripts/personal-wrap.sh"
+write_wrap_manifest
 "$register" --root "$tmp/srepo15" --quiet > /dev/null   # build せず register だけ
 run15 > "$tmp/out16" 2>&1 || fail "stale script dry-run should succeed"
 grep -q "skip: \[claude-code\].*run build first" "$tmp/out16" \
@@ -365,5 +374,36 @@ run15 --apply > "$tmp/out19" 2>&1 || status=$?
 grep -q "conflict: \[claude-code\].*symlink" "$tmp/out19" || fail "missing sidecar symlink conflict: $(cat "$tmp/out19")"
 [ ! -e "$tmp/realmarker/stolen.yml" ] || fail "must not write through symlinked sidecar marker"
 [ ! -e "$deployed" ] || fail "script body must not be created when sidecar is unsafe"
+
+# --- case 20: register 後に manifest が変わった entry は配置せず register を促す (#148) ---
+# (登録判断 (risk / review / targets) は manifest 依存。判断ごと stale なので fail-closed に skip)
+mkdir -p "$tmp/mrepo/shared/workflows" "$tmp/mcodex" "$tmp/mclaude"
+printf '# demo\n' > "$tmp/mrepo/shared/workflows/personal-mdemo.md"
+cat > "$tmp/mrepo/shared/workflows/personal-mdemo.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-mdemo
+kind: workflow
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/workflows/personal-mdemo.md
+  format: markdown
+EOF
+run20() { "$sync" --root "$tmp/mrepo" --codex-home "$tmp/mcodex" --claude-home "$tmp/mclaude" "$@"; }
+"$build" --root "$tmp/mrepo" --quiet > /dev/null
+"$register" --root "$tmp/mrepo" --quiet > /dev/null
+run20 > "$tmp/out20a" 2>&1 || fail "fresh manifest sync should succeed: $(cat "$tmp/out20a")"
+grep -q "create: \[claude-code\]" "$tmp/out20a" || fail "fresh manifest should plan create: $(cat "$tmp/out20a")"
+echo "# edited after register" >> "$tmp/mrepo/shared/workflows/personal-mdemo.asset.yml"
+status=0
+run20 --apply > "$tmp/out20b" 2>&1 || status=$?
+[ "$status" -eq 0 ] || fail "manifest-stale sync should exit 0 (skip): $(cat "$tmp/out20b")"
+grep -q "skip: \[claude-code\].*manifest changed; run scripts/register.sh first" "$tmp/out20b" \
+  || fail "missing manifest-stale skip reason: $(cat "$tmp/out20b")"
+[ ! -e "$tmp/mclaude/skills/personal-mdemo" ] || fail "manifest-stale entry must not be deployed"
 
 echo "ok: sync self-test passed"

--- a/shared/scripts/personal-safe-gh-hook.asset.yml
+++ b/shared/scripts/personal-safe-gh-hook.asset.yml
@@ -10,8 +10,10 @@ risk:
   privacy: low
 # script kind は実行コード配布のため常に human review 必須 (#147)。
 # 本 script は PR #136 で author≠reviewer レビュー済み・承認。
+# 承認は内容に紐づく (#148)。source 変更時は再レビューして approved_build_id を更新する。
 review:
   human_review: approved
+  approved_build_id: sha256:2ac81a3fd68f
 source:
   path: shared/scripts/personal-safe-gh-hook.rb
   format: text

--- a/shared/scripts/personal-safe-gh.asset.yml
+++ b/shared/scripts/personal-safe-gh.asset.yml
@@ -9,9 +9,11 @@ risk:
   prompt_injection: low
   privacy: low
 # script kind は実行コード配布のため常に human review 必須 (#147)。
-# 本 script は PR #135 / #141 で author≠reviewer レビュー済み・承認。
+# 本 script は PR #135 / #141 / #156 で author≠reviewer レビュー済み・承認。
+# 承認は内容に紐づく (#148)。source 変更時は再レビューして approved_build_id を更新する。
 review:
   human_review: approved
+  approved_build_id: sha256:15150e131602
 source:
   path: shared/scripts/personal-safe-gh.rb
   format: text

--- a/shared/skills/personal-asset-miner/asset.yml
+++ b/shared/skills/personal-asset-miner/asset.yml
@@ -22,7 +22,9 @@ review:
   # runtime-state (medium): SKILL.md が ~/.claude/projects ・ ~/.codex/sessions を
   # 参照するため検出される。この skill はセッションログを読むのが目的で、auth/config/
   # runtime state を変更しない read-only の正当な参照。人間レビューで承認 (#86)。
+  # 承認は内容に紐づく (#148)。source 変更時は再レビューして approved_build_id を更新する。
   human_review: approved
+  approved_build_id: sha256:d1cec48ac836
 compatibility:
   codex:
     artifact_kind: skill


### PR DESCRIPTION
Closes #148 (2026-07-02 全体アーキテクチャ監査 follow-up。Codex 独立レビューと収束した所見 2 件)。

## 変更 (catalog_version 2 → 3)

### 1. catalog の鮮度判定に manifest を含める

catalog の build_id は source content のみ由来で、manifest 側の登録条件 (risk / review / targets) を変えても catalog は fresh のままだった。register が manifest file bytes の SHA256 を entry (`manifest_path` / `manifest_digest`) に記録し:

- **sync**: 不一致 entry は配置せず `manifest changed; run scripts/register.sh first` で skip (fail-closed。旧 catalog の digest 欠落も同様)
- **doctor**: `manifest changed since register` の stale warn
- digest 計算は `Assets.manifest_digest` に一元化 (register と reader で割れない)

### 2. 承認を内容 (build_id) に紐づける

`human_review: approved` が finding/内容に紐づかない永続承認で、承認後に source が全面的に変わっても registered のまま残った。`review.approved_build_id` (承認時点の build_id) が現在の build_id と一致するときだけ承認が効く。不一致は human_review_required に戻し、register が現在の build_id を警告表示して再レビューを促す。check-manifests が形式 (`sha256:` + 12 hex) と approved との対を検証。

#147 で script artifact が human review 必須になったため、この紐づけで script の承認も steering から実質 hard へ格上げされる。

### 移行

既存 approved 資産 3 本 (personal-safe-gh / personal-safe-gh-hook / personal-asset-miner) に現在の build_id で `approved_build_id` を明記 (それぞれ PR #135/#136/#141/#156、#86 でレビュー済みの内容)。

### scope 外 (明示)

connect には digest 検査を入れていない。issue scope が sync / doctor で、connect の gate は registration + marker 照合、配置内容の更新は sync 経由のため。必要なら follow-up。

## 検証

- self-test 12 本全 pass (register に case 4b/4c: 承認の digest 欠落・失効 / sync case 20 / doctor manifest-stale / check-manifests 検証 2 種を追加)
- repo 本体 end-to-end: build → register (exit 0) → sync dry-run (0 changes) → doctor `catalog: present, 15 asset(s), fresh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5PTZ6xXKXAvuUQMTYecrM