### PR TITLE
refactor: pipeline lib の挙動不変リファクタ (衛生・一元化・marker/承認判定の集約)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -215,11 +215,11 @@ kind / tool の知識は `lib/artifact_targets.rb` に集約されているが (
 7. tests: `tests/build-test.sh` / `sync-test.sh` / `status-test.sh` /
    `register-test.sh` に既存 kind と対称のケースを足す。
 
-**tool を追加するとき** (v1 は 2 tool 固定。一元化は #152 low として将来):
+**tool を追加するとき** (v1 は 2 tool 固定。tool 語彙と home 既定値は #192 で一元化済み):
 
-1. tool 一覧: `lib/build.rb` / `lib/sync.rb` の `TOOLS`、
-   `lib/check_manifests.rb` の `TARGETS`。
-2. homes 既定値と CLI flag: `sync` / `connect` / `status` / `doctor` の `main`。
+1. tool 一覧と home 既定値: `lib/artifact_targets.rb` の `TOOLS` と `default_homes`
+   (build / sync / check-manifests / status / doctor はここを参照する)。
+2. CLI flag: `sync` / `connect` / `status` / `doctor` の `main` に `--<tool>-home` を足す。
 3. instruction を配るなら `ArtifactTargets::INSTRUCTION_FILENAMES` と connect の
    所有戦略 (import 対応可否)。
 

--- a/scripts/lib/artifact_targets.rb
+++ b/scripts/lib/artifact_targets.rb
@@ -16,6 +16,20 @@ module ArtifactTargets
   # catalog の repo root 相対 path。register が書き、Catalog.read が読む (#152)。
   CATALOG_PATH = "generated/catalog.json"
 
+  # 対応 tool の語彙 (走査順も配布順として意味を持つ)。tool を追加するときはここだけを
+  # 変える (build の生成走査・sync の prune 走査・check-manifests の targets 検証・status の
+  # generated 列挙が全てここを参照する, #152)。
+  TOOLS = %w[codex claude-code].freeze
+
+  # 既定の tool home。各 CLI main が --codex-home 等で上書き (破壊的代入) するため、
+  # frozen 定数ではなく毎回 fresh な mutable Hash を返す。
+  def self.default_homes
+    {
+      "codex" => File.expand_path("~/.codex"),
+      "claude-code" => File.expand_path("~/.claude"),
+    }
+  end
+
   # build が扱える artifact_kind。
   SUPPORTED_KINDS = %w[skill instruction script].freeze
 
@@ -58,6 +72,14 @@ module ArtifactTargets
 
   def self.supported?(kind)
     SUPPORTED_KINDS.include?(kind)
+  end
+
+  # asset のいずれかの target が指定 kind に解決されるか。register の script 判定と
+  # check_injection の instruction / skill 昇格判定が共有する。
+  # targets が Array であることの型ガードは呼び出し側の責務 (未検証 YAML を読む経路は
+  # 呼び出し側が fail-closed に弾いてから渡す)。
+  def self.resolves_any?(asset, kind)
+    (asset[:targets] || []).any? { |tool| resolve(asset, tool) == kind }
   end
 
   # 単一ファイル artifact (script) の sidecar management marker file path。

--- a/scripts/lib/assets.rb
+++ b/scripts/lib/assets.rb
@@ -25,6 +25,14 @@ module Assets
   rescue SystemCallError, IOError
     false
   end
+  # 絶対 path を root 相対に変換する (root prefix のみ剥がす)。root は File.expand_path
+  # 済みであることが前提 (呼び出し側の責務。生の相対 root を渡すと prefix が一致せず
+  # 絶対 path のまま返る)。build / check-manifests / check-injection の表示 path と
+  # manifest_path の正規化が共有する (#192)。
+  def self.rel(root, path)
+    path.sub(%r{\A#{Regexp.escape(root)}/}, "")
+  end
+
   # sidecar manifest と directory manifest を sort して返す (絶対 path)。
   # glob は `foo.asset.yml` という名前の directory にもマッチしうるため、File.read で
   # EISDIR を踏まないよう file だけに絞る (directory manifest は File.file? で残る)。
@@ -40,7 +48,7 @@ module Assets
   def self.load_all(root)
     root = File.expand_path(root)
     manifest_paths(root).map do |full|
-      rel = full.sub(%r{\A#{Regexp.escape(root)}/}, "")
+      rel = Assets.rel(root, full)
       from_manifest(YamlUtil.load(File.read(full), rel), rel)
     end
   end

--- a/scripts/lib/assets.rb
+++ b/scripts/lib/assets.rb
@@ -74,4 +74,5 @@ module Assets
       manifest_path: rel,
     }
   end
+  private_class_method :from_manifest
 end

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -16,6 +16,7 @@ require_relative "assets"
 require_relative "gate"
 require_relative "artifact_targets"
 require_relative "instruction_marker"
+require_relative "yaml_marker"
 
 module Build
   TOOLS = ArtifactTargets::TOOLS
@@ -111,7 +112,8 @@ module Build
       FileUtils.cp(File.join(@root, source), out)
       File.chmod(0o755, out) # script は配置先で実行されるため実行可能にする
       build_id = Build.build_id_for(@root, source, format)
-      File.write(ArtifactTargets.sidecar_marker_path(out), marker_yaml(name, tool, source, build_id))
+      File.write(ArtifactTargets.sidecar_marker_path(out),
+                 YamlMarker.render(name: name, target: tool, source: source, build_id: build_id))
       @built << rel(out)
     end
 
@@ -148,18 +150,7 @@ module Build
     # directory artifact (skill) の管理 marker を dir 直下に書く。
     def write_marker(out_dir, name, tool, source, build_id)
       File.write(File.join(out_dir, ArtifactTargets::MARKER_BASENAME),
-                 marker_yaml(name, tool, source, build_id))
-    end
-
-    # YAML marker の本文。directory marker (skill) と sidecar marker (script) が共有する。
-    def marker_yaml(name, tool, source, build_id)
-      YAML.dump(
-        "repo" => "agent-tools",
-        "name" => name,
-        "target" => tool,
-        "source" => source,
-        "build_id" => build_id,
-      )
+                 YamlMarker.render(name: name, target: tool, source: source, build_id: build_id))
     end
 
     def rel(path)
@@ -253,12 +244,8 @@ module Build
 
     # marker file が存在し agent-tools repo を示すか (本文 YAML を読む)。
     def marker_present?(marker_path)
-      return false unless File.file?(marker_path)
-
-      data = YamlUtil.load(File.read(marker_path), marker_path)
-      data.is_a?(Hash) && data["repo"] == "agent-tools"
-    rescue Psych::Exception
-      false
+      marker = YamlMarker.read_file(marker_path)
+      !marker.nil? && marker["repo"] == "agent-tools"
     end
   end
 

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -27,8 +27,6 @@ module Build
       @skipped = []
     end
 
-    attr_reader :built, :skipped
-
     def run
       Assets.load_all(@root).each do |asset|
         asset[:targets].each do |tool|

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -18,7 +18,7 @@ require_relative "artifact_targets"
 require_relative "instruction_marker"
 
 module Build
-  TOOLS = %w[codex claude-code].freeze
+  TOOLS = ArtifactTargets::TOOLS
 
   class Runner
     def initialize(root)

--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -154,7 +154,7 @@ module Build
     end
 
     def rel(path)
-      path.sub(%r{\A#{Regexp.escape(@root)}/}, "")
+      Assets.rel(@root, path)
     end
 
     public

--- a/scripts/lib/check_injection.rb
+++ b/scripts/lib/check_injection.rb
@@ -111,17 +111,6 @@ module CheckInjection
       @root = File.expand_path(root)
     end
 
-    # shared/ 配下のすべての text files を scan する。manifest も text として含める。
-    # directory skill の evals/ (テスト材料。意図的に攻撃的文字列を含みうる) は
-    # injection 攻撃文字列・fake path・email の scan からは外すが、inline private key leak
-    # のみ引き続き scan する (run で per-file に判定する)。
-    def target_files
-      Dir.glob(File.join(@root, "shared/**/*"), File::FNM_DOTMATCH)
-         .select { |p| File.file?(p) }
-         .reject { |p| File.basename(p) == ".gitkeep" }
-         .sort
-    end
-
     def run
       instruction_sources = instruction_source_paths
       eval_prefixes = skill_eval_dir_prefixes
@@ -154,6 +143,17 @@ module CheckInjection
     end
 
     private
+
+    # shared/ 配下のすべての text files を scan する。manifest も text として含める。
+    # directory skill の evals/ (テスト材料。意図的に攻撃的文字列を含みうる) は
+    # injection 攻撃文字列・fake path・email の scan からは外すが、inline private key leak
+    # のみ引き続き scan する (run で per-file に判定する)。
+    def target_files
+      Dir.glob(File.join(@root, "shared/**/*"), File::FNM_DOTMATCH)
+         .select { |p| File.file?(p) }
+         .reject { |p| File.basename(p) == ".gitkeep" }
+         .sort
+    end
 
     def strict_instruction(finding)
       return finding unless finding.category == "external-url"
@@ -205,7 +205,7 @@ module CheckInjection
     end
 
     # leak_only=true (evals/) のときは privacy/secret leak の category だけを当てる。
-    def scan(path, content, leak_only = false)
+    def scan(path, content, leak_only)
       patterns = leak_only ? PATTERNS.select { |p| LEAK_CATEGORIES.include?(p.category) } : PATTERNS
       patterns.flat_map do |pattern|
         positions = []

--- a/scripts/lib/check_injection.rb
+++ b/scripts/lib/check_injection.rb
@@ -199,7 +199,7 @@ module CheckInjection
     end
 
     def rel(path)
-      path.sub(%r{\A#{Regexp.escape(@root)}/}, "")
+      Assets.rel(@root, path)
     end
 
     # leak_only=true (evals/) のときは privacy/secret leak の category だけを当てる。

--- a/scripts/lib/check_injection.rb
+++ b/scripts/lib/check_injection.rb
@@ -112,8 +112,7 @@ module CheckInjection
     end
 
     def run
-      instruction_sources = instruction_source_paths
-      eval_prefixes = skill_eval_dir_prefixes
+      instruction_sources, eval_prefixes = asset_scan_context
       findings = []
       count = 0
       target_files.each do |full|
@@ -161,42 +160,35 @@ module CheckInjection
       Finding.new(finding.path, finding.line, "high", finding.category, finding.message)
     end
 
-    # instruction artifact を生成する asset の source path 一覧。
-    # 壊れた manifest では昇格しない (gate の check-manifests が別途 fail させる)。
-    def instruction_source_paths
+    # manifest 由来の scan 文脈を 1 回の走査で組み立てて [instruction_sources, eval_prefixes]
+    # で返す:
+    # - instruction artifact を生成する asset の source path 一覧 (external-url の high 昇格用)。
+    # - directory skill の evals/ 配下を leak_only 判定するための絶対 path prefix 一覧
+    #   (evals は injection 攻撃文字列を抑止し leak (private-key) のみ scan する。run が使う。)
+    # 壊れた manifest では昇格も prefix も出さない (gate の check-manifests が別途 fail させる)。
+    def asset_scan_context
       paths = []
-      Assets.load_all(@root).each do |asset|
-        next unless asset[:source].is_a?(Hash)
-        next unless asset[:targets].is_a?(Array)
-
-        paths << asset[:source]["path"] if ArtifactTargets.resolves_any?(asset, "instruction")
-      end
-      paths
-    rescue Psych::Exception
-      []
-    end
-
-    # directory skill の evals/ 配下を leak_only 判定するための絶対 path prefix 一覧。
-    # (evals は injection 攻撃文字列を抑止し leak (private-key) のみ scan する。run が使う。)
-    # 壊れた manifest では prefix を出さない (gate の check-manifests が別途 fail させる)。
-    def skill_eval_dir_prefixes
       prefixes = []
       Assets.load_all(@root).each do |asset|
         source = asset[:source]
-        next unless source.is_a?(Hash) && source["format"] == "directory"
-        next unless source["path"].is_a?(String)
+        next unless source.is_a?(Hash)
         next unless asset[:targets].is_a?(Array)
 
+        paths << source["path"] if ArtifactTargets.resolves_any?(asset, "instruction")
+
+        next unless source["format"] == "directory"
+        next unless source["path"].is_a?(String)
         next unless ArtifactTargets.resolves_any?(asset, "skill")
 
         ArtifactTargets::SKILL_NON_DEPLOY_DIRS.each do |sub|
           prefixes << "#{File.join(@root, source['path'], sub)}/"
         end
       end
-      prefixes
+      [paths, prefixes]
     rescue Psych::Exception
-      []
+      [[], []]
     end
+
 
     def rel(path)
       Assets.rel(@root, path)

--- a/scripts/lib/check_injection.rb
+++ b/scripts/lib/check_injection.rb
@@ -169,8 +169,7 @@ module CheckInjection
         next unless asset[:source].is_a?(Hash)
         next unless asset[:targets].is_a?(Array)
 
-        instruction = asset[:targets].any? { |t| ArtifactTargets.resolve(asset, t) == "instruction" }
-        paths << asset[:source]["path"] if instruction
+        paths << asset[:source]["path"] if ArtifactTargets.resolves_any?(asset, "instruction")
       end
       paths
     rescue Psych::Exception
@@ -188,8 +187,7 @@ module CheckInjection
         next unless source["path"].is_a?(String)
         next unless asset[:targets].is_a?(Array)
 
-        is_skill = asset[:targets].any? { |t| ArtifactTargets.resolve(asset, t) == "skill" }
-        next unless is_skill
+        next unless ArtifactTargets.resolves_any?(asset, "skill")
 
         ArtifactTargets::SKILL_NON_DEPLOY_DIRS.each do |sub|
           prefixes << "#{File.join(@root, source['path'], sub)}/"

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -16,7 +16,7 @@ module CheckManifests
   KINDS = %w[skill prompt workflow agent instruction script].freeze
   TRACKED_VISIBILITIES = %w[public personal].freeze
   FORBIDDEN_VISIBILITIES = %w[private work client secret].freeze
-  TARGETS = %w[codex claude-code].freeze
+  TARGETS = ArtifactTargets::TOOLS
   RISK_KEYS = %w[prompt_injection privacy].freeze
   RISK_LEVELS = %w[low medium high unknown].freeze
   SOURCE_FORMATS = %w[markdown yaml json toml text directory].freeze

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -41,8 +41,6 @@ module CheckManifests
   NON_ASSET_BASENAMES = %w[README.md].freeze
 
   class Runner
-    attr_reader :errors
-
     def initialize(root)
       @root = File.expand_path(root)
       @errors = []

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -65,7 +65,7 @@ module CheckManifests
     end
 
     def rel(path)
-      path.sub(%r{\A#{Regexp.escape(@root)}/}, "")
+      Assets.rel(@root, path)
     end
 
     def discover_manifests

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -196,10 +196,7 @@ module Connect
     root = Dir.pwd
     apply = false
     quiet = false
-    homes = {
-      "codex" => File.expand_path("~/.codex"),
-      "claude-code" => File.expand_path("~/.claude"),
-    }
+    homes = ArtifactTargets.default_homes
     until argv.empty?
       case (arg = argv.shift)
       when "--root"

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -39,14 +39,6 @@ module Connect
       load_catalog
     end
 
-    # catalog を source of truth として読む (reader は sync / status / doctor と共通の
-    # Catalog.read)。connect は registered な instruction だけを所有確立する (review gate)。
-    def load_catalog
-      result = Catalog.read(@root)
-      @catalog_present = result.present?
-      @entries = result.entries
-    end
-
     def plan
       claude_plans + codex_plans
     end
@@ -61,6 +53,14 @@ module Connect
     end
 
     private
+
+    # catalog を source of truth として読む (reader は sync / status / doctor と共通の
+    # Catalog.read)。connect は registered な instruction だけを所有確立する (review gate)。
+    def load_catalog
+      result = Catalog.read(@root)
+      @catalog_present = result.present?
+      @entries = result.entries
+    end
 
     # tool の generated instruction path (tool 固有 filename の解決は generated_path に委ねる)。
     def generated_instruction(tool)

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -9,7 +9,6 @@
 # - 出力に secrets / absolute private paths を含めない (paths は tilde 表記)。
 # - 外部依存ゼロ、network access なし。
 
-require "json"
 require "yaml"
 
 require_relative "assets"
@@ -19,8 +18,6 @@ require_relative "artifact_targets"
 require_relative "catalog"
 
 module Doctor
-  LEVELS = %w[ok info warn fail].freeze
-
   Line = Struct.new(:level, :area, :message) do
     def to_s
       "#{level}: #{area}: #{message}"

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -210,10 +210,7 @@ module Doctor
 
   def self.main(argv)
     root = Dir.pwd
-    homes = {
-      "codex" => File.expand_path("~/.codex"),
-      "claude-code" => File.expand_path("~/.claude"),
-    }
+    homes = ArtifactTargets.default_homes
     agents_home = File.expand_path("~/.agents")
     until argv.empty?
       case (arg = argv.shift)

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -85,8 +85,7 @@ module Register
       # fail-closed にしているのと対称に、常に human review を要求する。判定は manifest の
       # kind でなく resolve 後の artifact_kind で行う (compatibility override で任意 kind を
       # script 配布にできるため、kind 基準では迂回できてしまう)。
-      script_artifact = (asset[:targets] || [])
-                        .any? { |tool| ArtifactTargets.resolve(asset, tool) == "script" }
+      script_artifact = ArtifactTargets.resolves_any?(asset, "script")
       review_needed = asset[:flagged] ||
                       script_artifact ||
                       asset[:declared_risks].any? { |r| %w[medium unknown].include?(r) }

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -79,28 +79,10 @@ module Register
     # review 観点の registration は asset 単位で決まり、buildable でない
     # target-artifact は "unsupported" にして registered != buildable を防ぐ。
     def catalog_entries(asset)
-      # 宣言 risk の medium / unknown も human review 必須として扱う。
-      # script artifact は実行コードの配布で、静的 gate が当てられるのは injection 文言の
-      # regex のみ (コードの悪性は検査できない)。directory skill の scripts/ を #43 まで
-      # fail-closed にしているのと対称に、常に human review を要求する。判定は manifest の
-      # kind でなく resolve 後の artifact_kind で行う (compatibility override で任意 kind を
-      # script 配布にできるため、kind 基準では迂回できてしまう)。
-      script_artifact = ArtifactTargets.resolves_any?(asset, "script")
-      review_needed = asset[:flagged] ||
-                      script_artifact ||
-                      asset[:declared_risks].any? { |r| %w[medium unknown].include?(r) }
+      review_needed = review_needed?(asset)
       # source content の決定的 hash。target に依らない。doctor の鮮度判定に使う。
       build_id = Build.build_id_for(@root, asset[:source]["path"], asset[:source]["format"])
-      # 承認 identity は (内容 = build_id, 配布形態 = artifact_kind) の対 (#148, #184)。
-      # 内容のみの束縛だと、source 不変のまま kind を script に変えて「skill として承認した
-      # source を実行ファイルとして配布」でき、再レビューなしで意味が変わる穴が残る。
-      # artifact_kind は tool ごとに解決されるため、承認の有効性も tool 単位で判定する。
-      approved = asset[:human_review] == "approved"
-      if review_needed && approved && asset[:approved_build_id] != build_id
-        warn "#{asset[:name]}: human_review is approved but review.approved_build_id does not " \
-             "match current build_id #{build_id}; re-review the content and update approved_build_id"
-      end
-
+      warn_stale_approval(asset, build_id) if review_needed
       # 登録判断 (risk / review / targets) は manifest に依存する。manifest の digest を
       # entry に記録し、reader (sync / doctor) が register 後の manifest 変更を検出できる
       # ようにする (#148)。
@@ -108,42 +90,81 @@ module Register
 
       (asset[:targets] || []).map do |tool|
         artifact_kind = ArtifactTargets.resolve(asset, tool)
-        approval_effective = approved &&
-                             asset[:approved_build_id] == build_id &&
-                             asset[:approved_artifact_kind] == artifact_kind
-        if review_needed && approved && asset[:approved_build_id] == build_id &&
-           asset[:approved_artifact_kind] != artifact_kind
-          warn "#{asset[:name]}: human_review is approved but review.approved_artifact_kind " \
-               "#{asset[:approved_artifact_kind].inspect} does not match resolved artifact_kind " \
-               "#{artifact_kind.inspect} for #{tool}; re-review the distribution form and " \
-               "update approved_artifact_kind"
-        end
+        warn_kind_mismatch(asset, build_id, artifact_kind, tool) if review_needed
         review_registration =
           if !review_needed
             "registered"
-          elsif approval_effective
+          elsif approval_effective?(asset, build_id, artifact_kind)
             "registered"
           else
             "human_review_required"
           end
         registration = ArtifactTargets.buildable?(asset, tool) ? review_registration : "unsupported"
-        {
-          "name" => asset[:name],
-          "target" => tool,
-          "artifact_kind" => artifact_kind,
-          "kind" => asset[:kind],
-          "visibility" => asset[:visibility],
-          "source" => asset[:source],
-          "build_id" => build_id,
-          "manifest_path" => asset[:manifest_path],
-          "manifest_digest" => manifest_digest,
-          "checks" => {
-            "manifest_validation" => "pass",
-            "prompt_injection_static" => asset[:flagged] ? "human_review" : "pass",
-          },
-          "registration" => registration,
-        }
+        entry_for(asset, tool, artifact_kind, build_id, manifest_digest, registration)
       end
+    end
+
+    # 宣言 risk の medium / unknown も human review 必須として扱う。
+    # script artifact は実行コードの配布で、静的 gate が当てられるのは injection 文言の
+    # regex のみ (コードの悪性は検査できない)。directory skill の scripts/ を #43 まで
+    # fail-closed にしているのと対称に、常に human review を要求する。判定は manifest の
+    # kind でなく resolve 後の artifact_kind で行う (compatibility override で任意 kind を
+    # script 配布にできるため、kind 基準では迂回できてしまう)。
+    def review_needed?(asset)
+      asset[:flagged] ||
+        ArtifactTargets.resolves_any?(asset, "script") ||
+        asset[:declared_risks].any? { |r| %w[medium unknown].include?(r) }
+    end
+
+    # 承認 identity は (内容 = build_id, 配布形態 = artifact_kind) の対 (#148, #184)。
+    # 内容のみの束縛だと、source 不変のまま kind を script に変えて「skill として承認した
+    # source を実行ファイルとして配布」でき、再レビューなしで意味が変わる穴が残る。
+    # artifact_kind は tool ごとに解決されるため、承認の有効性も tool 単位で判定する。
+    def approval_effective?(asset, build_id, artifact_kind)
+      asset[:human_review] == "approved" &&
+        asset[:approved_build_id] == build_id &&
+        asset[:approved_artifact_kind] == artifact_kind
+    end
+
+    # 内容 (build_id) が承認時と変わった asset への再レビュー案内 (asset 単位・target loop 外)。
+    def warn_stale_approval(asset, build_id)
+      return unless asset[:human_review] == "approved" && asset[:approved_build_id] != build_id
+
+      warn "#{asset[:name]}: human_review is approved but review.approved_build_id does not " \
+           "match current build_id #{build_id}; re-review the content and update approved_build_id"
+    end
+
+    # 配布形態 (artifact_kind) が承認時と違う target への再レビュー案内。build_id が一致する
+    # ときだけ出す (両方不一致なら stale 警告が既に出ており、二重に案内しない)。
+    def warn_kind_mismatch(asset, build_id, artifact_kind, tool)
+      return unless asset[:human_review] == "approved" &&
+                    asset[:approved_build_id] == build_id &&
+                    asset[:approved_artifact_kind] != artifact_kind
+
+      warn "#{asset[:name]}: human_review is approved but review.approved_artifact_kind " \
+           "#{asset[:approved_artifact_kind].inspect} does not match resolved artifact_kind " \
+           "#{artifact_kind.inspect} for #{tool}; re-review the distribution form and " \
+           "update approved_artifact_kind"
+    end
+
+    # catalog entry の 1 行分。キー順は catalog.json の byte 表現に直結するため変えない。
+    def entry_for(asset, tool, artifact_kind, build_id, manifest_digest, registration)
+      {
+        "name" => asset[:name],
+        "target" => tool,
+        "artifact_kind" => artifact_kind,
+        "kind" => asset[:kind],
+        "visibility" => asset[:visibility],
+        "source" => asset[:source],
+        "build_id" => build_id,
+        "manifest_path" => asset[:manifest_path],
+        "manifest_digest" => manifest_digest,
+        "checks" => {
+          "manifest_validation" => "pass",
+          "prompt_injection_static" => asset[:flagged] ? "human_review" : "pass",
+        },
+        "registration" => registration,
+      }
     end
 
   end

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -79,7 +79,7 @@ module Status
       sources = safe_sources_by_name
       total = 0
       stale = 0
-      Sync::TOOLS.each do |tool|
+      ArtifactTargets::TOOLS.each do |tool|
         Dir.glob(File.join(ArtifactTargets.generated_dir(@root, tool, "skill"), "*")).sort.each do |artifact|
           next unless File.directory?(artifact)
 
@@ -204,10 +204,7 @@ module Status
   def self.main(argv)
     root = Dir.pwd
     json = false
-    homes = {
-      "codex" => File.expand_path("~/.codex"),
-      "claude-code" => File.expand_path("~/.claude"),
-    }
+    homes = ArtifactTargets.default_homes
     until argv.empty?
       case (arg = argv.shift)
       when "--root"

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -9,7 +9,6 @@
 # - 外部依存ゼロ、network access なし。
 
 require "json"
-require "yaml"
 
 require_relative "assets"
 require_relative "check_manifests"
@@ -18,6 +17,7 @@ require_relative "build"
 require_relative "sync"
 require_relative "artifact_targets"
 require_relative "catalog"
+require_relative "yaml_util"
 require_relative "instruction_marker"
 
 module Status

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -17,7 +17,7 @@ require_relative "build"
 require_relative "sync"
 require_relative "artifact_targets"
 require_relative "catalog"
-require_relative "yaml_util"
+require_relative "yaml_marker"
 require_relative "instruction_marker"
 
 module Status
@@ -124,15 +124,7 @@ module Status
 
     # YAML marker file (skill の dir 直下 / script の sidecar) から鮮度を判定する。
     def fresh_by_marker_file?(marker_path, sources)
-      return false unless File.file?(marker_path)
-
-      marker = YamlUtil.load(File.read(marker_path), marker_path)
-      return false unless marker.is_a?(Hash)
-
-      source = sources[marker["name"]]
-      return false unless source
-
-      marker["build_id"] == Build.build_id_for(@root, source["path"], source["format"])
+      marker_fresh?(YamlMarker.read_file(marker_path), sources)
     rescue StandardError
       # 鮮度判定は best-effort。marker / source / build_id 計算の失敗 (Psych /
       # source path 欠落の TypeError / source ファイル欠落の Errno 等) は、検証不能 =
@@ -142,16 +134,21 @@ module Status
 
     # instruction (ファイル内コメント marker) の鮮度判定。
     def fresh_instruction?(path, sources)
-      marker = InstructionMarker.parse(File.read(path))
+      marker_fresh?(InstructionMarker.parse(File.read(path)), sources)
+    rescue StandardError
+      # fresh? と同じく best-effort: 検証不能なら stale 扱い (Errno / TypeError 等)。
+      false
+    end
+
+    # marker (nil 可) の name から source manifest を引き、build_id が現在の source 内容と
+    # 一致するか。marker 形式 (YAML / HTML コメント) に依らない鮮度判定の共通 tail。
+    def marker_fresh?(marker, sources)
       return false unless marker
 
       source = sources[marker["name"]]
       return false unless source
 
       marker["build_id"] == Build.build_id_for(@root, source["path"], source["format"])
-    rescue StandardError
-      # fresh? と同じく best-effort: 検証不能なら stale 扱い (Errno / TypeError 等)。
-      false
     end
 
     # catalog (docs/register-catalog.md) の register summary。読めない catalog

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -14,10 +14,9 @@
 # - --prune で catalog に載らなくなった deployed asset を撤去する (marker-gated delete,
 #   #154)。削除も --apply が必須で、既定は dry-run。
 
-require "yaml"
 require "fileutils"
 
-require_relative "yaml_util"
+require_relative "yaml_marker"
 require_relative "artifact_targets"
 require_relative "catalog"
 require_relative "instruction_marker"
@@ -144,7 +143,7 @@ module Sync
                         :orphan_symlink)
         end
         marker = File.directory?(target) ? read_marker(target) : nil
-        unless managed?(marker, tool, name)
+        unless YamlMarker.managed?(marker, tool, name)
           next Plan.new("skip", tool, name, target, "orphan is unmanaged; left in place", "skill", nil,
                         :orphan_unmanaged)
         end
@@ -170,8 +169,8 @@ module Sync
           next Plan.new("skip", tool, name, target, "orphan is a symlink; left in place", "script", nil,
                         :orphan_symlink)
         end
-        marker = read_marker_file(ArtifactTargets.sidecar_marker_path(target))
-        unless managed?(marker, tool, name)
+        marker = YamlMarker.read_file(ArtifactTargets.sidecar_marker_path(target))
+        unless YamlMarker.managed?(marker, tool, name)
           next Plan.new("skip", tool, name, target, "orphan is unmanaged; left in place", "script", nil,
                         :orphan_unmanaged)
         end
@@ -223,7 +222,7 @@ module Sync
       end
 
       source_marker = read_marker(gen)
-      unless managed?(source_marker, tool, name)
+      unless YamlMarker.managed?(source_marker, tool, name)
         return Plan.new("conflict", tool, name, target, "generated artifact is missing a valid marker", "skill", gen)
       end
       # generated が catalog entry と一致するか (build_id)。不一致 = register 後に build して
@@ -243,7 +242,7 @@ module Sync
       end
 
       target_marker = File.directory?(target) ? read_marker(target) : nil
-      unless managed?(target_marker, tool, name)
+      unless YamlMarker.managed?(target_marker, tool, name)
         return Plan.new("conflict", tool, name, target, "existing target is unmanaged", "skill", gen)
       end
 
@@ -317,8 +316,8 @@ module Sync
         return Plan.new("skip", tool, name, target, "run build first", "script", gen, :build_first)
       end
 
-      source_marker = read_marker_file(ArtifactTargets.sidecar_marker_path(gen))
-      unless managed?(source_marker, tool, name)
+      source_marker = YamlMarker.read_file(ArtifactTargets.sidecar_marker_path(gen))
+      unless YamlMarker.managed?(source_marker, tool, name)
         return Plan.new("conflict", tool, name, target, "generated artifact is missing a valid marker", "script", gen)
       end
       # generated が catalog entry と一致するか (build_id)。不一致 = register 後に build して
@@ -338,14 +337,14 @@ module Sync
         # 管理状態も確認する (本体ありの update 経路と対称, #179 H-06)。symlink な sidecar は
         # script_target_symlink? が上で conflict 済み。
         sidecar = ArtifactTargets.sidecar_marker_path(target)
-        if File.exist?(sidecar) && !managed?(read_marker_file(sidecar), tool, name)
+        if File.exist?(sidecar) && !YamlMarker.managed?(YamlMarker.read_file(sidecar), tool, name)
           return Plan.new("conflict", tool, name, target, "existing sidecar marker is unmanaged", "script", gen)
         end
         return Plan.new("create", tool, name, target, nil, "script", gen)
       end
 
-      target_marker = File.file?(target) ? read_marker_file(ArtifactTargets.sidecar_marker_path(target)) : nil
-      unless managed?(target_marker, tool, name)
+      target_marker = File.file?(target) ? YamlMarker.read_file(ArtifactTargets.sidecar_marker_path(target)) : nil
+      unless YamlMarker.managed?(target_marker, tool, name)
         return Plan.new("conflict", tool, name, target, "existing target is unmanaged", "script", gen)
       end
 
@@ -369,24 +368,7 @@ module Sync
 
     # directory artifact (skill) の dir 直下 marker を読む。
     def read_marker(dir)
-      read_marker_file(File.join(dir, ArtifactTargets::MARKER_BASENAME))
-    end
-
-    # marker file を読んで Hash を返す。不在 / 型不正 / parse 失敗は nil。
-    def read_marker_file(path)
-      return nil unless File.file?(path)
-
-      data = YamlUtil.load(File.read(path), path)
-      data.is_a?(Hash) ? data : nil
-    rescue Psych::Exception
-      nil
-    end
-
-    def managed?(marker, tool, name)
-      marker &&
-        marker["repo"] == "agent-tools" &&
-        marker["target"] == tool &&
-        marker["name"] == name
+      YamlMarker.read_file(File.join(dir, ArtifactTargets::MARKER_BASENAME))
     end
 
   end

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -42,14 +42,6 @@ module Sync
       load_catalog
     end
 
-    # catalog を source of truth として読む (target-artifact 単位)。不在 / version 不一致 /
-    # 壊れた JSON は catalog なし扱い (Catalog.read が fail-closed に判定)。
-    def load_catalog
-      result = Catalog.read(@root)
-      @catalog_present = result.present?
-      @entries = result.entries
-    end
-
     attr_reader :catalog_present
 
     # catalog の各 target-artifact を列挙し、registered のものを配置する。
@@ -109,6 +101,14 @@ module Sync
     end
 
     private
+
+    # catalog を source of truth として読む (target-artifact 単位)。不在 / version 不一致 /
+    # 壊れた JSON は catalog なし扱い (Catalog.read が fail-closed に判定)。
+    def load_catalog
+      result = Catalog.read(@root)
+      @catalog_present = result.present?
+      @entries = result.entries
+    end
 
     # prune の削除実体。marker-gated 判定 (prune_skills / prune_scripts) を通った
     # plan だけが来る。script は本体と sidecar marker を対で消す。

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -24,7 +24,7 @@ require_relative "instruction_marker"
 require_relative "assets"
 
 module Sync
-  TOOLS = %w[codex claude-code].freeze
+  TOOLS = ArtifactTargets::TOOLS
 
   # code は reason (人間向け表示文言) と対になる機械可読な skip 理由。status が contract
   # の target state 判定に読む (#152: 表示文言の変更で contract を壊さないための分離)。
@@ -396,10 +396,7 @@ module Sync
     apply = false
     prune = false
     quiet = false
-    homes = {
-      "codex" => File.expand_path("~/.codex"),
-      "claude-code" => File.expand_path("~/.claude"),
-    }
+    homes = ArtifactTargets.default_homes
     until argv.empty?
       case (arg = argv.shift)
       when "--root"

--- a/scripts/lib/yaml_marker.rb
+++ b/scripts/lib/yaml_marker.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+require_relative "yaml_util"
+
+# agent-tools の YAML 管理 marker (skill の dir 直下 / script の sidecar) の format 知識を
+# 1 箇所に集約する (instruction の HTML コメント marker = InstructionMarker と対称, #192)。
+# build (生成)・sync (所有判定)・status (鮮度判定) が同じ生成・読取・判定を共有する。
+# marker format の正本は docs/status-manifest-contract.md。
+module YamlMarker
+  # marker 本文。directory marker (skill) と sidecar marker (script) が共有する。
+  # キー順 (repo/name/target/source/build_id) は配備済み marker との byte 一致に効くため
+  # 変えない。
+  def self.render(name:, target:, source:, build_id:)
+    YAML.dump(
+      "repo" => "agent-tools",
+      "name" => name,
+      "target" => target,
+      "source" => source,
+      "build_id" => build_id,
+    )
+  end
+
+  # marker file を読む。不在 / 非 mapping / YAML parse 失敗はすべて nil。
+  # nil をどう扱うか (unmanaged / conflict / stale) は呼び出し側の fail-closed 判定に委ねる。
+  def self.read_file(path)
+    return nil unless File.file?(path)
+
+    data = YamlUtil.load(File.read(path), path)
+    data.is_a?(Hash) ? data : nil
+  rescue Psych::Exception
+    nil
+  end
+
+  # marker が agent-tools 管理で tool / name に一致するか (marker-gated 判定)。
+  def self.managed?(marker, tool, name)
+    marker &&
+      marker["repo"] == "agent-tools" &&
+      marker["target"] == tool &&
+      marker["name"] == name
+  end
+end


### PR DESCRIPTION
## 概要

**Refs #192 #152** — ultracode (5 観点発見 → 敵対検証 → 統合) で確証した挙動不変リファクタのうち、**lib 本体の 5 クラスタ**を 1 コミット 1 クラスタで実装。

| commit | クラスタ |
|---|---|
| 1 | lib 衛生: dead code 削除 (Doctor::LEVELS / 未使用 attr_reader ×2 / 到達しない既定引数)・require 実依存整合・内部メソッド private 化 |
| 2 | ArtifactTargets へ一元化: `TOOLS` 三重定義 (**#152 残項目**)・default_homes 4 重複・`resolves_any?` 同形 3 箇所 |
| 3 | YamlMarker module 新設 (render/read_file/managed? — InstructionMarker と対称)・status 鮮度判定 tail の統一 |
| 4 | `Assets.rel` へ root 相対 path 変換を集約 (同一実装 3+1 箇所) |
| 5 | Register の approval 判定/警告 helper 抽出 (警告条件・位置・文言・entry キー順不変)・check_injection の manifest 走査 1-pass 化 |

## 挙動不変の実証

各クラスタごとに 13 suite 緑を確認したうえで、**main の baseline 実出力と全 diff 一致**:

- generated/ 全ファイル **byte 一致** (build_id 不変 = 再配備不要)
- catalog.json 一致 / status --json 一致 / doctor 一致
- sync dry-run / connect dry-run / sync --prune dry-run 一致
- check-manifests / check-injection の出力・exit code 一致
- self-test 13 suite 全緑・Ruby 2.6 構文のみ (ruby -c 全通過)

## 敵対検証で守った条件 (抜粋)

- resolves_any? に check_injection の型 guard を混ぜない (fail-closed 分業は呼び出し側)
- default_homes は frozen にしない (main が破壊的代入するため fresh mutable Hash)
- YamlMarker.render は同一 Hash リテラル・同一キー順の verbatim 移動 (marker byte 一致)
- best-effort の rescue StandardError → false は意図コメントごと呼び出し側に保持
- kind 不一致警告は現行の 4 項条件そのまま (approval_effective? の否定を再利用しない)

対象は pipeline tooling のみ (shared/ の配布 asset・docs 不変)。テスト側 (helper 集約) と CLI main 側 (parse loop 共通化) は別 PR で続く。

## レビュー観点 (相互レビュー: author=Claude → reviewer=Codex)

- 挙動同値性 (特に register の警告条件の等価・check_injection の guard 並置・YamlMarker の nil 経路)
- 削除した dead code の参照が本当にゼロか
- Ruby 2.6 互換

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv