### PR TITLE
fix: sync/catalog の fail-closed hardening (Closes #179)

### DIFF
--- a/scripts/lib/catalog.rb
+++ b/scripts/lib/catalog.rb
@@ -19,15 +19,23 @@ module Catalog
   end
 
   # catalog を読む。存在しない (:missing) / catalog_version 不一致 (:version_mismatch) /
-  # JSON として壊れている (:unreadable) は entries を空にして返す (fail-closed)。
+  # JSON として壊れている・shape 不正 (:unreadable) は entries を空にして返す (fail-closed)。
   def self.read(root)
     path = File.join(root, ArtifactTargets::CATALOG_PATH)
     return Result.new(:missing, []) unless File.file?(path)
 
     data = JSON.parse(File.read(path))
+    # 型不正な catalog を fail-closed で弾く (#179 M-06)。top-level が object でないと
+    # data["catalog_version"] 参照自体が TypeError になり JSON::ParserError の rescue を
+    # 抜けてしまうため、まず shape を検証する。assets も entry も、下流が Hash#[] を
+    # 前提に読む (target / name / build_id) ので Array of Hash を要求する。
+    return Result.new(:unreadable, []) unless data.is_a?(Hash)
     return Result.new(:version_mismatch, []) unless data["catalog_version"] == ArtifactTargets::CATALOG_VERSION
 
-    Result.new(:ok, data.fetch("assets", []))
+    assets = data.fetch("assets", [])
+    return Result.new(:unreadable, []) unless assets.is_a?(Array) && assets.all?(Hash)
+
+    Result.new(:ok, assets)
   rescue JSON::ParserError
     Result.new(:unreadable, [])
   end

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -143,7 +143,7 @@ module Doctor
         report("warn", "catalog", "version mismatch (re-run register)")
         return
       when :unreadable
-        report("fail", "catalog", "unreadable (invalid JSON)")
+        report("fail", "catalog", "unreadable (invalid JSON or shape)")
         return
       end
       entries = catalog.entries

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -333,6 +333,14 @@ module Sync
         return Plan.new("conflict", tool, name, target, "existing target is a symlink", "script", gen)
       end
       unless File.exist?(target)
+        # 本体が未配置でも sidecar marker が unmanaged な平ファイルとして残っていることがある。
+        # create で apply が無条件に sidecar を上書きしないよう、本体だけでなく sidecar の
+        # 管理状態も確認する (本体ありの update 経路と対称, #179 H-06)。symlink な sidecar は
+        # script_target_symlink? が上で conflict 済み。
+        sidecar = ArtifactTargets.sidecar_marker_path(target)
+        if File.exist?(sidecar) && !managed?(read_marker_file(sidecar), tool, name)
+          return Plan.new("conflict", tool, name, target, "existing sidecar marker is unmanaged", "script", gen)
+        end
         return Plan.new("create", tool, name, target, nil, "script", gen)
       end
 

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -696,4 +696,17 @@ echo '{"catalog_version":3,"assets":[1,2,3]}' > "$tmp/badcat/generated/catalog.j
 grep -q "no catalog" "$tmp/out30b" \
   || fail "non-Hash asset entries should be treated as no-catalog: $(cat "$tmp/out30b")"
 
+# --- case 31: 本体不在 + managed sidecar は conflict にせず create する (#179 H-06 の許可側) ---
+# (case 29 の unmanaged と対。本体だけ消えて自分の managed marker が残った状態からの再配置。)
+rm -rf "$tmp/sclaude15/agent-tools"
+mkdir -p "$tmp/sclaude15/agent-tools/scripts"
+cp "$tmp/srepo15/generated/claude-code/scripts/personal-wrap.agent-tools-managed.yml" \
+   "$tmp/sclaude15/agent-tools/scripts/personal-wrap.agent-tools-managed.yml"
+run15 > "$tmp/out31" 2>&1 || fail "body-absent + managed sidecar dry-run should succeed: $(cat "$tmp/out31")"
+grep -q "create: \[claude-code\]" "$tmp/out31" \
+  || fail "body-absent + managed sidecar should plan create (not conflict): $(cat "$tmp/out31")"
+run15 --apply --quiet > /dev/null 2>&1
+[ -f "$tmp/sclaude15/agent-tools/scripts/personal-wrap" ] \
+  || fail "create should deploy the body when the existing sidecar is managed"
+
 echo "ok: sync self-test passed"

--- a/scripts/tests/sync-test.sh
+++ b/scripts/tests/sync-test.sh
@@ -664,4 +664,36 @@ grep -q "conflict: \[codex\].*symlink" "$tmp/out28" \
 grep -q "# real file elsewhere" "$tmp/real-agents-sync.md" \
   || fail "must not write through a symlinked owned file"
 
+# --- case 29: 本体不在で unmanaged な sidecar だけ残る script は conflict (上書きしない, #179 H-06) ---
+# (case 17 は本体が unmanaged。本体が無く sidecar marker だけが平ファイルで残るケース。
+#  旧 create 経路は本体不在だけ見て sidecar を無条件上書きしていた。)
+rm -rf "$tmp/sclaude15/agent-tools"
+mkdir -p "$tmp/sclaude15/agent-tools/scripts"
+printf 'user-owned sidecar\n' \
+  > "$tmp/sclaude15/agent-tools/scripts/personal-wrap.agent-tools-managed.yml"
+status=0
+run15 --apply > "$tmp/out29" 2>&1 || status=$?
+[ "$status" -eq 1 ] || fail "unmanaged sidecar without body should exit 1, got $status: $(cat "$tmp/out29")"
+grep -q "conflict: \[claude-code\].*sidecar marker is unmanaged" "$tmp/out29" \
+  || fail "missing unmanaged-sidecar conflict: $(cat "$tmp/out29")"
+grep -q "user-owned sidecar" "$tmp/sclaude15/agent-tools/scripts/personal-wrap.agent-tools-managed.yml" \
+  || fail "unmanaged sidecar must not be overwritten"
+[ ! -e "$tmp/sclaude15/agent-tools/scripts/personal-wrap" ] \
+  || fail "body must not be created when the sidecar is unmanaged"
+
+# --- case 30: shape 不正な catalog は crash させず fail-closed で no-catalog 扱い (#179 M-06) ---
+mkdir -p "$tmp/badcat/generated"
+# top-level が object でない → 旧実装は data["catalog_version"] 参照で TypeError
+echo '["not","an","object"]' > "$tmp/badcat/generated/catalog.json"
+"$sync" --root "$tmp/badcat" --codex-home "$tmp/bc-codex" --claude-home "$tmp/bc-claude" \
+  > "$tmp/out30a" 2>&1 || fail "malformed catalog must not crash sync: $(cat "$tmp/out30a")"
+grep -q "no catalog" "$tmp/out30a" \
+  || fail "non-object catalog should be treated as no-catalog: $(cat "$tmp/out30a")"
+# assets が Array of Hash でない場合も fail-closed
+echo '{"catalog_version":3,"assets":[1,2,3]}' > "$tmp/badcat/generated/catalog.json"
+"$sync" --root "$tmp/badcat" --codex-home "$tmp/bc-codex" --claude-home "$tmp/bc-claude" \
+  > "$tmp/out30b" 2>&1 || fail "malformed assets must not crash sync: $(cat "$tmp/out30b")"
+grep -q "no catalog" "$tmp/out30b" \
+  || fail "non-Hash asset entries should be treated as no-catalog: $(cat "$tmp/out30b")"
+
 echo "ok: sync self-test passed"


### PR DESCRIPTION
Codex 監査 2026-07-10 の CONFIRMED 2 件。umbrella #176。

## H-06: unmanaged script sidecar の上書き
- `plan_script` の create 判定が本体不在だけを見て sidecar marker の管理状態を確認せず、本体が無く sidecar だけが unmanaged な平ファイルで残る場合に create → apply で無条件上書き (本体ありの update 経路は marker を managed 検査するので非対称)。
- create 経路でも sidecar が unmanaged なら conflict にする。

## M-06: catalog schema の未検証
- `Catalog.read` が JSON parse と catalog_version 一致しか見ず、top-level が非 object だと `data["catalog_version"]` 参照自体が TypeError で `JSON::ParserError` の rescue を抜けていた。assets が Array of Hash であることも未検証で下流 TypeError の余地。
- shape を検証し、不正形は既存 `:unreadable` state で fail-closed (no-catalog 扱い)。

## 検証
- 回帰テスト: 本体不在+unmanaged sidecar / 非 object catalog / 非 Hash asset entries。self-test 全緑。

author=Claude → reviewer=Codex。

🤖 Generated with [Claude Code](https://claude.com/claude-code)