### PR TITLE
refactor: kind/tool 知識の小集約 (generated_path / catalog reader / reason code) (#152)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -159,6 +159,39 @@ usage: register.sh [--root DIR] [--quiet]
 - 書き込みは `generated/catalog.json` のみ。
 - self-test: `tests/register-test.sh`
 
+## artifact_kind / tool を追加するときのチェックリスト
+
+kind / tool の知識は `lib/artifact_targets.rb` に集約されているが (#152)、追加時に
+触る場所は 1 箇所ではない。取り残しが docs drift・サイレント断裂の原因になるので、
+追加 PR ではここを順に確認する。
+
+**artifact_kind を追加するとき**:
+
+1. `lib/artifact_targets.rb`: `SUPPORTED_KINDS` / `DEFAULT_BY_KIND` /
+   `GENERATED_SUBDIRS` / `generated_path` / `target_path` / `buildable?`。
+2. `lib/check_manifests.rb`: asset kind の列挙 `KINDS` (manifest の `kind` と
+   artifact_kind は別物。後者の検証は `ArtifactTargets.supported?` を参照済み)。
+3. `lib/build.rb`: `build_<kind>` の実装と `run` の分岐、`prune` の期待リスト。
+   marker 戦略は [Status / Manifest Contract](../docs/status-manifest-contract.md)
+   (directory = 直下 marker / 単一ファイル = sidecar / 本文コメント) に従う。
+4. `lib/sync.rb`: `plan_<kind>` の実装 (所有 / stale / symlink 防御を既存 kind と
+   対称に) と `apply` の分岐。
+5. `lib/status.rb`: `generated_state` の鮮度判定が新 kind の marker を読めるか。
+6. docs: この README の該当 script 節 /
+   [Asset Manifest Schema](../docs/asset-manifest-schema.md) /
+   [Register / Catalog](../docs/register-catalog.md) /
+   [Sync Policy](../docs/sync-policy.md) / [onboarding](../docs/onboarding.md)。
+7. tests: `tests/build-test.sh` / `sync-test.sh` / `status-test.sh` /
+   `register-test.sh` に既存 kind と対称のケースを足す。
+
+**tool を追加するとき** (v1 は 2 tool 固定。一元化は #152 low として将来):
+
+1. tool 一覧: `lib/build.rb` / `lib/sync.rb` の `TOOLS`、
+   `lib/check_manifests.rb` の `TARGETS`。
+2. homes 既定値と CLI flag: `sync` / `connect` / `status` / `doctor` の `main`。
+3. instruction を配るなら `ArtifactTargets::INSTRUCTION_FILENAMES` と connect の
+   所有戦略 (import 対応可否)。
+
 ## 予定している scripts
 
 - `check-injection.sh` への追加: optional LLM review (privacy preflight つき)。

--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -11,6 +11,9 @@ module ArtifactTargets
   # v3: entry に manifest_path / manifest_digest を追加 (登録判断の鮮度検出, #148)。
   CATALOG_VERSION = 3
 
+  # catalog の repo root 相対 path。register が書き、Catalog.read が読む (#152)。
+  CATALOG_PATH = "generated/catalog.json"
+
   # build が扱える artifact_kind。
   SUPPORTED_KINDS = %w[skill instruction script].freeze
 
@@ -81,6 +84,31 @@ module ArtifactTargets
       File.join(home, "agent-tools", "scripts", name)
     else
       File.join(home, "skills", name)
+    end
+  end
+
+  # generated/ 配下の artifact_kind 別出力 dir。
+  GENERATED_SUBDIRS = {
+    "skill" => "skills",
+    "instruction" => "instructions",
+    "script" => "scripts",
+  }.freeze
+
+  # generated/ 配下の kind 別出力 dir (build の出力先 / status・prune の glob 起点)。
+  def self.generated_dir(root, tool, kind)
+    File.join(root, "generated", tool, GENERATED_SUBDIRS.fetch(kind))
+  end
+
+  # generated 側の artifact path (target_path の生成側対称。path 解決の単一 source)。
+  # - instruction: tool 固有ファイル名 (INSTRUCTION_FILENAMES)。name は使わず、filename を
+  #   解決できない tool では nil (target_path と同じ契約)。
+  # - それ以外 (skill / script): <generated_dir>/<name>。
+  def self.generated_path(root, tool, name, kind)
+    if kind == "instruction"
+      filename = INSTRUCTION_FILENAMES[tool]
+      filename && File.join(generated_dir(root, tool, kind), filename)
+    else
+      File.join(generated_dir(root, tool, kind), name)
     end
   end
 

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -55,7 +55,7 @@ module Build
       name = asset[:name]
       source = asset[:source]["path"]
       format = asset[:source]["format"]
-      out_dir = File.join(@root, "generated", tool, "skills", name)
+      out_dir = ArtifactTargets.generated_path(@root, tool, name, "skill")
 
       FileUtils.rm_rf(out_dir)
       FileUtils.mkdir_p(out_dir)
@@ -76,8 +76,8 @@ module Build
     # codex: AGENTS.md) として生成する。所有 marker は HTML コメントで本体に埋める
     # (instruction は単一ファイル所有なので skill の dir sidecar marker が使えない)。
     def build_instruction(tool, asset)
-      filename = ArtifactTargets::INSTRUCTION_FILENAMES[tool]
-      unless filename
+      out = ArtifactTargets.generated_path(@root, tool, asset[:name], "instruction")
+      unless out
         @skipped << "#{asset[:manifest_path]}: instruction unsupported for #{tool}"
         return
       end
@@ -88,9 +88,7 @@ module Build
         return
       end
 
-      out_dir = File.join(@root, "generated", tool, "instructions")
-      FileUtils.mkdir_p(out_dir)
-      out = File.join(out_dir, filename)
+      FileUtils.mkdir_p(File.dirname(out))
       content = File.read(File.join(@root, source))
       build_id = Build.build_id_for(@root, source, format)
       File.write(out, instruction_with_marker(content, asset[:name], tool, source, build_id))
@@ -110,9 +108,8 @@ module Build
         return
       end
 
-      out_dir = File.join(@root, "generated", tool, "scripts")
-      FileUtils.mkdir_p(out_dir)
-      out = File.join(out_dir, name)
+      out = ArtifactTargets.generated_path(@root, tool, name, "script")
+      FileUtils.mkdir_p(File.dirname(out))
       FileUtils.cp(File.join(@root, source), out)
       File.chmod(0o755, out) # script は配置先で実行されるため実行可能にする
       build_id = Build.build_id_for(@root, source, format)
@@ -198,7 +195,7 @@ module Build
       TOOLS.each do |tool|
         # skill: manifest に対応しない generated directory を削除する。
         # (skill -> instruction 転換で残った stale skill もここで消える)
-        Dir.glob(File.join(@root, "generated", tool, "skills", "*")).sort.each do |dir|
+        Dir.glob(File.join(ArtifactTargets.generated_dir(@root, tool, "skill"), "*")).sort.each do |dir|
           next unless File.directory?(dir)
           next if expected[tool].include?(File.basename(dir))
 
@@ -212,7 +209,7 @@ module Build
 
         # script: manifest に対応しない managed script (と sidecar marker) を削除する。
         # sidecar marker file 自体は本体と一緒に処理するため列挙対象から外す。
-        Dir.glob(File.join(@root, "generated", tool, "scripts", "*")).sort.each do |path|
+        Dir.glob(File.join(ArtifactTargets.generated_dir(@root, tool, "script"), "*")).sort.each do |path|
           next unless File.file?(path)
           next if path.end_with?(ArtifactTargets::MARKER_BASENAME)
           next if script_expected[tool].include?(File.basename(path))
@@ -229,7 +226,7 @@ module Build
         # instruction: 期待する canonical ファイル (INSTRUCTION_FILENAMES) 以外の
         # marker 付きファイルを削除する。instruction asset が無ければ canonical も対象。
         keep = instruction_expected[tool] ? ArtifactTargets::INSTRUCTION_FILENAMES[tool] : nil
-        Dir.glob(File.join(@root, "generated", tool, "instructions", "*")).sort.each do |file|
+        Dir.glob(File.join(ArtifactTargets.generated_dir(@root, tool, "instruction"), "*")).sort.each do |file|
           next unless File.file?(file)
           next if keep && File.basename(file) == keep
 

--- a/scripts/lib/catalog.rb
+++ b/scripts/lib/catalog.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "artifact_targets"
+
+# generated/catalog.json の共有 reader。register が書き、sync / connect / status /
+# doctor が読む。parse + catalog_version 照合の 4 重実装を 1 箇所に集約する (#152)。
+#
+# 消費者ごとに「読めない理由」の扱いが違う (doctor は 3 段階で報告、sync / status は
+# 不在扱い) ため、理由を潰さず state で返す。
+module Catalog
+  # 読み取り結果。state は :ok / :missing / :version_mismatch / :unreadable のいずれか。
+  # entries は :ok のときだけ catalog の target-artifact entry 配列、それ以外は空。
+  Result = Struct.new(:state, :entries) do
+    def present?
+      state == :ok
+    end
+  end
+
+  # catalog を読む。存在しない (:missing) / catalog_version 不一致 (:version_mismatch) /
+  # JSON として壊れている (:unreadable) は entries を空にして返す (fail-closed)。
+  def self.read(root)
+    path = File.join(root, ArtifactTargets::CATALOG_PATH)
+    return Result.new(:missing, []) unless File.file?(path)
+
+    data = JSON.parse(File.read(path))
+    return Result.new(:version_mismatch, []) unless data["catalog_version"] == ArtifactTargets::CATALOG_VERSION
+
+    Result.new(:ok, data.fetch("assets", []))
+  rescue JSON::ParserError
+    Result.new(:unreadable, [])
+  end
+end

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -127,7 +127,7 @@ module CheckManifests
         next unless entry.key?("artifact_kind")
 
         kind = entry["artifact_kind"]
-        unless ArtifactTargets::SUPPORTED_KINDS.include?(kind)
+        unless ArtifactTargets.supported?(kind)
           error(path, "compatibility.#{tool}.artifact_kind must be one of " \
                       "#{ArtifactTargets::SUPPORTED_KINDS.join(', ')}, got #{kind.inspect}")
         end

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -14,17 +14,16 @@
 # - symlink / 非通常ファイルは決して触らない。
 # - 外部依存ゼロ、network access なし。
 
-require "json"
 require "fileutils"
 
 require_relative "artifact_targets"
+require_relative "catalog"
 require_relative "instruction_marker"
 require_relative "assets"
 
 module Connect
   # 人間の CLAUDE.md から所有ファイルを取り込む import 行。
   CLAUDE_IMPORT = "@agent-tools/CLAUDE.md"
-  CATALOG_PATH = "generated/catalog.json"
 
   Plan = Struct.new(:action, :tool, :kind, :path, :reason, :gen) do
     def to_s
@@ -40,22 +39,12 @@ module Connect
       load_catalog
     end
 
-    # catalog を source of truth として読む (catalog_version check は sync/status/doctor と
-    # 同じ)。connect は registered な instruction だけを所有確立する (review gate)。
+    # catalog を source of truth として読む (reader は sync / status / doctor と共通の
+    # Catalog.read)。connect は registered な instruction だけを所有確立する (review gate)。
     def load_catalog
-      @catalog_present = false
-      @entries = []
-      path = File.join(@root, CATALOG_PATH)
-      return unless File.file?(path)
-
-      data = JSON.parse(File.read(path))
-      # version の一致しない catalog は古いものとして無視する (re-run register)。
-      return unless data["catalog_version"] == ArtifactTargets::CATALOG_VERSION
-
-      @catalog_present = true
-      @entries = data.fetch("assets", [])
-    rescue JSON::ParserError
-      @catalog_present = false
+      result = Catalog.read(@root)
+      @catalog_present = result.present?
+      @entries = result.entries
     end
 
     def plan
@@ -73,9 +62,10 @@ module Connect
 
     private
 
-    def generated_instruction(tool, filename)
-      path = File.join(@root, "generated", tool, "instructions", filename)
-      File.file?(path) ? path : nil
+    # tool の generated instruction path (tool 固有 filename の解決は generated_path に委ねる)。
+    def generated_instruction(tool)
+      path = ArtifactTargets.generated_path(@root, tool, nil, "instruction")
+      path && File.file?(path) ? path : nil
     end
 
     # instruction の gate を connect でも enforce する (sync の plan_instruction と同じ契約)。
@@ -111,7 +101,7 @@ module Connect
     def claude_plans
       tool = "claude-code"
       home = @homes.fetch(tool)
-      gen = generated_instruction(tool, "CLAUDE.md")
+      gen = generated_instruction(tool)
       return [] unless gen # instruction artifact が無ければ connect 不要
 
       owned = ArtifactTargets.target_path(home, tool, nil, "instruction")
@@ -126,7 +116,7 @@ module Connect
     def codex_plans
       tool = "codex"
       home = @homes.fetch(tool)
-      gen = generated_instruction(tool, "AGENTS.md")
+      gen = generated_instruction(tool)
       return [] unless gen
 
       owned = ArtifactTargets.target_path(home, tool, nil, "instruction")

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -14,9 +14,9 @@ require "yaml"
 
 require_relative "assets"
 require_relative "status"
-require_relative "sync"
 require_relative "build"
 require_relative "artifact_targets"
+require_relative "catalog"
 
 module Doctor
   LEVELS = %w[ok info warn fail].freeze
@@ -103,7 +103,7 @@ module Doctor
     # 深い recursion はせず、禁止 path 直下の marker file だけを見る。
     def check_forbidden_targets
       offenders = forbidden_paths.select do |path|
-        File.directory?(path) && File.file?(File.join(path, Sync::MARKER_FILE))
+        File.directory?(path) && File.file?(File.join(path, ArtifactTargets::MARKER_BASENAME))
       end
       if offenders.empty?
         report("ok", "forbidden", "no agent-tools markers in forbidden targets")
@@ -131,18 +131,19 @@ module Doctor
     # catalog の存在と鮮度 (docs/register-catalog.md)。
     # mtime ではなく、catalog の build_id を source content から再計算して比較する。
     def check_catalog
-      catalog = File.join(@root, "generated", "catalog.json")
-      unless File.file?(catalog)
+      catalog = Catalog.read(@root)
+      case catalog.state
+      when :missing
         report("info", "catalog", "not present (register not yet run)")
         return
-      end
-
-      data = JSON.parse(File.read(catalog))
-      unless data["catalog_version"] == ArtifactTargets::CATALOG_VERSION
+      when :version_mismatch
         report("warn", "catalog", "version mismatch (re-run register)")
         return
+      when :unreadable
+        report("fail", "catalog", "unreadable (invalid JSON)")
+        return
       end
-      entries = data.fetch("assets", [])
+      entries = catalog.entries
       # target-artifact 単位の catalog を name でまとめる。build_id は target 非依存
       # なので、鮮度判定は name 単位で正しい。
       by_name = entries.each_with_object({}) { |e, h| h[e["name"]] = e }
@@ -180,8 +181,6 @@ module Doctor
       else
         report("warn", "catalog", "stale (#{stale.join('; ')})")
       end
-    rescue JSON::ParserError
-      report("fail", "catalog", "unreadable (invalid JSON)")
     end
 
     # catalog entry の build_id と source content を比較する。source path 欠落 /

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -19,8 +19,6 @@ require_relative "build"
 require_relative "artifact_targets"
 
 module Register
-  CATALOG_PATH = "generated/catalog.json"
-
   class Error < StandardError; end
 
   class Runner
@@ -49,7 +47,7 @@ module Register
     end
 
     def write(catalog)
-      path = File.join(@root, CATALOG_PATH)
+      path = File.join(@root, ArtifactTargets::CATALOG_PATH)
       FileUtils.mkdir_p(File.dirname(path))
       File.write(path, JSON.pretty_generate(catalog) + "\n")
     end

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -17,6 +17,7 @@ require_relative "check_injection"
 require_relative "build"
 require_relative "sync"
 require_relative "artifact_targets"
+require_relative "catalog"
 require_relative "instruction_marker"
 
 module Status
@@ -79,19 +80,19 @@ module Status
       total = 0
       stale = 0
       Sync::TOOLS.each do |tool|
-        Dir.glob(File.join(@root, "generated", tool, "skills", "*")).sort.each do |artifact|
+        Dir.glob(File.join(ArtifactTargets.generated_dir(@root, tool, "skill"), "*")).sort.each do |artifact|
           next unless File.directory?(artifact)
 
           total += 1
           stale += 1 unless fresh?(artifact, sources)
         end
-        Dir.glob(File.join(@root, "generated", tool, "instructions", "*")).sort.each do |artifact|
+        Dir.glob(File.join(ArtifactTargets.generated_dir(@root, tool, "instruction"), "*")).sort.each do |artifact|
           next unless File.file?(artifact)
 
           total += 1
           stale += 1 unless fresh_instruction?(artifact, sources)
         end
-        Dir.glob(File.join(@root, "generated", tool, "scripts", "*")).sort.each do |artifact|
+        Dir.glob(File.join(ArtifactTargets.generated_dir(@root, tool, "script"), "*")).sort.each do |artifact|
           next unless File.file?(artifact)
           next if artifact.end_with?(ArtifactTargets::MARKER_BASENAME) # sidecar marker は本体と一緒に数える
 
@@ -113,7 +114,7 @@ module Status
 
     # skill (directory) の鮮度判定。dir 直下の marker を読む。
     def fresh?(artifact, sources)
-      fresh_by_marker_file?(File.join(artifact, Sync::MARKER_FILE), sources)
+      fresh_by_marker_file?(File.join(artifact, ArtifactTargets::MARKER_BASENAME), sources)
     end
 
     # script (単一ファイル) の鮮度判定。sidecar marker を読む。
@@ -153,27 +154,16 @@ module Status
       false
     end
 
-    # catalog (docs/register-catalog.md) の register summary。
+    # catalog (docs/register-catalog.md) の register summary。読めない catalog
+    # (不在 / version 不一致 / 壊れた JSON) は catalog なし扱い (Catalog.read に委ねる)。
     def register_summary
-      catalog_path = File.join(@root, "generated", "catalog.json")
-      summary = {
-        "catalog_present" => false, "registered" => 0,
-        "human_review_required" => 0, "unsupported" => 0
+      catalog = Catalog.read(@root)
+      {
+        "catalog_present" => catalog.present?,
+        "registered" => catalog.entries.count { |a| a["registration"] == "registered" },
+        "human_review_required" => catalog.entries.count { |a| a["registration"] == "human_review_required" },
+        "unsupported" => catalog.entries.count { |a| a["registration"] == "unsupported" },
       }
-      return summary unless File.file?(catalog_path)
-
-      data = JSON.parse(File.read(catalog_path))
-      # version の一致しない catalog は無視する (re-run register)。
-      return summary unless data["catalog_version"] == ArtifactTargets::CATALOG_VERSION
-
-      assets = data.fetch("assets", [])
-      summary["catalog_present"] = true
-      summary["registered"] = assets.count { |a| a["registration"] == "registered" }
-      summary["human_review_required"] = assets.count { |a| a["registration"] == "human_review_required" }
-      summary["unsupported"] = assets.count { |a| a["registration"] == "unsupported" }
-      summary
-    rescue JSON::ParserError
-      summary
     end
 
     def sync_targets
@@ -186,7 +176,9 @@ module Status
       end
     end
 
-    # Sync plan を contract の target state にマップする。
+    # Sync plan を contract の target state にマップする。skip の判定は plan.code
+    # (機械可読) だけを見て、表示文言 (plan.reason) に依存しない — sync の文言変更で
+    # dotfiles 連携 contract を壊さないため (#152)。
     # registered でない artifact は配置されないため、target は missing 扱い。
     # manifest-stale (登録判断が古い) は配置済みでも再 register が要るので stale。
     def target_state(plan)
@@ -195,11 +187,15 @@ module Status
       when "conflict" then "conflict"
       when "create" then "missing"
       when "skip"
-        case plan.reason
-        when "up-to-date" then "managed"
-        when /\Amanifest changed/ then "stale"
+        case plan.code
+        when :up_to_date then "managed"
+        when :manifest_stale then "stale"
         else "missing"
         end
+      else
+        # sync が未知の action を導入したら、nil (doctor が KeyError で crash) に落とさず
+        # conflict = fail に倒して表面化させる (fail-closed)。
+        "conflict"
       end
     end
 

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -13,20 +13,20 @@
 #   personal-* (sidecar marker つき)。それ以外の path は構成しない (docs/sync-policy.md)。
 
 require "yaml"
-require "json"
 require "fileutils"
 
 require_relative "yaml_util"
 require_relative "artifact_targets"
+require_relative "catalog"
 require_relative "instruction_marker"
 require_relative "assets"
 
 module Sync
-  MARKER_FILE = ArtifactTargets::MARKER_BASENAME
-  CATALOG_PATH = "generated/catalog.json"
   TOOLS = %w[codex claude-code].freeze
 
-  Plan = Struct.new(:action, :tool, :name, :target, :reason, :kind, :gen) do
+  # code は reason (人間向け表示文言) と対になる機械可読な skip 理由。status が contract
+  # の target state 判定に読む (#152: 表示文言の変更で contract を壊さないための分離)。
+  Plan = Struct.new(:action, :tool, :name, :target, :reason, :kind, :gen, :code) do
     def to_s
       line = "#{action}: [#{tool}] #{target}"
       reason ? "#{line} (#{reason})" : line
@@ -40,21 +40,12 @@ module Sync
       load_catalog
     end
 
-    # catalog を source of truth として読む (ArtifactTargets::CATALOG_VERSION、target-artifact 単位)。
+    # catalog を source of truth として読む (target-artifact 単位)。不在 / version 不一致 /
+    # 壊れた JSON は catalog なし扱い (Catalog.read が fail-closed に判定)。
     def load_catalog
-      @catalog_present = false
-      @entries = []
-      path = File.join(@root, CATALOG_PATH)
-      return unless File.file?(path)
-
-      data = JSON.parse(File.read(path))
-      # version の一致しない catalog は古いものとして無視する (re-run register)。
-      return unless data["catalog_version"] == ArtifactTargets::CATALOG_VERSION
-
-      @catalog_present = true
-      @entries = data.fetch("assets", [])
-    rescue JSON::ParserError
-      @catalog_present = false
+      result = Catalog.read(@root)
+      @catalog_present = result.present?
+      @entries = result.entries
     end
 
     attr_reader :catalog_present
@@ -96,13 +87,14 @@ module Sync
       kind = entry["artifact_kind"]
 
       if entry["registration"] != "registered"
-        return Plan.new("skip", tool, name, target_path(tool, name, kind), entry["registration"], kind, nil)
+        return Plan.new("skip", tool, name, target_path(tool, name, kind), entry["registration"], kind, nil,
+                        :not_registered)
       end
       # 登録判断 (risk / review / targets) は manifest に依存する。register 後に manifest が
       # 変わった entry は判断ごと stale なので、配置せず register を促す (fail-closed, #148)。
       unless Assets.manifest_fresh?(@root, entry)
         return Plan.new("skip", tool, name, target_path(tool, name, kind),
-                        "manifest changed; run scripts/register.sh first", kind, nil)
+                        "manifest changed; run scripts/register.sh first", kind, nil, :manifest_stale)
       end
 
       case kind
@@ -110,7 +102,7 @@ module Sync
       when "instruction" then plan_instruction(tool, name, entry["build_id"])
       when "script" then plan_script(tool, name, entry["build_id"])
       else
-        Plan.new("skip", tool, name, nil, "unsupported artifact_kind #{kind.inspect}", kind, nil)
+        Plan.new("skip", tool, name, nil, "unsupported artifact_kind #{kind.inspect}", kind, nil, :unsupported)
       end
     end
 
@@ -122,13 +114,13 @@ module Sync
 
     def plan_skill(tool, name, expected_build_id)
       target = target_path(tool, name, "skill")
-      gen = File.join(@root, "generated", tool, "skills", name)
+      gen = ArtifactTargets.generated_path(@root, tool, name, "skill")
 
       unless name.start_with?("personal-")
         return Plan.new("conflict", tool, name, target, "generated asset without personal- prefix", "skill", gen)
       end
       unless File.directory?(gen)
-        return Plan.new("skip", tool, name, target, "run build first", "skill", gen)
+        return Plan.new("skip", tool, name, target, "run build first", "skill", gen, :build_first)
       end
 
       source_marker = read_marker(gen)
@@ -139,7 +131,7 @@ module Sync
       # いない (stale generated)。instruction (plan_instruction) と同じく "run build first" で
       # skip し、古い generated を配置しない。
       if source_marker["build_id"] != expected_build_id
-        return Plan.new("skip", tool, name, target, "run build first", "skill", gen)
+        return Plan.new("skip", tool, name, target, "run build first", "skill", gen, :build_first)
       end
       # symlink は実体の所在によらず unmanaged target として扱い、決して触らない。
       # 親 dir (<home>/skills) が symlink の場合も、rm_rf / cp_r が外へ追従しないよう
@@ -157,7 +149,7 @@ module Sync
       end
 
       if target_marker["build_id"] == source_marker["build_id"]
-        Plan.new("skip", tool, name, target, "up-to-date", "skill", gen)
+        Plan.new("skip", tool, name, target, "up-to-date", "skill", gen, :up_to_date)
       else
         Plan.new("update", tool, name, target, nil, "skill", gen)
       end
@@ -167,11 +159,11 @@ module Sync
     # connect を促す。catalog の name / build_id を真実として generated と所有先の
     # marker を照合し、update / skip を決める。
     def plan_instruction(tool, name, expected_build_id)
-      filename = ArtifactTargets::INSTRUCTION_FILENAMES[tool]
-      unless filename
-        return Plan.new("skip", tool, name, nil, "instruction unsupported for #{tool}", "instruction", nil)
+      gen = ArtifactTargets.generated_path(@root, tool, name, "instruction")
+      unless gen
+        return Plan.new("skip", tool, name, nil, "instruction unsupported for #{tool}", "instruction", nil,
+                        :unsupported)
       end
-      gen = File.join(@root, "generated", tool, "instructions", filename)
       target = target_path(tool, name, "instruction")
 
       gen_marker = File.file?(gen) ? InstructionMarker.parse(File.read(gen)) : nil
@@ -179,7 +171,7 @@ module Sync
       # 一致しなければ build が未実行 / 古い。
       unless gen_marker && gen_marker["target"] == tool &&
              gen_marker["name"] == name && gen_marker["build_id"] == expected_build_id
-        return Plan.new("skip", tool, name, target, "run build first", "instruction", gen)
+        return Plan.new("skip", tool, name, target, "run build first", "instruction", gen, :build_first)
       end
       # 所有先とその親 dir が symlink なら決して触らない (connect と同じ保証)。
       if File.symlink?(target) || File.symlink?(File.dirname(target))
@@ -189,7 +181,7 @@ module Sync
       # 所有先が無い場合に加え、空ファイル (空白のみ) も未接続として扱う
       # (codex の AGENTS.md は空で存在しうる。空の claim は connect の責務)。
       if !File.exist?(target) || (File.file?(target) && File.read(target).strip.empty?)
-        return Plan.new("skip", tool, name, target, "run connect first", "instruction", gen)
+        return Plan.new("skip", tool, name, target, "run connect first", "instruction", gen, :connect_first)
       end
 
       target_marker = File.file?(target) ? InstructionMarker.parse(File.read(target)) : nil
@@ -200,7 +192,7 @@ module Sync
       end
 
       if target_marker["build_id"] == expected_build_id
-        Plan.new("skip", tool, name, target, "up-to-date", "instruction", gen)
+        Plan.new("skip", tool, name, target, "up-to-date", "instruction", gen, :up_to_date)
       else
         Plan.new("update", tool, name, target, nil, "instruction", gen)
       end
@@ -212,13 +204,13 @@ module Sync
     # 介さないため connect は不要で、未配置なら直接 create する。
     def plan_script(tool, name, expected_build_id)
       target = target_path(tool, name, "script")
-      gen = File.join(@root, "generated", tool, "scripts", name)
+      gen = ArtifactTargets.generated_path(@root, tool, name, "script")
 
       unless name.start_with?("personal-")
         return Plan.new("conflict", tool, name, target, "generated asset without personal- prefix", "script", gen)
       end
       unless File.file?(gen)
-        return Plan.new("skip", tool, name, target, "run build first", "script", gen)
+        return Plan.new("skip", tool, name, target, "run build first", "script", gen, :build_first)
       end
 
       source_marker = read_marker_file(ArtifactTargets.sidecar_marker_path(gen))
@@ -228,7 +220,7 @@ module Sync
       # generated が catalog entry と一致するか (build_id)。不一致 = register 後に build して
       # いない (stale generated)。plan_skill / plan_instruction と同じく run build first で skip。
       if source_marker["build_id"] != expected_build_id
-        return Plan.new("skip", tool, name, target, "run build first", "script", gen)
+        return Plan.new("skip", tool, name, target, "run build first", "script", gen, :build_first)
       end
       # 配置先本体・sidecar marker・その親 (agent-tools/scripts)・さらにその親
       # (agent-tools) のいずれかが symlink なら、cp / chmod が home の外へ追従しうるため
@@ -246,7 +238,7 @@ module Sync
       end
 
       if target_marker["build_id"] == source_marker["build_id"]
-        Plan.new("skip", tool, name, target, "up-to-date", "script", gen)
+        Plan.new("skip", tool, name, target, "up-to-date", "script", gen, :up_to_date)
       else
         Plan.new("update", tool, name, target, nil, "script", gen)
       end
@@ -265,7 +257,7 @@ module Sync
 
     # directory artifact (skill) の dir 直下 marker を読む。
     def read_marker(dir)
-      read_marker_file(File.join(dir, MARKER_FILE))
+      read_marker_file(File.join(dir, ArtifactTargets::MARKER_BASENAME))
     end
 
     # marker file を読んで Hash を返す。不在 / 型不正 / parse 失敗は nil。


### PR DESCRIPTION
## 概要

全体アーキ監査 follow-up #152 の **medium 3 件 + 絡む low 2 件**。kind 追加 1 回 = 5 ファイル約 10 箇所の同期修正が要る構造を、小さな集約で緩和する。**挙動不変のリファクタ**。

## 変更

### medium 1: generated path 解決の集約
`ArtifactTargets.generated_dir(root, tool, kind)` / `generated_path(root, tool, name, kind)` を追加し、`generated/<tool>/{skills,instructions,scripts}/` のハードコード (build 生成・prune glob / sync の gen 参照 / status の glob / connect) を寄せた。deploy 側の `target_path` と対称。connect のハードコード filename (`"CLAUDE.md"` / `"AGENTS.md"`) も `INSTRUCTION_FILENAMES` 経由に解消。

### medium 2: catalog reader の共通化
`Catalog.read(root)` (新規 `lib/catalog.rb`) に sync / connect / status / doctor の 4 重実装 (parse + catalog_version 照合) を集約。読めない理由を `state` (:ok / :missing / :version_mismatch / :unreadable) で保持し、doctor の 3 段階報告 (info / warn / fail) を潰さない。`CATALOG_PATH` は `CATALOG_VERSION` の隣 (ArtifactTargets) へ移動し、3 箇所の定数重複 + 2 箇所のインラインを解消。

### medium 3: sync Plan の reason を機械可読 code と表示文言に分離
`Sync::Plan` に `code` (:up_to_date / :manifest_stale / :build_first / :connect_first / :not_registered / :unsupported) を追加。status の `target_state` は code だけを見る (従来は `plan.reason == "up-to-date"` の文字列比較 + regex で、sync の文言変更だけで dotfiles 連携 contract の status JSON が壊れる構造だった)。未知 action は従来 nil → doctor の fetch が KeyError で crash する構造だったのを、conflict (= doctor fail) へ fail-closed に倒して表面化させる。

### low (絡む分のみ)
- `Sync::MARKER_FILE` / `Sync::CATALOG_PATH` の再輸出を削除し、`ArtifactTargets` 直参照に統一 (status / doctor / sync 内部)。
- 未使用だった `ArtifactTargets.supported?` を check_manifests の compatibility 検証で実使用。
- `scripts/README.md` に artifact_kind / tool 追加時のチェックリストを追加 (#152 の「併せて」項目。script kind 追加時の docs 取り残し #151 の再発防止)。

### スコープ外 (別 PR に残す #152 low)
connect/sync の「generated と catalog の一致検証」統一 / personal- prefix 検査の instruction 欠落 / docstring・docs 明記系 / tool 一覧・homes 既定値の一元化 (v1 は 2 tool 固定で顕在化は将来)。

## 検証

- self-test 全 12 本 green (build / sync / connect / status / doctor / register / check-manifests / check-injection / check-credential-isolation / setup / safe-gh / safe-gh-hook)。
- **挙動不変の実機確認**: main の worktree と本 branch で、実 repo (catalog 30 registered) に対する `status.sh --json` / `doctor.sh` / `sync.sh` / `connect.sh` の出力を diff → すべて一致 (差分は working tree の `repo.clean` のみ)。
- `check-manifests.sh` pass / `check-injection.sh` は既知の medium (human_review 承認済み asset) のみで従来どおり。

## 安全メモ

- install side effects: なし (pipeline tooling のみ。deployed asset / generated 成果物は不変)
- secret access: なし
- network changes: なし

Closes #152 の medium 3 件 (low の残りは issue に残置)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73L7dXxMEu2QGLugSh2bS