### PR TITLE
test: false-green ギャップと CI 運用の堅牢化 (#150 の論点なし分)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   self-tests:
     runs-on: macos-latest
+    timeout-minutes: 15
     steps:
       # 外部 action は full commit SHA で pin する (タグ移動による差し替え対策)。
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -23,10 +24,13 @@ jobs:
 
       - name: Run self-tests
         run: |
+          # 最初の失敗で止めず全 test を走らせ、1 回の CI で全失敗を可視化する。
+          failed=0
           for t in scripts/tests/*.sh; do
             echo "--- $t"
-            "$t"
+            "$t" || { echo "FAIL: $t"; failed=1; }
           done
+          exit "$failed"
 
       - name: Check repository assets
         run: |
@@ -39,5 +43,9 @@ jobs:
         run: |
           scripts/build.sh
           scripts/register.sh
-          scripts/status.sh --json
-          scripts/doctor.sh
+          # status / doctor は runner の実 ~/.codex 等を読まないよう空 home を渡す
+          # (環境依存の結果を避ける。CI では build/register の健全性だけ見る)。
+          homes="$RUNNER_TEMP/emptyhomes"
+          mkdir -p "$homes/codex" "$homes/claude" "$homes/agents"
+          scripts/status.sh --json --codex-home "$homes/codex" --claude-home "$homes/claude"
+          scripts/doctor.sh --codex-home "$homes/codex" --claude-home "$homes/claude" --agents-home "$homes/agents"

--- a/scripts/tests/check-injection-test.sh
+++ b/scripts/tests/check-injection-test.sh
@@ -54,7 +54,7 @@ grep -q "personal-evil.md:1:" "$tmp/out-high" \
 
 # --- case 3: medium のみは exit 3 (human review required) ---
 mkdir -p "$tmp/medium/shared/instructions"
-printf 'normal text with hidden\xe2\x80\x8bmarker inside\n' \
+printf 'normal text with hidden\342\200\213marker inside\n' \
   > "$tmp/medium/shared/instructions/personal-hidden.md"
 
 status=0

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -449,6 +449,76 @@ grep -q "artifact_kind must be one of" "$tmp/out-compat" \
 grep -q "compatibility has unknown tool: bogus-tool" "$tmp/out-compat" \
   || fail "expected unknown-tool error: $(cat "$tmp/out-compat")"
 
+# --- case: source.path の path traversal を拒否する (shared/ 脱出防止の要, #150) ---
+# 絶対 path
+mkdir -p "$tmp/abs/shared/workflows"
+echo "# x" > "$tmp/abs/shared/workflows/personal-abs.md"
+cat > "$tmp/abs/shared/workflows/personal-abs.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-abs
+kind: workflow
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: /etc/passwd
+  format: markdown
+EOF
+if "$check" --root "$tmp/abs" > "$tmp/out-abs" 2>&1; then
+  fail "check-manifests must reject an absolute source.path"
+fi
+grep -q "source.path must be relative" "$tmp/out-abs" \
+  || fail "expected absolute-path rejection: $(cat "$tmp/out-abs")"
+
+# .. を含む相対 path
+mkdir -p "$tmp/dotdot/shared/workflows"
+echo "# x" > "$tmp/dotdot/shared/workflows/personal-dd.md"
+cat > "$tmp/dotdot/shared/workflows/personal-dd.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-dd
+kind: workflow
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/../../etc/secret
+  format: markdown
+EOF
+if "$check" --root "$tmp/dotdot" > "$tmp/out-dd" 2>&1; then
+  fail "check-manifests must reject a '..' source.path"
+fi
+grep -q "source.path must not contain '..'" "$tmp/out-dd" \
+  || fail "expected dotdot rejection: $(cat "$tmp/out-dd")"
+
+# shared/ 外
+mkdir -p "$tmp/outside/shared/workflows"
+echo "# x" > "$tmp/outside/shared/workflows/personal-out.md"
+cat > "$tmp/outside/shared/workflows/personal-out.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-out
+kind: workflow
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: docs/secret.md
+  format: markdown
+EOF
+if "$check" --root "$tmp/outside" > "$tmp/out-outside" 2>&1; then
+  fail "check-manifests must reject a source.path outside shared/"
+fi
+grep -q "source.path must be under shared/" "$tmp/out-outside" \
+  || fail "expected outside-shared rejection: $(cat "$tmp/out-outside")"
+
 # --- case 5: repository 本体の manifest が pass する ---
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \

--- a/scripts/tests/register-test.sh
+++ b/scripts/tests/register-test.sh
@@ -70,7 +70,7 @@ jget "$catalog" assets 0 manifest_digest | grep -qE '"[0-9a-f]{64}"' \
 
 # --- case 3: medium finding + human_review なし → human_review_required, exit 3 ---
 mkdir -p "$tmp/medium/shared/workflows"
-printf '# demo with hidden\xe2\x80\x8bmarker\n' > "$tmp/medium/shared/workflows/personal-demo.md"
+printf '# demo with hidden\342\200\213marker\n' > "$tmp/medium/shared/workflows/personal-demo.md"
 write_manifest "$tmp/medium/shared/workflows"
 status=0
 "$register" --root "$tmp/medium" > "$tmp/r3" 2>&1 || status=$?
@@ -104,7 +104,7 @@ grep -q "approved_build_id does not match current build_id" "$tmp/r4b" \
 write_manifest "$tmp/medium/shared/workflows" "review:
   human_review: approved
   approved_build_id: $bid_medium"
-printf '# demo with hidden\xe2\x80\x8bmarker\nedited after approval\n' \
+printf '# demo with hidden\342\200\213marker\nedited after approval\n' \
   > "$tmp/medium/shared/workflows/personal-demo.md"
 status=0
 "$register" --root "$tmp/medium" > "$tmp/r4c" 2>&1 || status=$?
@@ -112,7 +112,7 @@ status=0
 [ "$(jget "$catalog" assets 0 registration)" = '"human_review_required"' ] \
   || fail "content change must invalidate approval"
 # 後続 case のために元の内容へ戻す
-printf '# demo with hidden\xe2\x80\x8bmarker\n' > "$tmp/medium/shared/workflows/personal-demo.md"
+printf '# demo with hidden\342\200\213marker\n' > "$tmp/medium/shared/workflows/personal-demo.md"
 
 # --- case 5: medium finding + rejected → fail, catalog 未更新 ---
 write_manifest "$tmp/medium/shared/workflows" "review:

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -406,4 +406,42 @@ grep -q "skip: \[claude-code\].*manifest changed; run scripts/register.sh first"
   || fail "missing manifest-stale skip reason: $(cat "$tmp/out20b")"
 [ ! -e "$tmp/mclaude/skills/personal-mdemo" ] || fail "manifest-stale entry must not be deployed"
 
+# --- case 21: 未レビュー (human_review_required) の asset は --apply でも配置しない (#150) ---
+# (register の review gate を sync が尊重すること。connect には同等テストがあるが sync に無かった)
+mkdir -p "$tmp/grepo/shared/skills/personal-gated" "$tmp/gcodex" "$tmp/gclaude"
+cat > "$tmp/grepo/shared/skills/personal-gated/SKILL.md" <<'EOF'
+---
+name: personal-gated
+description: pending review skill
+---
+
+# gated
+EOF
+cat > "$tmp/grepo/shared/skills/personal-gated/asset.yml" <<'EOF'
+schema_version: 1
+name: personal-gated
+kind: skill
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: medium
+  privacy: low
+source:
+  path: shared/skills/personal-gated
+  format: directory
+EOF
+run21() { "$sync" --root "$tmp/grepo" --codex-home "$tmp/gcodex" --claude-home "$tmp/gclaude" "$@"; }
+"$build" --root "$tmp/grepo" --quiet > /dev/null
+# 宣言 medium + 未承認 → register は human_review_required (exit 3, 非致命)
+status=0
+"$register" --root "$tmp/grepo" --quiet > /dev/null || status=$?
+[ "$status" -eq 3 ] || fail "pending skill should register as human_review_required (exit 3), got $status"
+status=0
+run21 --apply > "$tmp/out21" 2>&1 || status=$?
+[ "$status" -eq 0 ] || fail "sync of gated asset should exit 0 (skip): $(cat "$tmp/out21")"
+grep -q "skip: \[claude-code\].*human_review_required" "$tmp/out21" \
+  || fail "gated asset must skip with human_review_required reason: $(cat "$tmp/out21")"
+[ ! -e "$tmp/gclaude/skills/personal-gated" ] || fail "unreviewed asset must not be deployed"
+
 echo "ok: sync self-test passed"


### PR DESCRIPTION
#150 (2026-07-02 監査のテスト補強) のうち、**判断が要らないもの**を先行。論点のある項目は #150 に残す。

## 追加

- **sync review gate の未テスト** (sync-test case 21): 宣言 medium + 未承認 = `human_review_required` の asset を `--apply` しても配置せず skip することを assert。connect には同等テストがあったが sync に無く、gate 条件反転の regression を CI が捕まえられなかった。
- **path traversal reject の未テスト** (check-manifests-test): `source.path` の絶対 path / `..` / shared/ 外を reject することを assert (shared/ 脱出防止の要。symlink 側は既存テストあり)。
- **CI 堅牢化**:
  - self-test ループを最初の失敗で止めず全 test 実行 → 1 回の CI で全失敗を可視化
  - `timeout-minutes: 15` (hang 時の runner 消費抑制)
  - status / doctor step に空 home を渡し runner の実 `~/.codex` 等から隔離
- **printf の zero-width space を 8 進** (`\342\200\213`) に (POSIX 保証。`\xHH` は bash/zsh 拡張)

## #150 に残す (論点あり)

- self-test が実 repo の `generated/` / catalog を変異させる件 — 修正方針 (コメント明記 vs tmp コピー) の判断
- Ruby 3.x matrix 追加 — CI infra の判断
- 残りの reject 経路 (broken fixture 各種) の網羅

## 検証

- self-test 12 本 pass / check-manifests pass / workflow YAML 妥当
- コード変更なし (test と CI のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5PTZ6xXKXAvuUQMTYecrM