### PR TITLE
test: self-test の実 repo 変異を tmp コピー化 + Ruby 3.x matrix + 未到達分岐の補強 (#150)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,26 @@ jobs:
   self-tests:
     runs-on: macos-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # system = macOS 標準 Ruby (2.6 / psych 3) が配備先の床。3.4 は yaml_util.rb の
+        # psych >= 4 分岐を CI の dead path にしないための現行 Ruby (#150)。
+        ruby: [system, "3.4"]
     steps:
       # 外部 action は full commit SHA で pin する (タグ移動による差し替え対策)。
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # テストが repo 内の scripts を実行するため、token を .git/config に残さない。
           persist-credentials: false
+
+      # scripts/*.sh は PATH の ruby を exec するため、PATH 先頭を差し替えるだけで
+      # matrix の Ruby に切り替わる。system 行では何もしない (macOS 標準 Ruby のまま)。
+      - name: Set up Ruby ${{ matrix.ruby }}
+        if: matrix.ruby != 'system'
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
 
       - name: Run self-tests
         run: |

--- a/scripts/tests/build-test.sh
+++ b/scripts/tests/build-test.sh
@@ -472,11 +472,15 @@ grep -q "kept (unmanaged, no agent-tools marker): generated/codex/scripts/person
 [ -f "$tmp/scriptasset/generated/codex/scripts/personal-stray-script" ] \
   || fail "unmanaged script must not be pruned"
 
-# --- case 5: repository 本体が build できる ---
+# --- case 5: repository 本体が build できる (実 repo を変異させないよう tmp コピーで検証) ---
+# 実 repo の generated/ を直接上書きすると、branch でのテスト実行が実 sync の参照先を
+# 差し替える副作用がある (#150)。検証目的 (実 asset 一式で build が通る) はコピーでも同一。
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
-"$build" --root "$repo_root" --quiet > "$tmp/out-repo" 2>&1 \
+mkdir -p "$tmp/repocopy"
+cp -R "$repo_root/shared" "$tmp/repocopy/shared"
+"$build" --root "$tmp/repocopy" --quiet > "$tmp/out-repo" 2>&1 \
   || fail "repository build should pass: $(cat "$tmp/out-repo")"
-[ -f "$repo_root/generated/claude-code/skills/personal-project-operating-loop/SKILL.md" ] \
+[ -f "$tmp/repocopy/generated/claude-code/skills/personal-project-operating-loop/SKILL.md" ] \
   || fail "repository artifact missing"
 
 # --- case 6: CRLF frontmatter の single-file source を build しても二重化しない (B4) ---

--- a/scripts/tests/check-credential-isolation-test.sh
+++ b/scripts/tests/check-credential-isolation-test.sh
@@ -246,4 +246,32 @@ if [ "$(id -u)" -ne 0 ]; then
   chmod 644 "$tmp/unreadable.json"
 fi
 
+# --- case 19: 同一 (channel, operation) の positive 重複も曖昧 = 構造エラー (exit 2) (#150) ---
+# (case 7 は negative 重複のみで、positive 側の件数分岐が未到達だった)
+cat > "$tmp/duppos.json" <<'EOF'
+{
+  "probes": [
+    {"channel": "gh",        "mode": "negative", "operation": "read-priv", "authenticated": false},
+    {"channel": "gh",        "mode": "positive", "operation": "read-priv", "authenticated": true},
+    {"channel": "gh",        "mode": "positive", "operation": "read-priv", "authenticated": true},
+    {"channel": "git-https", "mode": "negative", "operation": "read-priv", "authenticated": false},
+    {"channel": "git-https", "mode": "positive", "operation": "read-priv", "authenticated": true},
+    {"channel": "git-ssh",   "mode": "negative", "operation": "read-priv", "authenticated": false},
+    {"channel": "git-ssh",   "mode": "positive", "operation": "read-priv", "authenticated": true},
+    {"channel": "curl",      "mode": "negative", "operation": "read-priv", "authenticated": false},
+    {"channel": "curl",      "mode": "positive", "operation": "read-priv", "authenticated": true}
+  ]
+}
+EOF
+run_case "duplicate-positive-probe" "$tmp/duppos.json" 2 \
+  "channel gh (operation read-priv): expected exactly one positive-control probe, got 2"
+
+# --- case 20: top-level が JSON object でなければ入力エラー (exit 2) (#150) ---
+echo '[]' > "$tmp/toplevel-array.json"
+run_case "top-level-not-object" "$tmp/toplevel-array.json" 2 "input must be a JSON object"
+
+# --- case 21: probes が array でなければ入力エラー (exit 2) (#150) ---
+echo '{ "probes": {} }' > "$tmp/probes-not-array.json"
+run_case "probes-not-array" "$tmp/probes-not-array.json" 2 "probes must be an array"
+
 echo "ok: check-credential-isolation self-test passed"

--- a/scripts/tests/check-manifests-test.sh
+++ b/scripts/tests/check-manifests-test.sh
@@ -551,4 +551,60 @@ grep -q "multiple asset sources share sidecar manifest personal-dup.asset.yml" "
 grep -q "personal-dup.txt" "$tmp/out-piggy" \
   || fail "rejection should name the piggybacking source: $(cat "$tmp/out-piggy")"
 
+# --- case 7: reject 経路の代表 fixture (フィールド検証の各分岐が実際に error を出す) (#150) ---
+# 1 つの broken manifest に代表的な違反を同居させ、validate_* の主要 reject 分岐を実行する。
+mkdir -p "$tmp/reject/shared/workflows"
+echo "# broken" > "$tmp/reject/shared/workflows/personal-broken.md"
+cat > "$tmp/reject/shared/workflows/personal-broken.asset.yml" <<'EOF'
+schema_version: 2
+name: personal-other
+kind: gadget
+visibility: private
+targets:
+  - vscode
+  - vscode
+risk:
+  prompt_injection: catastrophic
+  extra: low
+source:
+  path: shared/workflows/personal-broken.md
+  format: binary
+review:
+  human_review: maybe
+bogus: true
+EOF
+if "$check" --root "$tmp/reject" > "$tmp/out-reject" 2>&1; then
+  fail "check-manifests must reject the broken manifest"
+fi
+for expect in \
+  "unknown field: bogus" \
+  "schema_version must be 1" \
+  'name "personal-other" does not match asset base name "personal-broken"' \
+  "kind must be one of" \
+  'visibility "private" must not be tracked in this public repository' \
+  "targets must be one of" \
+  "targets must not contain duplicates" \
+  "unknown risk key: extra" \
+  "missing risk key: privacy" \
+  "risk.prompt_injection must be one of" \
+  "source.format must be one of" \
+  "review.human_review must be one of"
+do
+  grep -qF "$expect" "$tmp/out-reject" \
+    || fail "expected rejection <$expect>: $(cat "$tmp/out-reject")"
+done
+
+# 必須フィールド欠落は独立 fixture で (存在するキーの検証と混ざらないように)
+mkdir -p "$tmp/missing/shared/workflows"
+cat > "$tmp/missing/shared/workflows/personal-empty.asset.yml" <<'EOF'
+schema_version: 1
+EOF
+if "$check" --root "$tmp/missing" > "$tmp/out-missing" 2>&1; then
+  fail "check-manifests must reject a manifest missing required fields"
+fi
+for field in name kind visibility targets risk source; do
+  grep -qF "missing required field: $field" "$tmp/out-missing" \
+    || fail "expected missing-field rejection for $field: $(cat "$tmp/out-missing")"
+done
+
 echo "ok: check-manifests self-test passed"

--- a/scripts/tests/connect-test.sh
+++ b/scripts/tests/connect-test.sh
@@ -293,4 +293,16 @@ grep -q "@agent-tools/CLAUDE.md" "$tmp/claude14b/CLAUDE.md" || fail "import line
 head -c "$orig_size" "$tmp/claude14b/CLAUDE.md" | cmp -s - "$tmp/c14b-orig" \
   || fail "existing CLAUDE.md bytes must be preserved on append"
 
+# --- case 15: 所有先 AGENTS.md 自体が symlink なら conflict (実体へ書き抜けない) (#150) ---
+mkdir -p "$tmp/codex15" "$tmp/claude15"
+echo "# real file elsewhere" > "$tmp/real-agents.md"
+ln -s "$tmp/real-agents.md" "$tmp/codex15/AGENTS.md"
+status=0
+"$connect" --root "$tmp/repo5" --codex-home "$tmp/codex15" --claude-home "$tmp/claude15" --apply > "$tmp/c15" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlinked owned AGENTS.md should conflict (exit 1): $(cat "$tmp/c15")"
+grep -q "conflict: \[codex\] owned.*symlink" "$tmp/c15" \
+  || fail "missing owned-symlink conflict: $(cat "$tmp/c15")"
+grep -q "# real file elsewhere" "$tmp/real-agents.md" \
+  || fail "must not write through a symlinked owned file"
+
 echo "ok: connect self-test passed"

--- a/scripts/tests/register-test.sh
+++ b/scripts/tests/register-test.sh
@@ -294,10 +294,16 @@ EOF
 [ "$(jget "$tmp/scriptdir/generated/catalog.json" assets 0 registration)" = '"unsupported"' ] \
   || fail "directory script should be unsupported (not single-file buildable)"
 
-# --- case 11: repository 本体が register できる ---
+# --- case 11: repository 本体が register できる (実 repo を変異させないよう tmp コピーで検証) ---
+# 実 repo の catalog.json を直接上書きすると、branch でのテスト実行が実 sync の参照先を
+# 差し替える副作用がある (#150)。検証目的 (実 asset 一式で register が通る) はコピーでも同一。
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
-"$register" --root "$repo_root" --quiet > "$tmp/r8" 2>&1 \
+mkdir -p "$tmp/repocopy"
+cp -R "$repo_root/shared" "$tmp/repocopy/shared"
+cp -R "$repo_root/generated" "$tmp/repocopy/generated"
+rm -f "$tmp/repocopy/generated/catalog.json"
+"$register" --root "$tmp/repocopy" --quiet > "$tmp/r8" 2>&1 \
   || fail "repository register should pass: $(cat "$tmp/r8")"
-[ -f "$repo_root/generated/catalog.json" ] || fail "repository catalog missing"
+[ -f "$tmp/repocopy/generated/catalog.json" ] || fail "repository catalog missing"
 
 echo "ok: register self-test passed"

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -651,4 +651,17 @@ printf '\377' >> "$tmp/codex27b/AGENTS.md"
 grep -q "skip: \[codex\].*up-to-date" "$tmp/out27b" \
   || fail "managed owned file with non-UTF-8 tail should stay up-to-date: $(cat "$tmp/out27b")"
 
+# --- case 28: 所有先 AGENTS.md 自体が symlink なら conflict (実体へ書き抜けない) (#150) ---
+# (case 11 は親 dir の symlink。所有ファイル自体が symlink のケースはここで押さえる)
+mkdir -p "$tmp/codex28" "$tmp/claude28"
+echo "# real file elsewhere" > "$tmp/real-agents-sync.md"
+ln -s "$tmp/real-agents-sync.md" "$tmp/codex28/AGENTS.md"
+status=0
+"$sync" --root "$tmp/repo" --codex-home "$tmp/codex28" --claude-home "$tmp/claude28" --apply > "$tmp/out28" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "symlinked owned AGENTS.md should conflict (exit 1): $(cat "$tmp/out28")"
+grep -q "conflict: \[codex\].*symlink" "$tmp/out28" \
+  || fail "missing owned-symlink conflict: $(cat "$tmp/out28")"
+grep -q "# real file elsewhere" "$tmp/real-agents-sync.md" \
+  || fail "must not write through a symlinked owned file"
+
 echo "ok: sync self-test passed"


### PR DESCRIPTION
## 概要

監査FU #150 の残 5 件。方針は issue の 2026-07-05 判断コメントで確定済み。テスト・CI のみの変更で、pipeline 本体のコード変更なし・配備影響なし。

## 変更内容

### 1. self-test の実 repo 変異を tmp コピー化 (medium)

build-test case 5 / register-test case 11 が実 repo の `generated/` と `catalog.json` を直接上書きしていた。branch でテストを走らせると実 sync の参照先が branch 内容に差し替わり、sync --prune (#165) 導入後は「後日 `sync --prune --apply` で現役 deployed が撤去される」まで悪化しうる。`shared/` (+ register は `generated/`) を tmp へコピーしてから実行する方式に変更。検証目的 (実 asset 一式で pipeline が通る) はコピーでも同一。

### 2. Ruby 3.x CI matrix (low)

CI が macOS system Ruby (2.6 / psych 3) のみで、`yaml_util.rb` の psych >= 4 分岐が dead path (未検証の互換性主張) だった。matrix (`system` + `3.4`) を追加。setup-ruby は full commit SHA pin (`d45b1a4e…` = v1.316.0)。`scripts/*.sh` は PATH の ruby を exec するため PATH 差し替えだけで切り替わる。branch protection の required check は未設定のため check 名の matrix 化による影響なし。

### 3. check-manifests reject 経路の代表 fixture (low)

`validate_*` の主要 reject 分岐 (unknown field / schema_version / name 不一致 / kind / visibility / targets / risk / source.format / review 値 / 必須フィールド欠落) を case 7 で到達させる。

### 4. check-credential-isolation の未到達分岐 (low)

positive 重複の件数エラー分岐 (case 7 は negative 側のみだった) と、top-level 型エラー 2 種 (JSON object でない / probes が array でない) を case 19-21 で到達させる。

### 5. AGENTS.md 自体が symlink のケース (low)

既存テストは親 dir symlink のみだった。所有ファイル自体が symlink のケースを connect-test case 15 / sync-test case 28 に追加し、conflict になり実体へ書き抜けないことを assert。

## 検証

- self-test 12 本すべて緑 (macOS system ruby 2.6、main rebase 後に再実行)
- tmp コピー化後、テスト実行で実 repo の `generated/` / `catalog.json` に diff が出ないことを確認
- Ruby 3.4 行は本 PR の CI matrix が検証する (local に 3.x 環境なし)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv