### PR TITLE
docs: Codex trust hash 未検証点に反映ループと再 trust 運用の道筋を追記 (#129 P3-07 follow-up)

### DIFF
--- a/docs/runtime-injection-defense.md
+++ b/docs/runtime-injection-defense.md
@@ -204,6 +204,17 @@ boundary でない)。
     対話 trust が要る (公式 docs)。hash の対象範囲 (hook 定義のみか script 内容を含むか = 再配備で
     trust が剥がれるか) は**未検証**。つまり Claude 側の「登録漏れ = 不活性」に加えて
     **「登録済みでも未 trust = 不活性」**の段がある。
+    - **検証と本項の更新 (反映ループ)**: この未検証点は dotfiles#181 (Codex 登録) の受け入れ確認で
+      決着する — 登録 → `/hooks` trust → **hook script を再配備 (agent-tools `sync --apply`) して
+      steer が出続けるか**を見れば、trust hash が script 内容を含むか判別できる。**結果が出たら
+      本項の「未検証」を実測に更新する** (docs drift 防止・反映先はこの段落)。
+    - **script 内容を含む場合の運用対処**: agent-tools が hook body を更新して再配備するたびに
+      Codex 側 trust が剥がれ、**再 trust するまで無警告で不活性**になる。対処は 2 択で、どちらを
+      採るかは dotfiles 側の登録判断: (a) 再配備を伴う agent-tools 側の hook 更新を dotfiles へ
+      通知し `/hooks` 再 trust を運用フローに組み込む (agent-tools 側 = source 更新時に
+      `approved_build_id` を再計算する #148 の内容紐づけが「再 trust が要る変更」の signal になる)、
+      または (b) 対話 trust の要らない managed hooks (system 層) で登録し trust 剥離自体を無くす
+      (ただし上記 `allow_managed_hooks_only` の副作用に注意)。
   - hook 読み込みは **user 層 (`~/.codex/hooks.json` / `config.toml` の `[hooks]`) のみ実機で確認**。
     project 層 (`<repo>/.codex/hooks.json`) は公式 docs に記載があるが **0.142.2 実機では scan
     されない** (docs と実装の乖離)。登録は user 層 = dotfiles managed に置く。

--- a/docs/runtime-injection-defense.md
+++ b/docs/runtime-injection-defense.md
@@ -205,9 +205,12 @@ boundary でない)。
     trust が剥がれるか) は**未検証**。つまり Claude 側の「登録漏れ = 不活性」に加えて
     **「登録済みでも未 trust = 不活性」**の段がある。
     - **検証と本項の更新 (反映ループ)**: この未検証点は dotfiles#181 (Codex 登録) の受け入れ確認で
-      決着する — 登録 → `/hooks` trust → **hook script を再配備 (agent-tools `sync --apply`) して
-      steer が出続けるか**を見れば、trust hash が script 内容を含むか判別できる。**結果が出たら
-      本項の「未検証」を実測に更新する** (docs drift 防止・反映先はこの段落)。
+      決着する — 登録 → `/hooks` trust → **hook body に観測可能な変更 (= build_id が変わる差分。
+      steer 文言の一時変更など) を入れて再配備 (agent-tools `build` → `sync --apply`) し、trust
+      再要求なしで steer が出続けるか**を見る。**内容不変の再配備 (`sync --apply` のみ) では hash も
+      不変で剥離が起きず判別できない**点に注意 (これが本 hash 範囲テストの肝)。判定: 出続ける =
+      trust hash は hook 定義 (command path 等) のみ / 出なくなる = script 内容を含み再配備で剥離。
+      **結果が出たら本項の「未検証」を実測に更新する** (docs drift 防止・反映先はこの段落)。
     - **script 内容を含む場合の運用対処**: agent-tools が hook body を更新して再配備するたびに
       Codex 側 trust が剥がれ、**再 trust するまで無警告で不活性**になる。対処は 2 択で、どちらを
       採るかは dotfiles 側の登録判断: (a) 再配備を伴う agent-tools 側の hook 更新を dotfiles へ


### PR DESCRIPTION
## 概要

#172 (P3-07 Codex parity) の follow-up。docs の Codex trust hash 項が「未検証」と honest-label
しただけで **反映方法が抜けていた**ため、2 点を追記した (docs 1 ファイル・11 行・hook body 無変更)。

1. **反映ループ**: dotfiles#181 の受け入れ確認で trust hash 範囲を実測したら、結果を **本項の
   「未検証」に反映する**という道筋 (反映先ポインタを段落自身に固定)。判別手順 (再配備して steer が
   出続けるか) も明記。放置すると「dotfiles で検証済みなのに agent-tools docs は未検証のまま」の
   drift になるのを防ぐ。
2. **再 trust の運用対処**: trust hash が script 内容を含む場合、agent-tools が hook を再配備する
   たびに Codex trust が剥がれ無警告で不活性になる。対処 2 択 ((a) `approved_build_id` 再計算を
   signal にした `/hooks` 再 trust の運用化 / (b) managed hooks で剥離自体を無くす) を記載。

dotfiles#181 側にも対の follow-back を投稿済み (issue コメント)。

## 検証

- diff は `docs/runtime-injection-defense.md` のみ (hook body・asset.yml 無変更 = build_id 不変・
  承認再計算不要)
- self-test (safe-gh-hook) 緑 / check-manifests 緑

Refs #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv