### PR TITLE
docs: safe-gh-hook の登録所有と配備先パス契約の明文化(#146)

### DIFF
--- a/docs/boundary-with-dotfiles.md
+++ b/docs/boundary-with-dotfiles.md
@@ -24,7 +24,7 @@
 - tool-specific generated artifacts。
 - runtime GitHub injection 防御の **body / 振る舞い**: provenance 3 軸の trust 判定ロジック、
   `safe-gh` wrapper 本体、`PreToolUse` hook の script body と home 配布 (build / sync)、
-  隔離 reader workflow、policy data の single source (tool 別 render)、Codex hook 配線
+  隔離 reader workflow、policy data の single source (tool 別 render)、Codex hook 用の body 互換 (登録・配線は dotfiles)
   (下記「runtime GitHub injection 防御の分担」)。
 - registered assets 向け prompt injection review policy (supply-side: 配布する asset 自体に
   injection が仕込まれていないかを register / sync 前に検査する。runtime の外部入力防御とは
@@ -44,7 +44,7 @@ review policy」) とは攻撃面が逆向きの別レイヤー。設計の spec
   参照、doctor の presence report、射程と限界の docs。
 - **agent-tools (body)**: trust 判定ロジック (provenance 3 軸)、`safe-gh` wrapper 本体、hook の
   script body とその home 配布 (build / sync)、隔離 reader workflow、policy data の single source、
-  Codex hook 配線。
+  Codex hook 用の body 互換 (登録・配線は dotfiles)。
 
 原則は「runtime / invocation に属するものは agent-tools、宣言 / 規約 / capability に属するものは
 dotfiles」。command-string allowlist / hook / provenance は enforcement boundary ではなく steering で

--- a/docs/boundary-with-dotfiles.md
+++ b/docs/boundary-with-dotfiles.md
@@ -50,6 +50,13 @@ review policy」) とは攻撃面が逆向きの別レイヤー。設計の spec
 dotfiles」。command-string allowlist / hook / provenance は enforcement boundary ではなく steering で
 ある (egress も hostname best-effort) 点は、過大評価しないよう spec と docs で honest に明記する。
 
+hook のように 1 つの機能が両 repo にまたがるもの (実体 = agent-tools / 登録 = dotfiles) は、所有を
+明示しないとどちらも持たず宙に浮く (機能は配備済みなのに不活性になる)。script 資産の配備先 path
+(`<home>/agent-tools/scripts/<name>`) は dotfiles が settings.json 等から絶対 path で参照する
+**公開契約**であり、agent-tools は path の変更を breaking change として扱う (dotfiles 側の参照更新と
+同期するまで旧 path を壊さない)。詳細は
+[Runtime GitHub Injection 防御](runtime-injection-defense.md) の「PreToolUse hook」節。
+
 ## どちらの repository も持たないもの
 
 - tokens。

--- a/docs/runtime-injection-defense.md
+++ b/docs/runtime-injection-defense.md
@@ -194,6 +194,14 @@ boundary でない)。
   入力 `tool_input.command` は両 tool 共通。
 - 純粋 match ロジックは `scripts/tests/safe-gh-hook-test.sh` で deterministic に検証。実 hook 配線
   (どの event に結ぶか)は dotfiles の settings.json = 実機(下記「検証境界」)。
+- **登録の所有と配備先パス契約 (実体 = agent-tools / 登録 = dotfiles)**: hook script の実体と home
+  配布は agent-tools が持ち、settings.json への hook 登録 (宣言) は dotfiles の settings template が
+  持つ。所有を明示しないとどちらの repo も登録を持たず宙に浮く (実際に 2026-07-02 の監査まで未登録 =
+  不活性だった)。**登録が無い間この hook は不活性**で steering は一切効かない (fail-open の帰結・
+  honest-label)。dotfiles は配備先の絶対 path
+  (`<home>/agent-tools/scripts/personal-safe-gh-hook`) を参照するため、この path は**公開契約**として
+  安定を保証する: 配置規約 (`<home>/agent-tools/scripts/<name>`) や script name の変更は
+  **breaking change** として扱い、dotfiles 側の hook 宣言の更新と同期するまで旧 path を壊さない。
 
 ## body ⇔ control plane 対応表
 


### PR DESCRIPTION
## Summary

personal-safe-gh-hook が「実体は配備済み・登録はどこも持たず不活性」のまま宙に浮いていた構造 (#146) に対する agent-tools 側の対応。docs のみ・配備影響なし (Closes #146)。

- **所有の明示**: 実体 (script body + home 配布) = agent-tools / 登録 (settings.json の hooks 宣言) = dotfiles settings template。未登録の間 hook は**不活性**で steering は効かない (fail-open の帰結) を honest-label として明記
- **配備先パスの公開契約**: `<home>/agent-tools/scripts/<name>` を dotfiles が絶対 path 参照する契約とし、**path 変更 = breaking change**(dotfiles 側の参照更新と同期するまで旧 path を壊さない)
- boundary-with-dotfiles.md には要約 + 正本 (runtime-injection-defense.md) へのリンクのみ (二重正本を作らない)

登録そのもの (settings.json template への hooks キー追加) と dotfiles 側管理責務分担表への明記は、dotfiles 側の対応 issue で実施する (issue #146 記載どおり登録済み)。

## 検証

- docs のみの変更 (shared/ 非接触・build/catalog 影響なし)
- 記載した配備先 path が実装 (ArtifactTargets の script 配置則・既存 docs 記述) と一致することを確認

## レビュー依頼

author = Claude のため Codex のレビューをお願いします(観点: 契約の記述が実装・既存 docs と矛盾しないか / over-claim がないか)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv