### PR TITLE
chore: #152 残 low の掃除 (一致検証統一 / 暗黙契約の明記 4 件)

### DIFF
--- a/docs/runtime-injection-defense.md
+++ b/docs/runtime-injection-defense.md
@@ -154,6 +154,11 @@ boundary でない)。
   env override を最優先で読むため、それらを書ける主体は任意 author を self と詐称でき、
   その author の body withhold が外れる。local file / env の改変は本 wrapper の脅威モデル外
   (steering であり、床は実行環境側の責務)。
+- **trust file の path 契約 (dotfiles 連携)**: 既定 path は
+  `~/.config/dotfiles/github-trust.local`、env `SAFE_GH_TRUST_FILE` で上書き可
+  (コード内定数 `DEFAULT_SELF_TRUST_FILE` / `SELF_TRUST_FILE_ENV` が正本)。この file は
+  dotfiles 側が非コミットで置く local-only config で、実値 (login/id) はどちらの repo にも
+  入れない。path を変えるときは dotfiles 側の置き場規約と同時に更新する。
 - **他人の Issue/PR**: metadata (number/state/author/labels) のみ。**title も body も親へ渡さない**
   (title は attacker 制御の free-text = injection 面)。**自分の Issue/PR**: title/body を渡す。
 - **他人コメント**: count + 固定理由のみ。著者名・プレビュー・untrusted 由来の文字列を出力に

--- a/docs/sync-policy.md
+++ b/docs/sync-policy.md
@@ -75,6 +75,10 @@ default は必ず conservative にします。
 ~/.agents/skills/*/teams
 ```
 
+補足: `scripts/doctor.sh` の forbidden target 検査は、上記禁止リストのうち directory の
+部分集合だけを見る (directory 直下の marker file の有無で判定するため、file 型の
+`auth.json` / `config.toml` / `*.sqlite` はこの検査方式の対象外)。
+
 ## Management Marker
 
 marker format は [Status / Manifest Contract](status-manifest-contract.md) で定義します。

--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -68,6 +68,8 @@ module ArtifactTargets
 
   # tool home 内の target-artifact 配置先 path を返す (path 解決の単一 source)。
   # home は解決済みの tool home dir (例 ~/.claude / ~/.codex)。
+  # name の要否は kind で変わる: instruction は name を使わない (nil 可)、
+  # skill / script は name が path に入るため必須 (generated_path と同じ契約)。
   # - instruction: tool 固有ファイル名 (INSTRUCTION_FILENAMES)。claude-code は
   #   agent-tools/ subdir 配下に所有ファイルを置き、codex は home 直下。filename を
   #   解決できない tool では nil。

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -88,9 +88,9 @@ module Connect
         return "manifest changed; run scripts/register.sh first"
       end
 
-      marker = InstructionMarker.parse(File.read(gen))
-      unless marker && marker["target"] == tool &&
-             marker["name"] == entry["name"] && marker["build_id"] == entry["build_id"]
+      # generated が catalog entry と一致するか (判定は sync と共通の InstructionMarker.matches?, #152)。
+      unless InstructionMarker.matches?(File.read(gen), target: tool,
+                                        name: entry["name"], build_id: entry["build_id"])
         return "generated instruction is stale; run scripts/build.sh && scripts/register.sh first"
       end
 

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -101,6 +101,9 @@ module Doctor
 
     # 禁止 targets に agent-tools marker が誤って存在しないことを確認する。
     # 深い recursion はせず、禁止 path 直下の marker file だけを見る。
+    # 検査対象は docs/sync-policy.md の禁止リストのうち directory の部分集合のみ (#152)。
+    # file 型の禁止 target (auth.json / config.toml / *.sqlite) は直下に marker file を
+    # 持ち得ないためこの検査方式の対象外 (sync はそもそもそれらの path を構成しない)。
     def check_forbidden_targets
       offenders = forbidden_paths.select do |path|
         File.directory?(path) && File.file?(File.join(path, ArtifactTargets::MARKER_BASENAME))

--- a/scripts/lib/instruction_marker.rb
+++ b/scripts/lib/instruction_marker.rb
@@ -55,4 +55,13 @@ module InstructionMarker
     marker = parse(content)
     !marker.nil? && marker["target"] == target
   end
+
+  # content (generated instruction) が catalog entry (target / name / build_id) と一致するか。
+  # 不一致 = source 変更後に build していない (stale generated)。sync / connect が配置前の
+  # gate として共有する (#152: 別実装だった一致検証の単一 source)。
+  def self.matches?(content, target:, name:, build_id:)
+    marker = parse(content)
+    !marker.nil? && marker["target"] == target &&
+      marker["name"] == name && marker["build_id"] == build_id
+  end
 end

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -166,11 +166,15 @@ module Sync
       end
       target = target_path(tool, name, "instruction")
 
-      gen_marker = File.file?(gen) ? InstructionMarker.parse(File.read(gen)) : nil
+      # instruction は plan_skill / plan_script のような personal- prefix 検査をしない:
+      # あの検査は配置先 namespace (<home>/skills/personal-* 等、name から導出される path) を
+      # 守るためのもので、instruction の配置先は name 非依存の固定ファイル (CLAUDE.md /
+      # AGENTS.md)。name 自体の prefix は check-manifests が manifest 段階で enforce する。
+
       # generated が catalog entry と一致するか (target + name + build_id)。
-      # 一致しなければ build が未実行 / 古い。
-      unless gen_marker && gen_marker["target"] == tool &&
-             gen_marker["name"] == name && gen_marker["build_id"] == expected_build_id
+      # 一致しなければ build が未実行 / 古い (判定は InstructionMarker.matches? に集約, #152)。
+      unless File.file?(gen) &&
+             InstructionMarker.matches?(File.read(gen), target: tool, name: name, build_id: expected_build_id)
         return Plan.new("skip", tool, name, target, "run build first", "instruction", gen, :build_first)
       end
       # 所有先とその親 dir が symlink なら決して触らない (connect と同じ保証)。


### PR DESCRIPTION
## 概要

#152 の残 low のうち、defer 条件つきの「tool 一覧・homes 既定値の一元化」(tool 追加需要待ち) を除く 5 件を対応する掃除 PR。

Refs #152 (close しない: tool 一元化の 1 項目が需要待ちで残置)

## 変更

1. **一致検証の統一**: sync (`plan_instruction`) / connect (`unconnectable_reason`) で別実装だった「generated instruction と catalog entry の一致検証 (target + name + build_id)」を `InstructionMarker.matches?` に統一
2. **prefix 検査の理由明記**: `plan_instruction` に personal- prefix 検査を足さない理由をコメント明記 (prefix guard は name 由来の配置先 namespace を守るもの。instruction の配置先は name 非依存の固定ファイルで、name の prefix は check-manifests が manifest 段階で enforce 済み)
3. **`target_path` docstring**: name の要否が kind で変わる暗黙契約 (instruction は不使用 / skill・script は必須) を明記
4. **doctor forbidden 検査の範囲明記**: sync-policy 禁止リストの directory 部分集合のみ検査すること (file 型の auth.json / config.toml / *.sqlite は marker 方式の対象外) を doctor.rb コメント + docs/sync-policy.md に明記
5. **safe-gh trust file path 契約**: `SAFE_GH_TRUST_FILE` env / 既定 `~/.config/dotfiles/github-trust.local` が docs 未記載だったので docs/runtime-injection-defense.md の safe-gh 節に追記 (コード内定数として既に public)

## 検証

- self-test 12 本すべて緑
- 挙動不変の実証: main の worktree に generated/ をコピーし、sync / connect / status --json / doctor の dry-run 出力を比較 → 全一致 (repo.clean の差のみ = 未コミット変更由来で想定どおり)
- 配備物への影響なし (pipeline tooling の refactor + docs のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YwFZyF9ovkHuhphzw9Q3Q