### PR TITLE
feat: status の deployed-but-inactive を missing と区別 (Closes #186)

### DIFF
--- a/docs/status-manifest-contract.md
+++ b/docs/status-manifest-contract.md
@@ -24,7 +24,7 @@ dotfiles 側の実装は含めません。
 
 ```json
 {
-  "contract_version": 2,
+  "contract_version": 3,
   "repo": {
     "present": true,
     "clean": true
@@ -59,8 +59,8 @@ dotfiles 側の実装は含めません。
 
 ### Fields
 
-- `contract_version`: この contract の version。現行は `2`
-  (v2 で `register` を追加)。
+- `contract_version`: この contract の version。現行は `3`
+  (v2 で `register` を追加、v3 で target state に `deployed_but_inactive` を追加 #186)。
 - `repo.present`: agent-tools repository が存在するか。
 - `repo.clean`: working tree が clean か。
 - `assets.total`: tracked manifest の数。
@@ -81,6 +81,7 @@ dotfiles 側の実装は含めません。
 | `stale` | agent-tools marker を持つが、generated artifact より古い。 |
 | `conflict` | 同名 target が存在するが marker を持たない (unmanaged)。 |
 | `missing` | generated artifact はあるが、target がまだ存在しない。 |
+| `deployed_but_inactive` | catalog entry が registered でない (human_review_required / unsupported) のに、target 実体がディスクに残っている (一度承認して配布 → 後で gate がかかった等)。sync は配置も削除もしないため、手動掃除か再承認まで居座る (#186)。 |
 
 `conflict` の target は sync が変更してはいけません。
 
@@ -141,7 +142,7 @@ build_id: sha256:...
 ## dotfiles が読んでよい情報
 
 - status output contract の JSON 全体。
-- 各 target の state (`managed` / `stale` / `conflict` / `missing`)。
+- 各 target の state (`managed` / `stale` / `conflict` / `missing` / `deployed_but_inactive`)。
 - checks の結果 (`pass` / `fail` / `human_review` / `not_run`)。
 
 ## dotfiles が読まない・status に含めない情報

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -158,9 +158,9 @@ usage: sync.sh [--root DIR] [--apply] [--prune] [--codex-home DIR] [--claude-hom
 usage: status.sh [--root DIR] [--json] [--codex-home DIR] [--claude-home DIR]
 ```
 
-- `--json` で contract_version 2 の JSON、省略時は human-readable summary。
+- `--json` で contract_version 3 の JSON、省略時は human-readable summary。
 - manifest validation / injection check の結果、generated の stale 数、
-  sync target state (managed / stale / conflict / missing) を含む。
+  sync target state (managed / stale / conflict / missing / deployed_but_inactive) を含む。
 - read-only。いかなる state も変更しない。
 - 出力に absolute local paths / secrets を含めない。
 - self-test: `tests/status-test.sh`

--- a/scripts/lib/doctor.rb
+++ b/scripts/lib/doctor.rb
@@ -80,7 +80,10 @@ module Doctor
       report(level, "generated", "#{generated['total']} artifact(s), #{generated['stale']} stale")
 
       status["sync_targets"].each do |t|
-        level = { "managed" => "ok", "missing" => "info", "stale" => "warn", "conflict" => "fail" }.fetch(t["state"])
+        # deployed_but_inactive = 未登録 (gate 中) なのに実体が残っている = 掃除対象の
+        # 可能性があるので warn (#186)。
+        level = { "managed" => "ok", "missing" => "info", "stale" => "warn", "conflict" => "fail",
+                  "deployed_but_inactive" => "warn" }.fetch(t["state"])
         report(level, "target", "[#{t['tool']}] #{t['name']} #{t['state']}")
       end
     end

--- a/scripts/lib/status.rb
+++ b/scripts/lib/status.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Report-only status。dotfiles が読める contract JSON を出力する。
-# Spec: docs/status-manifest-contract.md (contract_version 2)
+# Spec: docs/status-manifest-contract.md (contract_version 3)
 #
 # - いかなる state も変更しない (read-only inspection のみ)。
 # - secrets / absolute local paths を出力しない。
@@ -22,7 +22,7 @@ require_relative "instruction_marker"
 require_relative "cli"
 
 module Status
-  CONTRACT_VERSION = 2
+  CONTRACT_VERSION = 3
 
   class Runner
     def initialize(root, homes)
@@ -177,8 +177,11 @@ module Status
     # Sync plan を contract の target state にマップする。skip の判定は plan.code
     # (機械可読) だけを見て、表示文言 (plan.reason) に依存しない — sync の文言変更で
     # dotfiles 連携 contract を壊さないため (#152)。
-    # registered でない artifact は配置されないため、target は missing 扱い。
     # manifest-stale (登録判断が古い) は配置済みでも再 register が要るので stale。
+    # registered でない entry は sync が配置しないが、過去に配置した実体が target に
+    # 残っていることがある (一度承認して配布 → 後で gate がかかった等)。これを missing
+    # (target 不在) と混同すると掃除対象に気づけないので deployed_but_inactive で
+    # 区別する (#186・contract v3)。
     def target_state(plan)
       case plan.action
       when "update" then "stale"
@@ -188,6 +191,7 @@ module Status
         case plan.code
         when :up_to_date then "managed"
         when :manifest_stale then "stale"
+        when :not_registered then not_registered_state(plan)
         else "missing"
         end
       else
@@ -195,6 +199,14 @@ module Status
         # conflict = fail に倒して表面化させる (fail-closed)。
         "conflict"
       end
+    end
+
+    # 未登録 (human_review_required / unsupported) entry の deployment state。
+    # target 実体がディスクに在れば deployed_but_inactive、無ければ missing。
+    # symlink は (dangling でも) path が塞がっている事実を隠さないため「在る」扱い
+    # (sync 自体は symlink に触らない)。
+    def not_registered_state(plan)
+      File.exist?(plan.target) || File.symlink?(plan.target) ? "deployed_but_inactive" : "missing"
     end
 
   end

--- a/scripts/tests/doctor-test.sh
+++ b/scripts/tests/doctor-test.sh
@@ -137,4 +137,26 @@ run_bdoctor > "$tmp/d8" 2>&1 || status=$?
 grep -q "warn: catalog: freshness 未検証" "$tmp/d8" \
   || fail "broken manifest should warn (not crash) in catalog check: $(cat "$tmp/d8")"
 
+# --- case 9: deployed_but_inactive target は warn で報告する (crash しない) (#186) ---
+# 「一度配布 → 後で gate」を catalog の registration 変更で再現。doctor の state→level map に
+# 新語彙が無いと .fetch が KeyError で crash するため、その回帰も兼ねる。
+mkdir -p "$tmp/gcodex/skills" "$tmp/gclaude/skills" "$tmp/gagents"
+WAM_EXTRA='summary: demo workflow'
+make_demo_repo "$tmp/grepo" workflows personal-demo workflow '# demo'
+"$build" --root "$tmp/grepo" --quiet > /dev/null
+"$script_dir/../register.sh" --root "$tmp/grepo" --quiet > /dev/null
+"$sync" --root "$tmp/grepo" --codex-home "$tmp/gcodex" --claude-home "$tmp/gclaude" --apply --quiet > /dev/null
+ruby -rjson -e '
+  path = ARGV[0]
+  catalog = JSON.parse(File.read(path))
+  catalog["assets"].each { |a| a["registration"] = "human_review_required" }
+  File.write(path, JSON.pretty_generate(catalog))
+' "$tmp/grepo/generated/catalog.json"
+status=0
+"$doctor" --root "$tmp/grepo" --codex-home "$tmp/gcodex" \
+  --claude-home "$tmp/gclaude" --agents-home "$tmp/gagents" > "$tmp/d9" 2>&1 || status=$?
+[ "$status" -eq 0 ] || fail "deployed_but_inactive should warn, not fail/crash (exit $status): $(cat "$tmp/d9")"
+grep -q "warn: target: \[codex\] personal-demo deployed_but_inactive" "$tmp/d9" \
+  || fail "missing deployed_but_inactive warn line: $(cat "$tmp/d9")"
+
 echo "ok: doctor self-test passed"

--- a/scripts/tests/register-test.sh
+++ b/scripts/tests/register-test.sh
@@ -53,9 +53,9 @@ jget "$catalog" assets 0 build_id | grep -q '"sha256:' || fail "catalog entry sh
 jget "$catalog" assets 0 manifest_digest | grep -qE '"[0-9a-f]{64}"' \
   || fail "catalog entry should carry manifest_digest (sha256 hex)"
 
-# --- case 2: status が register summary を返す (contract v2) ---
+# --- case 2: status が register summary を返す (contract v2 で追加・現行 v3) ---
 "$status_sh" --root "$tmp/ok" --json > "$tmp/s2" 2>&1
-[ "$(jget "$tmp/s2" contract_version)" = "2" ] || fail "contract_version should be 2"
+[ "$(jget "$tmp/s2" contract_version)" = "3" ] || fail "contract_version should be 3"
 [ "$(jget "$tmp/s2" register catalog_present)" = "true" ] || fail "catalog_present should be true"
 [ "$(jget "$tmp/s2" register registered)" = "1" ] || fail "registered count should be 1"
 

--- a/scripts/tests/status-test.sh
+++ b/scripts/tests/status-test.sh
@@ -28,7 +28,7 @@ make_demo_repo "$tmp/repo" workflows personal-demo workflow '# demo v1'
 
 # --- case 1: build 前。generated 0、sync_targets は空 ---
 run_status > "$tmp/s1" 2>&1 || fail "status should succeed: $(cat "$tmp/s1")"
-[ "$(jget "$tmp/s1" contract_version)" = "2" ] || fail "contract_version should be 2"
+[ "$(jget "$tmp/s1" contract_version)" = "3" ] || fail "contract_version should be 3 (v3: deployed_but_inactive, #186)"
 [ "$(jget "$tmp/s1" register catalog_present)" = "false" ] || fail "catalog_present should be false before register"
 [ "$(jget "$tmp/s1" assets total)" = "1" ] || fail "assets.total should be 1"
 [ "$(jget "$tmp/s1" checks manifest_validation)" = '"pass"' ] || fail "manifest check should pass"
@@ -170,5 +170,36 @@ write_approved_script_manifest "$tmp/screpo" shared/scripts/personal-wrap.sh \
 printf '#!/bin/sh\necho changed\n' > "$tmp/screpo/shared/scripts/personal-wrap.sh"
 "$status_sh" --root "$tmp/screpo" --codex-home "$tmp/sccodex" --claude-home "$tmp/scclaude" --json > "$tmp/sc13b" 2>&1
 [ "$(jget "$tmp/sc13b" generated stale)" = "1" ] || fail "changed script source should be stale: $(cat "$tmp/sc13b")"
+
+# --- case 14: 未登録 (gate 中) でも実体が残っていれば deployed_but_inactive (#186) ---
+# 「一度 registered で配布 → 後で gate がかかった」を再現するため、sync --apply 後に
+# catalog の registration を human_review_required へ変更する (registration state と
+# deployment state の分離を pin。missing = target 不在の contract 定義を守る)。
+mkdir -p "$tmp/dcodex/skills" "$tmp/dclaude/skills"
+WAM_EXTRA='summary: demo workflow'
+make_demo_repo "$tmp/drepo" workflows personal-demo workflow '# demo'
+"$build" --root "$tmp/drepo" --quiet > /dev/null
+"$script_dir/../register.sh" --root "$tmp/drepo" --quiet > /dev/null
+"$sync" --root "$tmp/drepo" --codex-home "$tmp/dcodex" --claude-home "$tmp/dclaude" --apply --quiet > /dev/null
+ruby -rjson -e '
+  path = ARGV[0]
+  catalog = JSON.parse(File.read(path))
+  catalog["assets"].each { |a| a["registration"] = "human_review_required" }
+  File.write(path, JSON.pretty_generate(catalog))
+' "$tmp/drepo/generated/catalog.json"
+"$status_sh" --root "$tmp/drepo" --codex-home "$tmp/dcodex" --claude-home "$tmp/dclaude" --json > "$tmp/s14" 2>&1
+[ "$(jget "$tmp/s14" sync_targets 0 state)" = '"deployed_but_inactive"' ] \
+  || fail "gated + deployed target should be deployed_but_inactive: $(cat "$tmp/s14")"
+[ "$(jget "$tmp/s14" sync_targets 1 state)" = '"deployed_but_inactive"' ] \
+  || fail "both deployed targets should be deployed_but_inactive: $(cat "$tmp/s14")"
+# 実体を消した側は従来どおり missing (deployment state だけが変わる)
+rm -rf "$tmp/dcodex/skills/personal-demo"
+"$status_sh" --root "$tmp/drepo" --codex-home "$tmp/dcodex" --claude-home "$tmp/dclaude" --json > "$tmp/s14b" 2>&1
+s14b_0=$(jget "$tmp/s14b" sync_targets 0 state)
+s14b_1=$(jget "$tmp/s14b" sync_targets 1 state)
+case "$s14b_0 $s14b_1" in
+  '"missing" "deployed_but_inactive"'|'"deployed_but_inactive" "missing"') ;;
+  *) fail "removing one deployed target should split states, got $s14b_0 / $s14b_1: $(cat "$tmp/s14b")" ;;
+esac
 
 echo "ok: status self-test passed"


### PR DESCRIPTION
## 概要

Closes #186 (Codex 監査 2026-07-10 M-02 / umbrella #176)。

status は未登録 entry (registration = human_review_required / unsupported) を target のディスク確認前に missing へ変換していた。そのため「一度承認して配布 → 後で gate がかかった」配置物が実際にはディスク上に残っているのに missing と表示され、掃除対象と気づけず居座る (contract の missing = 「target がまだ存在しない」定義にも反する)。

issue の確定方針どおり registration state と deployment state を分離し、**未登録かつ target 実体あり → `deployed_but_inactive`** で報告する。

## 変更内容

- **status (`status.rb`)**: plan.code `:not_registered` のとき target のディスク実体を確認し、在れば `deployed_but_inactive`・無ければ従来どおり `missing`。symlink (dangling 含む) は path が塞がっている事実を隠さないため「在る」扱い。**contract_version 2→3** (状態語彙の追加。v1→v2 が additive な `register` 追加で bump した前例に整合)。
- **doctor (`doctor.rb`)**: state→level map に `deployed_but_inactive => warn` を追加。map は default なしの `.fetch` のため、**追加しないと新語彙で doctor が KeyError crash する** (producer/consumer の同時整合)。warn は「gate 中なのに実体が残っている = 掃除候補」の可視化。
- **docs**: `status-manifest-contract.md` に state 行 + version 履歴 (`現行は 3`)、`scripts/README.md` 追従。`register-catalog.md` 等の「v2 で register を追加」は歴史的記述なので据え置き。
- **テスト**: status case 14 (sync --apply 後に catalog の registration を human_review_required へ変更 → 両 target が deployed_but_inactive / 片側の実体を消すと missing に分離)、doctor case 9 (warn 行 + KeyError crash 回帰・exit 0)、register-test / status-test の contract_version assert 追従。

## dotfiles 側への影響 (cross-repo)

dotfiles の `scripts/doctor.sh` は `contract_version` を **"2" の exact-match** で確認し、不一致時は「fields を解釈しない」warn に倒れる (fail-closed)。state 値は `conflict` / `stale` の件数しか見ておらず新語彙自体は無害。本 PR の merge 後、**dotfiles 側に v3 受け入れの追従 PR を出す** (それまでの warn は誤解釈ではなく意図した fail-closed 動作)。

## 検証

- self-test 全 14 suite 緑。
- 実 repo で `status --json` → contract_version=3・30 target すべて managed (健全経路の挙動不変)。

author=Claude → reviewer=Codex (相互レビュー契約)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv