### PR TITLE
fix: correctness の機械的 fix 6 件 (#149 の論点なし分)

### DIFF
--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -236,6 +236,9 @@ target tool ごとの変換 hint です。
 `compatibility.<tool>.artifact_kind` で、その tool 向けに生成する artifact の種類を
 明示できます。未指定なら asset の `kind` から既定値が導出されます (`instruction` kind は
 instruction、`script` kind は script、`skill` / `prompt` / `workflow` / `template` は skill)。
+tool キーは初期 target (`codex` / `claude-code`)、`artifact_kind` は build 対応 kind
+(`skill` / `instruction` / `script`) に限られ、check-manifests が検証します (typo は
+silent に unsupported へ落とさず error にする)。
 
 build が対応する artifact_kind は `skill` / `instruction` / `script` です。いずれも build →
 register → sync で配置されます (instruction の所有確立は connect が担当)。

--- a/scripts/lib/assets.rb
+++ b/scripts/lib/assets.rb
@@ -26,10 +26,14 @@ module Assets
     false
   end
   # sidecar manifest と directory manifest を sort して返す (絶対 path)。
+  # glob は `foo.asset.yml` という名前の directory にもマッチしうるため、File.read で
+  # EISDIR を踏まないよう file だけに絞る (directory manifest は File.file? で残る)。
   def self.manifest_paths(root)
     root = File.expand_path(root)
     (Dir.glob(File.join(root, "shared/**/*.asset.yml")) +
-     Dir.glob(File.join(root, "shared/**/asset.yml"))).sort
+     Dir.glob(File.join(root, "shared/**/asset.yml")))
+      .select { |p| File.file?(p) }
+      .sort
   end
 
   # すべての asset を正規化した hash で返す。

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -277,7 +277,7 @@ module Build
       # copy (copy_directory_asset は Dir.children + cp_r で dotfile も配る) と揃えるため
       # FNM_DOTMATCH で dotfile も hash に含める。含めないと dotfile だけ変えた更新が
       # build_id 不変となり sync が up-to-date で skip し、永久に配布されない。
-      # `.` / `..` は `**/*` が返さず、File.file? が非ファイルを弾く。
+      # FNM_DOTMATCH では `.` 等の dir entry も返りうるが、File.file? が非ファイルを弾く。
       Dir.glob(File.join(src_dir, "**/*"), File::FNM_DOTMATCH).sort.each do |f|
         next unless File.file?(f)
         # copy と同じく、manifest として除外するのは top-level の asset.yml のみ。

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -185,7 +185,10 @@ module Build
           case ArtifactTargets.resolve(asset, tool)
           when "instruction" then instruction_expected[tool] = true
           when "script" then script_expected[tool] << asset[:name]
-          else expected[tool] << asset[:name]
+          when "skill" then expected[tool] << asset[:name]
+          # unsupported は build しないので期待リストに入れない。else で skill 扱いすると
+          # kind 変更 (skill→agent 等) 後の stale な generated/<tool>/skills/<name> が
+          # prune 保護されて残ってしまう。
           end
         end
       end
@@ -271,7 +274,11 @@ module Build
       # 相対 path 計算 (evals 除外) が末尾スラッシュで壊れないよう正規化する。
       src_dir = File.join(root, source).chomp("/")
       digest = Digest::SHA256.new
-      Dir.glob(File.join(src_dir, "**/*")).sort.each do |f|
+      # copy (copy_directory_asset は Dir.children + cp_r で dotfile も配る) と揃えるため
+      # FNM_DOTMATCH で dotfile も hash に含める。含めないと dotfile だけ変えた更新が
+      # build_id 不変となり sync が up-to-date で skip し、永久に配布されない。
+      # `.` / `..` は `**/*` が返さず、File.file? が非ファイルを弾く。
+      Dir.glob(File.join(src_dir, "**/*"), File::FNM_DOTMATCH).sort.each do |f|
         next unless File.file?(f)
         # copy と同じく、manifest として除外するのは top-level の asset.yml のみ。
         next if f == File.join(src_dir, "asset.yml")

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -102,8 +102,36 @@ module CheckManifests
       validate_risk(path, data["risk"]) if data.key?("risk")
       validate_source(path, data["source"]) if data.key?("source")
       validate_review(path, data["review"]) if data.key?("review")
+      validate_compatibility(path, data["compatibility"]) if data.key?("compatibility")
       validate_text_field(path, "summary", data["summary"]) if data.key?("summary")
       validate_text_field(path, "description", data["description"]) if data.key?("description")
+    end
+
+    # compatibility は { <tool> => { "artifact_kind" => <kind> } }。無検証だと typo
+    # (artifact_kind: skil など) が silent に unsupported へ落ち、配布されない原因に人間が
+    # 気づけない (gate の fail-closed 方針に反する)。キーと値を厳密に検証する。
+    def validate_compatibility(path, value)
+      unless value.is_a?(Hash)
+        error(path, "compatibility must be a mapping")
+        return
+      end
+      value.each do |tool, entry|
+        error(path, "compatibility has unknown tool: #{tool}") unless TARGETS.include?(tool)
+        unless entry.is_a?(Hash)
+          error(path, "compatibility.#{tool} must be a mapping")
+          next
+        end
+        (entry.keys - %w[artifact_kind]).each do |key|
+          error(path, "compatibility.#{tool} has unknown key: #{key}")
+        end
+        next unless entry.key?("artifact_kind")
+
+        kind = entry["artifact_kind"]
+        unless ArtifactTargets::SUPPORTED_KINDS.include?(kind)
+          error(path, "compatibility.#{tool}.artifact_kind must be one of " \
+                      "#{ArtifactTargets::SUPPORTED_KINDS.join(', ')}, got #{kind.inspect}")
+        end
+      end
     end
 
     def validate_schema_version(path, value)

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -504,4 +504,43 @@ crlf_skill="$tmp/crlf/generated/claude-code/skills/personal-crlf/SKILL.md"
 fm_count=$(grep -c -- '^---' "$crlf_skill" || true)
 [ "$fm_count" = "2" ] || fail "CRLF frontmatter must not be duplicated (got $fm_count '---' lines): $(cat "$crlf_skill")"
 
+# --- case: directory asset 内の dotfile が build_id に反映され、配置もされる (#149) ---
+# (FNM_DOTMATCH 無しだと dotfile 変更が build_id 不変 → 永久に未配布になる回帰)
+mkdir -p "$tmp/dot/shared/skills/personal-dot/references"
+cat > "$tmp/dot/shared/skills/personal-dot/SKILL.md" <<'EOF'
+---
+name: personal-dot
+description: dotfile build_id regression
+---
+
+# dot skill
+EOF
+printf 'v1\n' > "$tmp/dot/shared/skills/personal-dot/references/.hidden.md"
+cat > "$tmp/dot/shared/skills/personal-dot/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-dot
+kind: skill
+visibility: personal
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/skills/personal-dot
+  format: directory
+EOF
+dotmarker="$tmp/dot/generated/claude-code/skills/personal-dot/.agent-tools-managed.yml"
+"$build" --root "$tmp/dot" --quiet > /dev/null 2>&1 || fail "dot skill build should pass"
+bid_before=$(grep build_id "$dotmarker")
+# dotfile が配置されている
+[ -f "$tmp/dot/generated/claude-code/skills/personal-dot/references/.hidden.md" ] \
+  || fail "dotfile should be deployed into generated skill"
+# dotfile だけ変更 → build_id が変わる (FNM_DOTMATCH で hash に含まれるため)
+printf 'v2-changed\n' > "$tmp/dot/shared/skills/personal-dot/references/.hidden.md"
+"$build" --root "$tmp/dot" --quiet > /dev/null 2>&1 || fail "dot skill rebuild should pass"
+bid_after=$(grep build_id "$dotmarker")
+[ "$bid_before" != "$bid_after" ] \
+  || fail "dotfile change must change build_id (else update never syncs): $bid_before"
+
 echo "ok: build self-test passed"

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -419,6 +419,36 @@ grep -q "approved_build_id must be a build_id" "$tmp/out-abid" \
 grep -q "approved_build_id requires review.human_review: approved" "$tmp/out-abid" \
   || fail "expected approved-pairing error: $(cat "$tmp/out-abid")"
 
+# --- case: compatibility フィールドの検証 (#149)。typo / 不明 tool / 型不正を reject ---
+mkdir -p "$tmp/compat/shared/workflows"
+echo "# demo" > "$tmp/compat/shared/workflows/personal-compat.md"
+cat > "$tmp/compat/shared/workflows/personal-compat.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-compat
+kind: workflow
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+compatibility:
+  claude-code:
+    artifact_kind: skil
+  bogus-tool:
+    artifact_kind: skill
+source:
+  path: shared/workflows/personal-compat.md
+  format: markdown
+EOF
+if "$check" --root "$tmp/compat" > "$tmp/out-compat" 2>&1; then
+  fail "check-manifests must reject invalid compatibility"
+fi
+grep -q "artifact_kind must be one of" "$tmp/out-compat" \
+  || fail "expected artifact_kind typo error: $(cat "$tmp/out-compat")"
+grep -q "compatibility has unknown tool: bogus-tool" "$tmp/out-compat" \
+  || fail "expected unknown-tool error: $(cat "$tmp/out-compat")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/safe-gh-test.sh
+++ b/scripts/tests/safe-gh-test.sh
@@ -156,6 +156,19 @@ check("non-numeric id kept (fail-closed)", SafeGh.classify({ "login" => "me", "i
 # 存在しない file は nil (file パス単体)
 check("self_identity file missing -> nil", SafeGh.self_identity_from_file({ "SAFE_GH_TRUST_FILE" => "#{trust_file}.nope" }).nil?)
 
+# ---- pagination: --slurp 出力 (array-of-pages) を flatten して全件返す ----
+# gh_capture を stub して 2 ページ分 (--slurp 形式 [[..],[..]]) を返す。
+module SafeGh
+  def self.gh_capture(args)
+    raise "expected --paginate --slurp for comments" unless args.include?("--slurp") && args.include?("--paginate")
+    ['[[{"user":{"login":"me","id":1},"body":"c1"}],[{"user":{"login":"me","id":1},"body":"c2"}]]', true]
+  end
+end
+paged = SafeGh.fetch_comments("o/r", 5)
+check("paginated comments flattened to 2", paged.length == 2)
+check("paginated first comment body", paged[0]["body"] == "c1")
+check("paginated second comment body", paged[1]["body"] == "c2")
+
 # ---- 引数バリデーション ----
 check("valid invocation", SafeGh.valid_invocation?("issue", "view", "12"))
 check("invalid number", !SafeGh.valid_invocation?("issue", "view", "abc"))

--- a/scripts/tests/safe-gh-test.sh
+++ b/scripts/tests/safe-gh-test.sh
@@ -144,6 +144,15 @@ check("no excluded -> count 0", env["excluded_comments_count"] == 0)
 ident = SafeGh.self_identity(env: { "SAFE_GH_TRUST_FILE" => trust_file })
 check("self_identity from file login", ident && ident["login"] == "owner-login")
 check("self_identity from file id", ident && ident["id"] == 4242)
+
+# ---- id 正規化: trust file に文字列 id を書いても integer 比較で self になる ----
+str_id = SafeGh.normalize_identity({ "login" => "me", "id" => "1" })
+check("string id normalized to integer", str_id["id"] == 1)
+check("self by normalized string id", SafeGh.classify({ "login" => "me", "id" => 1 }, str_id) == "self")
+check("integer id passthrough", SafeGh.normalize_identity({ "login" => "me", "id" => 1 })["id"] == 1)
+# 非数値 id はそのまま (integer と一致せず fail-closed)
+weird = SafeGh.normalize_identity({ "login" => "me", "id" => "abc" })
+check("non-numeric id kept (fail-closed)", SafeGh.classify({ "login" => "me", "id" => 1 }, weird) == "other")
 # 存在しない file は nil (file パス単体)
 check("self_identity file missing -> nil", SafeGh.self_identity_from_file({ "SAFE_GH_TRUST_FILE" => "#{trust_file}.nope" }).nil?)
 

--- a/shared/scripts/personal-safe-gh.asset.yml
+++ b/shared/scripts/personal-safe-gh.asset.yml
@@ -9,11 +9,11 @@ risk:
   prompt_injection: low
   privacy: low
 # script kind は実行コード配布のため常に human review 必須 (#147)。
-# 本 script は PR #135 / #141 / #156 で author≠reviewer レビュー済み・承認。
+# 本 script は PR #135 / #141 / #156 / #160 で author≠reviewer レビュー済み・承認。
 # 承認は内容に紐づく (#148)。source 変更時は再レビューして approved_build_id を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:15150e131602
+  approved_build_id: sha256:c44a080a596f
 source:
   path: shared/scripts/personal-safe-gh.rb
   format: text

--- a/shared/scripts/personal-safe-gh.asset.yml
+++ b/shared/scripts/personal-safe-gh.asset.yml
@@ -13,7 +13,7 @@ risk:
 # 承認は内容に紐づく (#148)。source 変更時は再レビューして approved_build_id を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:c44a080a596f
+  approved_build_id: sha256:35cdec4f7860
 source:
   path: shared/scripts/personal-safe-gh.rb
   format: text

--- a/shared/scripts/personal-safe-gh.rb
+++ b/shared/scripts/personal-safe-gh.rb
@@ -175,7 +175,20 @@ module SafeGh
     return nil unless data.is_a?(Hash)
     return nil if data["login"].nil? && data["id"].nil?
 
-    { "login" => data["login"], "id" => data["id"] }
+    # id は GitHub API では integer。trust file に文字列 "12345" で書かれても integer 比較で
+    # 一致するよう正規化する (不一致だと自分の投稿まで恒久 untrusted に化ける)。
+    { "login" => data["login"], "id" => normalize_id(data["id"]) }
+  end
+
+  # numeric id を Integer に正規化する。integer / 数字文字列は Integer 化、nil は nil、
+  # 非数値はそのまま返す (integer と一致せず fail-closed のまま)。
+  def normalize_id(id)
+    return nil if id.nil?
+    return id if id.is_a?(Integer)
+
+    Integer(id.to_s, 10)
+  rescue ArgumentError, TypeError
+    id
   end
 
   def parse_json(text)
@@ -192,9 +205,14 @@ module SafeGh
   end
 
   # gh REST を叩いて JSON を返す。失敗 (network/auth/not found) は Error。安全側に倒すため
-  # 部分的な envelope は作らず止める。
-  def gh_api(path)
-    out, ok = gh_capture(["api", path])
+  # 部分的な envelope は作らず止める。paginate=true のとき --paginate を付け、配列を返す
+  # list endpoint (comments 等) の全ページを 1 つの JSON 配列にまとめて取得する
+  # (30 件で切れると excluded count が過少になり自分の comment 本文も落ちる)。
+  def gh_api(path, paginate: false)
+    args = ["api"]
+    args << "--paginate" if paginate
+    args << path
+    out, ok = gh_capture(args)
     raise Error, "gh api #{path} failed (gh が未認証 / network / 対象が存在しない可能性)" unless ok
 
     parse_json(out) || raise(Error, "gh api #{path} returned invalid JSON")
@@ -222,7 +240,7 @@ module SafeGh
   end
 
   def fetch_comments(repo, number)
-    gh_api("repos/#{repo}/issues/#{number}/comments")
+    gh_api("repos/#{repo}/issues/#{number}/comments", paginate: true)
   end
 
   # ---- entrypoint ------------------------------------------------------------

--- a/shared/scripts/personal-safe-gh.rb
+++ b/shared/scripts/personal-safe-gh.rb
@@ -205,17 +205,22 @@ module SafeGh
   end
 
   # gh REST を叩いて JSON を返す。失敗 (network/auth/not found) は Error。安全側に倒すため
-  # 部分的な envelope は作らず止める。paginate=true のとき --paginate を付け、配列を返す
-  # list endpoint (comments 等) の全ページを 1 つの JSON 配列にまとめて取得する
-  # (30 件で切れると excluded count が過少になり自分の comment 本文も落ちる)。
+  # 部分的な envelope は作らず止める。
+  #
+  # paginate=true は配列を返す list endpoint (comments 等) の全ページを取得する
+  # (30 件で切れると excluded count が過少になり自分の comment 本文も落ちる)。plain
+  # `--paginate` は array endpoint でページ境界に `][` を挟み単一 JSON として不正になり得る
+  # ため、`--slurp` で各ページを 1 要素とする配列にまとめ、flatten(1) で平坦化する
+  # (single page でも `[[...]]` を平坦化するので結果は常に flat な配列)。
   def gh_api(path, paginate: false)
     args = ["api"]
-    args << "--paginate" if paginate
+    args += ["--paginate", "--slurp"] if paginate
     args << path
     out, ok = gh_capture(args)
     raise Error, "gh api #{path} failed (gh が未認証 / network / 対象が存在しない可能性)" unless ok
 
-    parse_json(out) || raise(Error, "gh api #{path} returned invalid JSON")
+    data = parse_json(out) || raise(Error, "gh api #{path} returned invalid JSON")
+    paginate ? data.flatten(1) : data
   end
 
   # owner/repo を解決する。-R で明示されていればそれを、無ければ現在の repo を gh から引く。


### PR DESCRIPTION
#149 (2026-07-02 監査の correctness) のうち、**fail-closed が自明な機械的 fix のみ**を先行。論点のある 2 件は #149 に残す。

## 修正 (medium 3 + low 3)

| # | 穴 | 修正 |
|---|---|---|
| medium | directory asset の dotfile が build_id に入らず、dotfile 変更が永久に未配布 | `build_id_for` に `FNM_DOTMATCH` (copy と揃える) |
| medium | safe-gh コメントが 31 件目以降を黙って欠落 (excluded count 過少・自分の本文も落ちる) | `gh api --paginate` |
| medium | `compatibility` 無検証で typo/不明 tool が silent に unsupported へ | `validate_compatibility` を追加 |
| low | `foo.asset.yml` 名の directory で `File.read` が EISDIR crash | `manifest_paths` を `File.file?` で絞る |
| low | `build --prune` の else が unsupported を skill 扱い → kind 変更後の stale が残る | `when "skill"` を明示 |
| low | trust file の文字列 id が integer 比較で不一致 → 自分の投稿が untrusted 化 | `normalize_id` で Integer 化 |

## #148 との連動

safe-gh の source 変更で build_id が変わるため、`approved_build_id` を新値に更新 (承認の内容紐づけ)。現在 dotfile を持つ directory asset は無いため build_id_for 変更で既存 asset の hash は動かない。

## #149 に残す (論点あり)

- sync の plan→apply 間 TOCTOU の再検証 — 個人ツールで同時実行前提が薄く、複雑化に見合うかの判断
- 拡張子違い同名 source の sidecar 相乗り検出 — 検証メソッドの書き換え + テスト互換性の判断

## 検証

- self-test 12 本 pass (dotfile build_id 回帰 / compatibility 検証 / id 正規化を追加)
- repo register exit 0 (safe-gh の approved_build_id 一致を確認)
- pagination は実機のみ (safe-gh の gh 呼び出しは 実機手動検証。純ロジックは fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5PTZ6xXKXAvuUQMTYecrM