### PR TITLE
refactor: CLI 引数解析と sync/connect epilogue の共通化 (characterization テスト先行)

### DIFF
--- a/scripts/lib/build.rb
+++ b/scripts/lib/build.rb
@@ -17,6 +17,7 @@ require_relative "gate"
 require_relative "artifact_targets"
 require_relative "instruction_marker"
 require_relative "yaml_marker"
+require_relative "cli"
 
 module Build
   TOOLS = ArtifactTargets::TOOLS
@@ -305,25 +306,12 @@ module Build
   private_class_method :digest_framed
 
   def self.main(argv)
-    root = Dir.pwd
-    quiet = false
-    prune = false
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--quiet"
-        quiet = true
-      when "--prune"
-        prune = true
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    opts = Cli.parse(argv, usage: USAGE, bool_flags: %w[--quiet --prune], value_flags: %w[--root])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
+    quiet = opts.key?("--quiet")
+    prune = opts.key?("--prune")
 
     unless run_gates(root)
       warn "fail: pre-build gates did not pass; nothing was generated"
@@ -351,14 +339,7 @@ module Build
     errors.empty?
   end
 
-  def self.print_usage
-    puts "usage: build.sh [--root DIR] [--prune] [--quiet]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: build.sh [--root DIR] [--prune] [--quiet]"
 end
 
 exit Build.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/check_injection.rb
+++ b/scripts/lib/check_injection.rb
@@ -9,6 +9,7 @@
 
 require_relative "assets"
 require_relative "artifact_targets"
+require_relative "cli"
 
 module CheckInjection
   Pattern = Struct.new(:category, :risk, :regexp, :message)
@@ -213,22 +214,11 @@ module CheckInjection
   end
 
   def self.main(argv)
-    root = Dir.pwd
-    quiet = false
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--quiet"
-        quiet = true
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    opts = Cli.parse(argv, usage: USAGE, bool_flags: %w[--quiet], value_flags: %w[--root])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
+    quiet = opts.key?("--quiet")
 
     count, findings = Runner.new(root).run
     findings.sort_by! { |f| [f.path, f.line, -RISK_ORDER.fetch(f.risk)] }
@@ -250,14 +240,7 @@ module CheckInjection
     end
   end
 
-  def self.print_usage
-    puts "usage: check-injection.sh [--root DIR] [--quiet]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: check-injection.sh [--root DIR] [--quiet]"
 end
 
 exit CheckInjection.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -11,6 +11,7 @@ require "yaml"
 require_relative "yaml_util"
 require_relative "assets"
 require_relative "artifact_targets"
+require_relative "cli"
 
 module CheckManifests
   KINDS = %w[skill prompt workflow agent instruction script].freeze
@@ -573,22 +574,11 @@ module CheckManifests
   end
 
   def self.main(argv)
-    root = Dir.pwd
-    quiet = false
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--quiet"
-        quiet = true
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    opts = Cli.parse(argv, usage: USAGE, bool_flags: %w[--quiet], value_flags: %w[--root])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
+    quiet = opts.key?("--quiet")
 
     count, errors = Runner.new(root).run
     errors.each { |line| puts line }
@@ -601,14 +591,7 @@ module CheckManifests
     end
   end
 
-  def self.print_usage
-    puts "usage: check-manifests.sh [--root DIR] [--quiet]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: check-manifests.sh [--root DIR] [--quiet]"
 end
 
 exit CheckManifests.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/cli.rb
+++ b/scripts/lib/cli.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# CLI 引数解析の共通 boilerplate (#192)。8 entrypoint (sync / connect / status / doctor /
+# build / register / check-manifests / check-injection) の同型 parse loop を宣言 spec で
+# 置き換える。挙動の正本は characterization test (scripts/tests/cli-args-test.sh):
+#
+# - 左から 1 token ずつ読み、同一 flag の重複は後勝ち。
+# - -h / --help は usage を stdout に出して即 :help を返す (以降の token は読まない。
+#   exit フローは main 側の return 0 に残す)。
+# - 未知 option は "unknown option: <arg>" を stderr、usage を stdout に出して exit 2。
+# - value flag の値欠落 (argv 枯渇 = nil) は unknown 行なしで usage を stdout に出して exit 2。
+# - 値の加工 (File.expand_path 等) は呼び出し元の責務 (--root を生値のまま使う既存挙動を
+#   変えないため)。
+#
+# check_credential_isolation.rb は error 時 usage を stderr に出す別契約のため対象外。
+module Cli
+  # argv を { "--flag" => true | "<value>" } に解析して返す。-h / --help は :help を返す。
+  def self.parse(argv, usage:, bool_flags: [], value_flags: [])
+    opts = {}
+    until argv.empty?
+      arg = argv.shift
+      case arg
+      when "-h", "--help"
+        puts usage
+        return :help
+      when *bool_flags
+        opts[arg] = true
+      when *value_flags
+        value = argv.shift
+        if value.nil?
+          puts usage
+          exit 2
+        end
+        opts[arg] = value
+      else
+        warn "unknown option: #{arg}"
+        puts usage
+        exit 2
+      end
+    end
+    opts
+  end
+end

--- a/scripts/lib/connect.rb
+++ b/scripts/lib/connect.rb
@@ -20,6 +20,8 @@ require_relative "artifact_targets"
 require_relative "catalog"
 require_relative "instruction_marker"
 require_relative "assets"
+require_relative "cli"
+require_relative "plan_report"
 
 module Connect
   # 人間の CLAUDE.md から所有ファイルを取り込む import 行。
@@ -193,30 +195,17 @@ module Connect
   end
 
   def self.main(argv)
-    root = Dir.pwd
-    apply = false
-    quiet = false
+    opts = Cli.parse(argv, usage: USAGE,
+                     bool_flags: %w[--apply --quiet],
+                     value_flags: %w[--root --codex-home --claude-home])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
+    apply = opts.key?("--apply")
+    quiet = opts.key?("--quiet")
     homes = ArtifactTargets.default_homes
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--apply"
-        apply = true
-      when "--codex-home"
-        homes["codex"] = File.expand_path(argv.shift || abort_usage)
-      when "--claude-home"
-        homes["claude-code"] = File.expand_path(argv.shift || abort_usage)
-      when "--quiet"
-        quiet = true
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    homes["codex"] = File.expand_path(opts["--codex-home"]) if opts["--codex-home"]
+    homes["claude-code"] = File.expand_path(opts["--claude-home"]) if opts["--claude-home"]
 
     runner = Runner.new(root, homes)
     plans = runner.plan
@@ -226,32 +215,11 @@ module Connect
       return 0
     end
 
-    plans.each { |p| puts p.to_s.sub(Dir.home, "~") }
-
-    conflicts = plans.select { |p| p.action == "conflict" }
-    unless conflicts.empty?
-      warn "fail: #{conflicts.size} conflict(s); nothing was applied"
-      return 1
-    end
-
-    changes = plans.count { |p| %w[create add-import].include?(p.action) }
-    if apply
-      runner.apply(plans)
-      puts "ok: applied #{changes} change(s)" unless quiet
-    else
-      puts "ok: dry-run only, #{changes} change(s) pending (use --apply to write)" unless quiet
-    end
-    0
+    PlanReport.finish(plans, runner, apply: apply, quiet: quiet,
+                      change_actions: %w[create add-import])
   end
 
-  def self.print_usage
-    puts "usage: connect.sh [--root DIR] [--apply] [--codex-home DIR] [--claude-home DIR] [--quiet]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: connect.sh [--root DIR] [--apply] [--codex-home DIR] [--claude-home DIR] [--quiet]"
 end
 
 exit Connect.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -16,6 +16,7 @@ require_relative "status"
 require_relative "build"
 require_relative "artifact_targets"
 require_relative "catalog"
+require_relative "cli"
 
 module Doctor
   Line = Struct.new(:level, :area, :message) do
@@ -209,27 +210,15 @@ module Doctor
   end
 
   def self.main(argv)
-    root = Dir.pwd
+    opts = Cli.parse(argv, usage: USAGE,
+                     value_flags: %w[--root --codex-home --claude-home --agents-home])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
     homes = ArtifactTargets.default_homes
-    agents_home = File.expand_path("~/.agents")
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--codex-home"
-        homes["codex"] = File.expand_path(argv.shift || abort_usage)
-      when "--claude-home"
-        homes["claude-code"] = File.expand_path(argv.shift || abort_usage)
-      when "--agents-home"
-        agents_home = File.expand_path(argv.shift || abort_usage)
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    homes["codex"] = File.expand_path(opts["--codex-home"]) if opts["--codex-home"]
+    homes["claude-code"] = File.expand_path(opts["--claude-home"]) if opts["--claude-home"]
+    agents_home = File.expand_path(opts["--agents-home"] || "~/.agents")
 
     lines = Runner.new(root, homes, agents_home).run
     lines.each { |line| puts line }
@@ -243,14 +232,7 @@ module Doctor
     end
   end
 
-  def self.print_usage
-    puts "usage: doctor.sh [--root DIR] [--codex-home DIR] [--claude-home DIR] [--agents-home DIR]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: doctor.sh [--root DIR] [--codex-home DIR] [--claude-home DIR] [--agents-home DIR]"
 end
 
 exit Doctor.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/plan_report.rb
+++ b/scripts/lib/plan_report.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# sync / connect の main が共有する epilogue (#192): plan の表示 → conflict fail →
+# apply / dry-run の集計行。require 時の副作用はない (status.rb が sync 経由で load する)。
+module PlanReport
+  # plans を表示し、conflict なら 1 / 正常なら 0 を返す (main がそのまま exit code に使う)。
+  # change_actions は「変更として数える action」(sync: create/update/delete、
+  # connect: create/add-import)。plans 空の分岐は文言が tool ごとに違うため main に残す。
+  def self.finish(plans, runner, apply:, quiet:, change_actions:)
+    # 表示は tilde 表記に正規化する (docs/status-manifest-contract.md)。
+    plans.each { |p| puts p.to_s.sub(Dir.home, "~") }
+
+    conflicts = plans.select { |p| p.action == "conflict" }
+    unless conflicts.empty?
+      warn "fail: #{conflicts.size} conflict(s); nothing was applied"
+      return 1
+    end
+
+    changes = plans.count { |p| change_actions.include?(p.action) }
+    if apply
+      runner.apply(plans)
+      puts "ok: applied #{changes} change(s)" unless quiet
+    else
+      puts "ok: dry-run only, #{changes} change(s) pending (use --apply to write)" unless quiet
+    end
+    0
+  end
+end

--- a/scripts/lib/register.rb
+++ b/scripts/lib/register.rb
@@ -17,6 +17,7 @@ require_relative "gate"
 require_relative "check_injection"
 require_relative "build"
 require_relative "artifact_targets"
+require_relative "cli"
 
 module Register
   class Error < StandardError; end
@@ -170,22 +171,11 @@ module Register
   end
 
   def self.main(argv)
-    root = Dir.pwd
-    quiet = false
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--quiet"
-        quiet = true
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    opts = Cli.parse(argv, usage: USAGE, bool_flags: %w[--quiet], value_flags: %w[--root])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
+    quiet = opts.key?("--quiet")
 
     runner = Runner.new(root)
     begin
@@ -208,14 +198,7 @@ module Register
     pending.zero? ? 0 : 3
   end
 
-  def self.print_usage
-    puts "usage: register.sh [--root DIR] [--quiet]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: register.sh [--root DIR] [--quiet]"
 end
 
 exit Register.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -19,6 +19,7 @@ require_relative "artifact_targets"
 require_relative "catalog"
 require_relative "yaml_marker"
 require_relative "instruction_marker"
+require_relative "cli"
 
 module Status
   CONTRACT_VERSION = 2
@@ -199,27 +200,16 @@ module Status
   end
 
   def self.main(argv)
-    root = Dir.pwd
-    json = false
+    opts = Cli.parse(argv, usage: USAGE,
+                     bool_flags: %w[--json],
+                     value_flags: %w[--root --codex-home --claude-home])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
+    json = opts.key?("--json")
     homes = ArtifactTargets.default_homes
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--json"
-        json = true
-      when "--codex-home"
-        homes["codex"] = File.expand_path(argv.shift || abort_usage)
-      when "--claude-home"
-        homes["claude-code"] = File.expand_path(argv.shift || abort_usage)
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    homes["codex"] = File.expand_path(opts["--codex-home"]) if opts["--codex-home"]
+    homes["claude-code"] = File.expand_path(opts["--claude-home"]) if opts["--claude-home"]
 
     report = Runner.new(root, homes).report
     if json
@@ -242,14 +232,7 @@ module Status
     end
   end
 
-  def self.print_usage
-    puts "usage: status.sh [--root DIR] [--json] [--codex-home DIR] [--claude-home DIR]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: status.sh [--root DIR] [--json] [--codex-home DIR] [--claude-home DIR]"
 end
 
 exit Status.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/lib/sync.rb
+++ b/scripts/lib/sync.rb
@@ -21,6 +21,8 @@ require_relative "artifact_targets"
 require_relative "catalog"
 require_relative "instruction_marker"
 require_relative "assets"
+require_relative "cli"
+require_relative "plan_report"
 
 module Sync
   TOOLS = ArtifactTargets::TOOLS
@@ -374,33 +376,18 @@ module Sync
   end
 
   def self.main(argv)
-    root = Dir.pwd
-    apply = false
-    prune = false
-    quiet = false
+    opts = Cli.parse(argv, usage: USAGE,
+                     bool_flags: %w[--apply --prune --quiet],
+                     value_flags: %w[--root --codex-home --claude-home])
+    return 0 if opts == :help
+
+    root = opts["--root"] || Dir.pwd
+    apply = opts.key?("--apply")
+    prune = opts.key?("--prune")
+    quiet = opts.key?("--quiet")
     homes = ArtifactTargets.default_homes
-    until argv.empty?
-      case (arg = argv.shift)
-      when "--root"
-        root = argv.shift or abort_usage
-      when "--apply"
-        apply = true
-      when "--prune"
-        prune = true
-      when "--codex-home"
-        homes["codex"] = File.expand_path(argv.shift || abort_usage)
-      when "--claude-home"
-        homes["claude-code"] = File.expand_path(argv.shift || abort_usage)
-      when "--quiet"
-        quiet = true
-      when "-h", "--help"
-        print_usage
-        return 0
-      else
-        warn "unknown option: #{arg}"
-        abort_usage
-      end
-    end
+    homes["codex"] = File.expand_path(opts["--codex-home"]) if opts["--codex-home"]
+    homes["claude-code"] = File.expand_path(opts["--claude-home"]) if opts["--claude-home"]
 
     runner = Runner.new(root, homes)
     plans = runner.plan
@@ -412,33 +399,11 @@ module Sync
       return 0
     end
 
-    # 表示は tilde 表記に正規化する (docs/status-manifest-contract.md)。
-    plans.each { |p| puts p.to_s.sub(Dir.home, "~") }
-
-    conflicts = plans.select { |p| p.action == "conflict" }
-    unless conflicts.empty?
-      warn "fail: #{conflicts.size} conflict(s); nothing was applied"
-      return 1
-    end
-
-    changes = plans.count { |p| %w[create update delete].include?(p.action) }
-    if apply
-      runner.apply(plans)
-      puts "ok: applied #{changes} change(s)" unless quiet
-    else
-      puts "ok: dry-run only, #{changes} change(s) pending (use --apply to write)" unless quiet
-    end
-    0
+    PlanReport.finish(plans, runner, apply: apply, quiet: quiet,
+                      change_actions: %w[create update delete])
   end
 
-  def self.print_usage
-    puts "usage: sync.sh [--root DIR] [--apply] [--prune] [--codex-home DIR] [--claude-home DIR] [--quiet]"
-  end
-
-  def self.abort_usage
-    print_usage
-    exit 2
-  end
+  USAGE = "usage: sync.sh [--root DIR] [--apply] [--prune] [--codex-home DIR] [--claude-home DIR] [--quiet]"
 end
 
 exit Sync.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/tests/cli-args-test.sh
+++ b/scripts/tests/cli-args-test.sh
@@ -53,6 +53,49 @@ for cmd in $COMMANDS; do
   status=0
   (cd "$tmp" && "$bin" --help --bogus-flag > "$tmp/out" 2> "$tmp/err") || status=$?
   [ "$status" -eq 0 ] || fail "$cmd: --help must short-circuit before --bogus-flag, got $status"
+
+  # --- 5: help 時は stderr 空・stdout は usage 1 行のみ ---
+  status=0
+  (cd "$tmp" && "$bin" --help > "$tmp/out" 2> "$tmp/err") || status=$?
+  [ ! -s "$tmp/err" ] || fail "$cmd: --help must not write to stderr: $(cat "$tmp/err")"
+  [ "$(wc -l < "$tmp/out" | tr -d ' ')" = "1" ] || fail "$cmd: --help stdout should be the usage line only"
+  case "$(cat "$tmp/out")" in "usage: $cmd.sh "*) ;; *) fail "$cmd: usage line should name $cmd.sh: $(cat "$tmp/out")";; esac
+
+  # --- 6: 位置引数は未知 option として拒否 ---
+  status=0
+  (cd "$tmp" && "$bin" positional > "$tmp/out" 2> "$tmp/err") || status=$?
+  [ "$status" -eq 2 ] || fail "$cmd: positional arg should exit 2, got $status"
+  grep -q "unknown option: positional" "$tmp/err" || fail "$cmd: positional arg should be reported as unknown option"
+
+  # --- 7: 引数途中の -h でも usage + exit 0 (value flag を先に読んでから) ---
+  status=0
+  (cd "$tmp" && "$bin" --root "$tmp" -h > "$tmp/out" 2> "$tmp/err") || status=$?
+  [ "$status" -eq 0 ] || fail "$cmd: mid-args -h should exit 0, got $status"
+  grep -q "^usage:" "$tmp/out" || fail "$cmd: mid-args -h should print usage"
 done
+
+# --- Cli.parse の直接 unit (外形から観測しにくい equivalence): 空文字列値 / 重複後勝ち /
+#     value flag が直後の flag を値として食う / help は以降の argv を消費しない ---
+ruby -r"$script_dir/../lib/cli" -e '
+  def check(name, cond)
+    return if cond
+    warn "FAIL: #{name}"
+    exit 1
+  end
+  # 空文字列は有効な値 (値欠落は argv 枯渇 = nil のみ)
+  opts = Cli.parse(["--root", ""], usage: "usage: x", value_flags: ["--root"])
+  check("empty string value accepted", opts["--root"] == "")
+  # 同一 flag 重複は後勝ち
+  opts = Cli.parse(["--root", "a", "--root", "b"], usage: "usage: x", value_flags: ["--root"])
+  check("duplicate value flag: last wins", opts["--root"] == "b")
+  # value flag は直後の token を無条件に値として食う (旧 loop と同じ)
+  opts = Cli.parse(["--root", "--quiet"], usage: "usage: x",
+                   bool_flags: ["--quiet"], value_flags: ["--root"])
+  check("value flag eats following flag token", opts["--root"] == "--quiet" && !opts.key?("--quiet"))
+  # help は :help を返し以降の argv を消費しない
+  argv = ["--help", "--rest"]
+  check("help returns :help", Cli.parse(argv, usage: "usage: x") == :help)
+  check("help leaves rest of argv", argv == ["--rest"])
+' > /dev/null || fail "Cli.parse direct unit checks failed"
 
 echo "ok: cli-args characterization test passed"

--- a/scripts/tests/cli-args-test.sh
+++ b/scripts/tests/cli-args-test.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# 8 entrypoint の CLI 引数処理の characterization test (#192)。
+# Cli helper への共通化 (scripts/lib/cli.rb) が守るべき現行挙動を先に固定する:
+#   1. 未知 option: stderr に "unknown option: <arg>" + usage を stdout + exit 2
+#   2. value flag の値欠落 (argv 枯渇): unknown 行なしで usage を stdout + exit 2
+#   3. -h / --help: usage を stdout + exit 0
+#   4. --help の後の token は読まない (--help --bogus でも exit 0)
+# いずれも repo 状態に依存しない parse 段の挙動なので、cwd は空 tmp で走らせる。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# value flag を持つ全 entrypoint (--root は共通の value flag)。
+COMMANDS="sync connect status doctor build register check-manifests check-injection"
+
+for cmd in $COMMANDS; do
+  bin="$script_dir/../$cmd.sh"
+
+  # --- 1: 未知 option → stderr に unknown option + stdout に usage + exit 2 ---
+  status=0
+  (cd "$tmp" && "$bin" --bogus-flag > "$tmp/out" 2> "$tmp/err") || status=$?
+  [ "$status" -eq 2 ] || fail "$cmd: unknown option should exit 2, got $status"
+  grep -q "unknown option: --bogus-flag" "$tmp/err" \
+    || fail "$cmd: missing unknown-option line on stderr: $(cat "$tmp/err")"
+  grep -q "^usage:" "$tmp/out" || fail "$cmd: usage should go to stdout: $(cat "$tmp/out")"
+
+  # --- 2: value flag の値欠落 → unknown 行なしで usage + exit 2 ---
+  status=0
+  (cd "$tmp" && "$bin" --root > "$tmp/out" 2> "$tmp/err") || status=$?
+  [ "$status" -eq 2 ] || fail "$cmd: missing value should exit 2, got $status"
+  grep -q "^usage:" "$tmp/out" || fail "$cmd: missing-value usage should go to stdout"
+  if grep -q "unknown option" "$tmp/err"; then
+    fail "$cmd: missing value must not report unknown option: $(cat "$tmp/err")"
+  fi
+
+  # --- 3: -h / --help → usage + exit 0 ---
+  for flag in -h --help; do
+    status=0
+    (cd "$tmp" && "$bin" "$flag" > "$tmp/out" 2> "$tmp/err") || status=$?
+    [ "$status" -eq 0 ] || fail "$cmd: $flag should exit 0, got $status"
+    grep -q "^usage:" "$tmp/out" || fail "$cmd: $flag should print usage to stdout"
+  done
+
+  # --- 4: --help は以降の token を読まない ---
+  status=0
+  (cd "$tmp" && "$bin" --help --bogus-flag > "$tmp/out" 2> "$tmp/err") || status=$?
+  [ "$status" -eq 0 ] || fail "$cmd: --help must short-circuit before --bogus-flag, got $status"
+done
+
+echo "ok: cli-args characterization test passed"


### PR DESCRIPTION
## 概要

**Refs #192** — **#195 の作り直し** (base の refactor-192 が #193 merge で削除された際に自動 retarget されず close されたため、main へ rebase して再作成。内容は同一 + Codex should 対応済み)。

**レビューは #195 で完結済み**: Codex 判定 **✅ must 0** — 旧 loop と新 Cli.parse を Ruby 2.6.10 上で 14 ケース実測比較し戻り値・exit・stdout・stderr・argv 消費の一致を確認 / PlanReport の conflict return 1・apply 未呼出・quiet 挙動を確認 / should 1 (エッジ characterization 追加) は採用対応済み。詳細は #195 のレビューコメント参照。

2 段構成 (rebase 後も同じ 3 commit):
1. characterization テスト先行 (`scripts/tests/cli-args-test.sh`): 8 entrypoint × (未知 option / 値欠落 / help / short-circuit) + エッジ (空文字列値 / 重複後勝ち / value flag の flag 食い / 位置引数 / stderr 空) を現行実装 oracle で固定
2. `scripts/lib/cli.rb` (parse loop ×8 の宣言 spec 化) + `scripts/lib/plan_report.rb` (sync/connect epilogue、change_actions のみ引数化)

## 検証 (rebase 後に再実行)

- self-test **15 suite 全緑** (#194 のテスト変更との共存確認込み)
- generated/ byte 一致・baseline 出力一致 (rebase 前に確認、diff 内容は不変)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv