### PR TITLE
fix: 非 UTF-8 crash の scrub 解消 + sidecar 相乗り検出 + TOCTOU 既知限界の明記 (#149)

### DIFF
--- a/docs/sync-policy.md
+++ b/docs/sync-policy.md
@@ -126,3 +126,14 @@ instruction artifact は connect が所有を確立し、sync が更新する。
 これらは日常 sync では create せず、connect だけが所有を開始する。symlink / 非通常
 ファイル / unmanaged な所有先は conflict として停止する。詳細は
 [Instruction Artifact Kind](instruction-artifact-kind.md)。
+
+## 既知の限界 (TOCTOU)
+
+symlink / unmanaged の検査は plan 時に行い、apply は配置先を再検証しません。
+plan→apply 間に配置先を差し替えられると検査を通過した plan のまま書き込みます。
+
+これを意図的に突ける主体は、同一ユーザー権限で任意のファイルを書き換えられる攻撃者に
+限られます。その主体は apply 直前の再検証も同様に無効化できるため、再検証を足しても
+防御になりません (実装しない判断, #149)。同時実行による事故は、個人ツールとして同時
+実行の前提が薄いこと、書き込み先が marker-gated な managed target に限定されることで
+被害が限定されます。

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -397,11 +397,14 @@ module CheckManifests
     end
 
     # shared/<category>/ 直下の asset source に manifest が無いものを検出する。
+    # sidecar は「拡張子を除いた同名」で対応づくため、拡張子違いの同名 source が同じ
+    # sidecar に相乗りして manifest 欠落検出を逃れられる。相乗りは error にする (#149)。
     def check_sources_have_manifests
       ASSET_CATEGORIES.each do |category|
         dir = File.join(@root, "shared", category)
         next unless File.directory?(dir)
 
+        sidecar_sources = Hash.new { |h, k| h[k] = [] }
         Dir.children(dir).sort.each do |entry|
           next if entry.start_with?(".")
           next if NON_ASSET_BASENAMES.include?(entry)
@@ -414,9 +417,21 @@ module CheckManifests
             end
           else
             sidecar = File.join(dir, "#{entry.sub(/\.[^.]+\z/, '')}.asset.yml")
-            unless File.file?(sidecar)
+            if File.file?(sidecar)
+              sidecar_sources[sidecar] << full
+            else
               error(rel(full), "asset source is missing sidecar manifest #{File.basename(sidecar)}")
             end
+          end
+        end
+
+        sidecar_sources.each do |sidecar, sources|
+          next if sources.size < 2
+
+          sources.each do |source|
+            others = (sources - [source]).map { |s| File.basename(s) }.join(", ")
+            error(rel(source),
+                  "multiple asset sources share sidecar manifest #{File.basename(sidecar)} (also: #{others})")
           end
         end
       end

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -140,7 +140,10 @@ module Connect
       end
       return Plan.new("create", tool, "owned", owned, nil, gen) unless File.exist?(owned)
 
-      content = File.read(owned)
+      # 非 UTF-8 バイトは scrub してから判定する (crash させない, #149)。scrub は判定用で、
+      # 書き込みは do_create の byte copy なので所有先の内容を壊さない。marker が壊れて
+      # いれば managed? が false → conflict (fail-closed)。
+      content = File.read(owned).scrub("�")
       if content.strip.empty?
         return Plan.new("create", tool, "owned", owned, "claiming empty file", gen)
       end
@@ -160,7 +163,9 @@ module Connect
         return Plan.new("conflict", tool, "import", import_file, "CLAUDE.md is not a regular file", nil)
       end
       if File.file?(import_file)
-        content = File.read(import_file)
+        # scrub は判定用のみ。追記 (do_add_import) はファイルを読み直すので、人間の
+        # CLAUDE.md の既存バイト列は保全される (#149)。
+        content = File.read(import_file).scrub("�")
         if content.lines.any? { |l| l.strip == CLAUDE_IMPORT }
           return Plan.new("skip", tool, "import", import_file, "import already present", nil)
         end

--- a/scripts/lib/instruction_marker.rb
+++ b/scripts/lib/instruction_marker.rb
@@ -23,8 +23,11 @@ module InstructionMarker
 
   # content の先頭行から marker を厳密に解析する。
   # 妥当な agent-tools instruction marker でなければ nil を返す。
+  # 非 UTF-8 バイトは scrub してから解析する (String#strip の ArgumentError で
+  # クラッシュさせない, #149)。marker 行自体が壊れていれば下の検査で nil に落ち、
+  # unmanaged 扱い = conflict に倒れる (fail-closed)。
   def self.parse(content)
-    first = content.to_s.lines.first&.strip
+    first = content.to_s.scrub("�").lines.first&.strip
     return nil unless first&.start_with?(PREFIX) && first.end_with?(SUFFIX)
 
     body = first[PREFIX.length...-SUFFIX.length].strip

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -76,6 +76,11 @@ module Sync
       TOOLS.flat_map { |tool| prune_skills(tool) + prune_scripts(tool) }
     end
 
+    # 既知の限界 (TOCTOU): symlink / unmanaged の検査は plan 時のみで、apply は配置先を
+    # 再検証しない。plan→apply 間の差し替えを突ける主体は同一ユーザー権限で任意書込できる
+    # 攻撃者に限られ、その主体は再検証も同様に無効化できるため、再検証は防御にならない
+    # (実装しない判断, #149)。同時実行の事故は個人ツールで前提が薄く、書き込み先が
+    # marker-gated に限定されることで被害も限定される。docs/sync-policy.md の既知の限界も参照。
     def apply(plans)
       plans.each do |p|
         if p.action == "delete"
@@ -278,7 +283,8 @@ module Sync
       # 未接続なら connect を促す。sync は create しない。
       # 所有先が無い場合に加え、空ファイル (空白のみ) も未接続として扱う
       # (codex の AGENTS.md は空で存在しうる。空の claim は connect の責務)。
-      if !File.exist?(target) || (File.file?(target) && File.read(target).strip.empty?)
+      # 人間所有ファイルの非 UTF-8 バイトは scrub してから判定する (crash させない, #149)。
+      if !File.exist?(target) || (File.file?(target) && File.read(target).scrub("�").strip.empty?)
         return Plan.new("skip", tool, name, target, "run connect first", "instruction", gen, :connect_first)
       end
 

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -525,4 +525,30 @@ repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 "$check" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \
   || fail "repository manifests should pass: $(cat "$tmp/out-repo")"
 
+# --- case 6: 拡張子違いの同名 source は sidecar manifest に相乗りできない (#149) ---
+mkdir -p "$tmp/piggy/shared/workflows"
+echo "# a" > "$tmp/piggy/shared/workflows/personal-dup.md"
+echo "# b" > "$tmp/piggy/shared/workflows/personal-dup.txt"
+cat > "$tmp/piggy/shared/workflows/personal-dup.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-dup
+kind: workflow
+visibility: public
+targets:
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/workflows/personal-dup.md
+  format: markdown
+EOF
+if "$check" --root "$tmp/piggy" > "$tmp/out-piggy" 2>&1; then
+  fail "check-manifests must reject sources sharing one sidecar manifest"
+fi
+grep -q "multiple asset sources share sidecar manifest personal-dup.asset.yml" "$tmp/out-piggy" \
+  || fail "expected shared-sidecar rejection: $(cat "$tmp/out-piggy")"
+grep -q "personal-dup.txt" "$tmp/out-piggy" \
+  || fail "rejection should name the piggybacking source: $(cat "$tmp/out-piggy")"
+
 echo "ok: check-manifests self-test passed"

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -249,4 +249,48 @@ grep -q "skip: \[codex\] owned.*manifest changed" "$tmp/c13" \
 [ ! -e "$tmp/claude11/agent-tools/CLAUDE.md" ] || fail "manifest-stale instruction must not create owned file"
 [ ! -e "$tmp/codex11/AGENTS.md" ] || fail "manifest-stale instruction must not create owned codex file"
 
+# --- case 14: 非 UTF-8 バイトで crash しない (#149) ---
+mkdir -p "$tmp/repo5/shared/instructions"
+cat > "$tmp/repo5/shared/instructions/personal-ops.md" <<'EOF'
+# operating rules
+EOF
+cat > "$tmp/repo5/shared/instructions/personal-ops.asset.yml" <<'EOF'
+schema_version: 1
+name: personal-ops
+kind: instruction
+visibility: public
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+source:
+  path: shared/instructions/personal-ops.md
+  format: markdown
+EOF
+"$build" --root "$tmp/repo5" --quiet > /dev/null
+"$register" --root "$tmp/repo5" --quiet > /dev/null
+
+# 14a: unmanaged な非 UTF-8 所有先は conflict (String#strip の ArgumentError で落ちない)
+mkdir -p "$tmp/codex14a" "$tmp/claude14a"
+printf 'existing \377\376 content\n' > "$tmp/codex14a/AGENTS.md"
+status=0
+"$connect" --root "$tmp/repo5" --codex-home "$tmp/codex14a" --claude-home "$tmp/claude14a" > "$tmp/c14a" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "connect with non-UTF-8 owned file should conflict (exit 1), not crash: $(cat "$tmp/c14a")"
+grep -q "conflict: \[codex\] owned.*unmanaged" "$tmp/c14a" \
+  || fail "non-UTF-8 owned AGENTS.md should be an unmanaged conflict: $(cat "$tmp/c14a")"
+
+# 14b: 人間の CLAUDE.md の非 UTF-8 バイトは import 判定を crash させず、追記でバイト列を保全する
+mkdir -p "$tmp/codex14b" "$tmp/claude14b"
+printf '# human notes \377\376\n' > "$tmp/claude14b/CLAUDE.md"
+cp "$tmp/claude14b/CLAUDE.md" "$tmp/c14b-orig"
+orig_size=$(wc -c < "$tmp/c14b-orig")
+"$connect" --root "$tmp/repo5" --codex-home "$tmp/codex14b" --claude-home "$tmp/claude14b" --apply > "$tmp/c14b" 2>&1 \
+  || fail "connect with non-UTF-8 CLAUDE.md should succeed: $(cat "$tmp/c14b")"
+grep -q "add-import: \[claude-code\]" "$tmp/c14b" || fail "expected add-import plan: $(cat "$tmp/c14b")"
+grep -q "@agent-tools/CLAUDE.md" "$tmp/claude14b/CLAUDE.md" || fail "import line should be appended"
+head -c "$orig_size" "$tmp/claude14b/CLAUDE.md" | cmp -s - "$tmp/c14b-orig" \
+  || fail "existing CLAUDE.md bytes must be preserved on append"
+
 echo "ok: connect self-test passed"

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -632,4 +632,23 @@ grep -q "no catalog; run scripts/register.sh first" "$tmp/out26" \
   || fail "prune without catalog should ask for register: $(cat "$tmp/out26")"
 [ -f "$tmp/nclaude/skills/personal-x/SKILL.md" ] || fail "prune without catalog must not delete anything"
 
+# --- case 27: 所有先の非 UTF-8 バイトで crash せず判定できる (#149) ---
+# 27a: unmanaged な非 UTF-8 所有先は conflict (String#strip の ArgumentError で落ちない)
+mkdir -p "$tmp/codex27" "$tmp/claude27"
+printf '# memo \377\376 non-utf8\n' > "$tmp/codex27/AGENTS.md"
+status=0
+"$sync" --root "$tmp/repo" --codex-home "$tmp/codex27" --claude-home "$tmp/claude27" > "$tmp/out27a" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "non-UTF-8 unmanaged owned file should conflict (exit 1), not crash: $(cat "$tmp/out27a")"
+grep -q "conflict: \[codex\].*unmanaged" "$tmp/out27a" \
+  || fail "non-UTF-8 owned file should be an unmanaged conflict: $(cat "$tmp/out27a")"
+
+# 27b: marker が正常なら、末尾に非 UTF-8 バイトがあっても managed のまま (scrub は判定のみ)
+mkdir -p "$tmp/codex27b" "$tmp/claude27b"
+cp "$tmp/repo/generated/codex/instructions/AGENTS.md" "$tmp/codex27b/AGENTS.md"
+printf '\377' >> "$tmp/codex27b/AGENTS.md"
+"$sync" --root "$tmp/repo" --codex-home "$tmp/codex27b" --claude-home "$tmp/claude27b" > "$tmp/out27b" 2>&1 \
+  || fail "sync with managed non-UTF-8 tail should succeed: $(cat "$tmp/out27b")"
+grep -q "skip: \[codex\].*up-to-date" "$tmp/out27b" \
+  || fail "managed owned file with non-UTF-8 tail should stay up-to-date: $(cat "$tmp/out27b")"
+
 echo "ok: sync self-test passed"


### PR DESCRIPTION
## 概要

監査FU #149 の残 3 件。方針は issue の 2026-07-05 判断コメントで確定済み。

## 変更内容

### 1. 非 UTF-8 バイトによる crash を scrub で解消 (medium)

`String#strip` が invalid byte sequence の ArgumentError を投げ、sync / connect / build --prune がクラッシュしていた (connect は人間所有の `~/.claude/CLAUDE.md` を読む経路を含む)。check-injection と同じ scrub パターンで解消:

- **`InstructionMarker.parse`** に scrub を集約 (sync / connect / build の全 caller が恩恵)。marker 行が壊れていれば従来どおり nil → unmanaged → conflict に倒れる (fail-closed)
- **sync の空ファイル判定** (`plan_instruction`) と **connect の owned / import 判定**の直接 `.strip` 箇所も scrub
- scrub は**判定用のみ**。書き込み経路 (do_create の byte copy / do_add_import のファイル再読) は触らず、人間ファイルの既存バイト列を保全する (テストで assert)

### 2. sidecar manifest への相乗り検出 (low)

`check_sources_have_manifests` は sidecar を「拡張子を除いた同名」で対応づけるため、拡張子違いの同名 source (例: `foo.rb` と `foo.sh`) が同じ `foo.asset.yml` に相乗りして manifest 欠落検出を逃れられた。同一 sidecar を共有する source が 2 つ以上あれば error にする。実 repo の manifest 15 本は false positive なしで pass。

### 3. plan→apply TOCTOU は「既知の限界」として明記 (low・実装しない判断)

apply 直前の再検証は実装しない: この穴を突ける主体 = 同一ユーザー権限で任意書込できる攻撃者で、その主体は再検証も同様に無効化できるため防御にならない。同時実行事故は個人ツールで前提が薄く、marker-gated な書込先限定で被害も限定。`sync.rb` の apply コメント + `docs/sync-policy.md` の「既知の限界 (TOCTOU)」節に明記。

## 検証

- self-test 12 本すべて緑 (macOS system ruby)
- 回帰テスト 3 本 (sync-test case 27a/27b、connect-test case 14a/14b、check-manifests-test case 6) を **main の worktree に当てて全て fail することを確認** (sync/connect = ArgumentError crash、check-manifests = 検出漏れ)
- CI 相当の check-manifests / check-injection / build / register を実 repo で実行し、generated/ と catalog に diff なし = **配備影響なし**

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv