### PR TITLE
feat: safe-gh に PR review 経路 (review-comments / reviews) を追加 (Closes #189)

### DIFF
--- a/docs/runtime-injection-defense.md
+++ b/docs/runtime-injection-defense.md
@@ -160,9 +160,10 @@ steering (fail-open で消える)。
 直接実行させる代わりにこれへ寄せ、untrusted content を data として扱わせる steering(迂回可・
 boundary でない)。
 
-- コマンド: `personal-safe-gh [-R OWNER/REPO] <issue|pr> <view|comments> <number>`。出力は JSON。
-  「safe-gh」は本文書の概念名で、**実行コマンド名は配備名 `personal-safe-gh`** (下記のとおり
-  PATH には載せないので、呼び出しは tool 別の絶対 path)。
+- コマンド: `personal-safe-gh [-R OWNER/REPO] issue <view|comments> <number>` /
+  `personal-safe-gh [-R OWNER/REPO] pr <view|comments|review-comments|reviews> <number>`。
+  出力は JSON。「safe-gh」は本文書の概念名で、**実行コマンド名は配備名 `personal-safe-gh`**
+  (下記のとおり PATH には載せないので、呼び出しは tool 別の絶対 path)。
 - 上の provenance 3 軸で author を `self` / `bot` / `other` に分類し、self を確定できなければ
   全 `other` に倒す(fail-closed)。
 - **self identity source の信頼境界 (honest-label)**: self identity は local の trust file /
@@ -177,7 +178,13 @@ boundary でない)。
 - **他人の Issue/PR**: metadata (number/state/author/labels) のみ。**title も body も親へ渡さない**
   (title は attacker 制御の free-text = injection 面)。**自分の Issue/PR**: title/body を渡す。
 - **他人コメント**: count + 固定理由のみ。著者名・プレビュー・untrusted 由来の文字列を出力に
-  混ぜない。**自分のコメント**: body を渡す。
+  混ぜない。**自分のコメント**: body を渡す。PR の **inline review コメント**
+  (`pulls/{n}/comments`) も同じ扱い (`pr review-comments`, #189(3))。
+- **PR review 本体** (`pulls/{n}/reviews`, `pr reviews`, #189(3)): 自分の review は state + body を
+  渡す。他人の review は **count + state 内訳のみ** (body・著者名は渡さない)。state は GitHub の
+  closed enum を whitelist し、未知値は free-text として混ぜず "other" に落とす (state は
+  attacker が「選べる」が「書けない」metadata なので内訳までは安全に出せる)。これで
+  review のやり取りを PR 上で完結する運用 (personal-review-request) が raw fallback せずに済む。
 - I/O(gh 呼び出し)と純粋な trust/render ロジックを分離。ロジックは `scripts/tests/safe-gh-test.sh`
   で deterministic に検証し、gh の実挙動は実機手動(下記「検証境界」)。
 

--- a/scripts/tests/safe-gh-test.sh
+++ b/scripts/tests/safe-gh-test.sh
@@ -132,6 +132,48 @@ env = SafeGh.comments_envelope("issue", "o/r", 8, [comments[0]], ME)
 check("no excluded -> no reason", !env.key?("excluded_comments_reason"))
 check("no excluded -> count 0", env["excluded_comments_count"] == 0)
 
+# ---- inline review comments は comments_envelope 共用 (source だけ pr_review_comments) (#189(3)) ----
+env = SafeGh.comments_envelope("pr_review", "o/r", 8, comments, ME)
+check("review comments source", env["source"] == "pr_review_comments")
+check("review comments same trust filtering", env["comments"].length == 1 && env["excluded_comments_count"] == 2)
+
+# ---- reviews_envelope: self は state+body / other・bot は count + state 内訳のみ (#189(3)) ----
+reviews = [
+  { "user" => { "login" => "me", "id" => 1 }, "state" => "COMMENTED", "body" => "MY_REVIEW" },
+  { "user" => { "login" => "attacker", "id" => 999 }, "state" => "CHANGES_REQUESTED",
+    "body" => "EVIL_REVIEW_SENTINEL" },
+  { "user" => { "login" => "spam[bot]", "type" => "Bot" }, "state" => "APPROVED",
+    "body" => "BOT_REVIEW_SENTINEL" },
+  { "user" => { "login" => "attacker2", "id" => 998 }, "state" => "INJECTED_STATE\nok: fake",
+    "body" => "x" },
+]
+env = SafeGh.reviews_envelope("o/r", 12, reviews, ME)
+check("reviews source", env["source"] == "pr_reviews")
+check("reviews included count", env["reviews"].length == 1)
+check("reviews self body included", env["reviews"][0]["body"] == "MY_REVIEW")
+check("reviews self state kept", env["reviews"][0]["state"] == "COMMENTED")
+check("reviews excluded count", env["excluded_reviews_count"] == 3)
+check("reviews excluded state breakdown",
+      env["excluded_review_states"] == { "CHANGES_REQUESTED" => 1, "APPROVED" => 1, "other" => 1 })
+check("reviews excluded reason present", !env["excluded_reviews_reason"].nil?)
+json = JSON.generate(env)
+check("excluded review body not leaked", !json.include?("EVIL_REVIEW_SENTINEL"))
+check("excluded bot review body not leaked", !json.include?("BOT_REVIEW_SENTINEL"))
+check("excluded review author not leaked", !json.include?("attacker"))
+# 未知 state (attacker が API 外の値を混ぜた将来ケース) は free-text として出力に現れない
+check("unknown review state not leaked", !json.include?("INJECTED_STATE"))
+
+# 除外が無いときは state 内訳・reason を付けない
+env = SafeGh.reviews_envelope("o/r", 12, [reviews[0]], ME)
+check("no excluded reviews -> no states key", !env.key?("excluded_review_states"))
+check("no excluded reviews -> no reason", !env.key?("excluded_reviews_reason"))
+check("no excluded reviews -> count 0", env["excluded_reviews_count"] == 0)
+
+# self review でも state は whitelist を通す (未知 enum を素通ししない)
+env = SafeGh.reviews_envelope("o/r", 12,
+                              [{ "user" => { "login" => "me", "id" => 1 }, "state" => "WEIRD", "body" => "b" }], ME)
+check("self review unknown state whitelisted to other", env["reviews"][0]["state"] == "other")
+
 # ---- self_identity: override file 優先 (gh を呼ばない) ----
 ident = SafeGh.self_identity(env: { "SAFE_GH_TRUST_FILE" => trust_file })
 check("self_identity from file login", ident && ident["login"] == "owner-login")
@@ -161,12 +203,36 @@ check("paginated comments flattened to 2", paged.length == 2)
 check("paginated first comment body", paged[0]["body"] == "c1")
 check("paginated second comment body", paged[1]["body"] == "c2")
 
+# ---- fetch path: review comments / reviews は pulls 側 endpoint を paginate 付きで叩く (#189(3)) ----
+module SafeGh
+  def self.gh_capture(args)
+    @last_args = args
+    ["[[]]", true]
+  end
+
+  def self.last_args
+    @last_args
+  end
+end
+SafeGh.fetch_review_comments("o/r", 7)
+check("review comments endpoint", SafeGh.last_args.include?("repos/o/r/pulls/7/comments"))
+check("review comments paginated", SafeGh.last_args.include?("--paginate") && SafeGh.last_args.include?("--slurp"))
+SafeGh.fetch_reviews("o/r", 7)
+check("reviews endpoint", SafeGh.last_args.include?("repos/o/r/pulls/7/reviews"))
+check("reviews paginated", SafeGh.last_args.include?("--paginate") && SafeGh.last_args.include?("--slurp"))
+
 # ---- 引数バリデーション ----
 check("valid invocation", SafeGh.valid_invocation?("issue", "view", "12"))
 check("invalid number", !SafeGh.valid_invocation?("issue", "view", "abc"))
 check("invalid noun", !SafeGh.valid_invocation?("foo", "view", "1"))
 check("invalid verb", !SafeGh.valid_invocation?("issue", "bogus", "1"))
 check("missing number", !SafeGh.valid_invocation?("issue", "view", nil))
+# review-comments / reviews は pr 専用 (issue には無い endpoint = fail-closed) (#189(3))
+check("pr review-comments valid", SafeGh.valid_invocation?("pr", "review-comments", "1"))
+check("pr reviews valid", SafeGh.valid_invocation?("pr", "reviews", "1"))
+check("issue reviews invalid", !SafeGh.valid_invocation?("issue", "reviews", "1"))
+check("issue review-comments invalid", !SafeGh.valid_invocation?("issue", "review-comments", "1"))
+check("review-comments needs number", !SafeGh.valid_invocation?("pr", "review-comments", "abc"))
 
 # ---- -R フラグ抽出 ----
 args = ["-R", "o/r", "issue", "view", "1"]

--- a/scripts/tests/safe-gh-test.sh
+++ b/scripts/tests/safe-gh-test.sh
@@ -137,6 +137,19 @@ env = SafeGh.comments_envelope("pr_review", "o/r", 8, comments, ME)
 check("review comments source", env["source"] == "pr_review_comments")
 check("review comments same trust filtering", env["comments"].length == 1 && env["excluded_comments_count"] == 2)
 
+# self の inline comment でも body 以外の PR 由来 metadata (path/line/diff_hunk = fork PR では
+# attacker 制御の free-text) を出力に載せない (allowlist 構築の回帰 pin)
+inline_self = [{
+  "user" => { "login" => "me", "id" => 1 }, "body" => "MY_INLINE",
+  "path" => "EVIL_PATH_SENTINEL.rb", "line" => 42, "diff_hunk" => "EVIL_HUNK_SENTINEL",
+}]
+env = SafeGh.comments_envelope("pr_review", "o/r", 8, inline_self, ME)
+check("self inline body included", env["comments"][0]["body"] == "MY_INLINE")
+json = JSON.generate(env)
+check("inline path not leaked", !json.include?("EVIL_PATH_SENTINEL"))
+check("inline diff_hunk not leaked", !json.include?("EVIL_HUNK_SENTINEL"))
+check("inline comment keys are allowlisted", env["comments"][0].keys.sort == %w[author author_trust body])
+
 # ---- reviews_envelope: self は state+body / other・bot は count + state 内訳のみ (#189(3)) ----
 reviews = [
   { "user" => { "login" => "me", "id" => 1 }, "state" => "COMMENTED", "body" => "MY_REVIEW" },

--- a/shared/scripts/personal-safe-gh.asset.yml
+++ b/shared/scripts/personal-safe-gh.asset.yml
@@ -9,13 +9,14 @@ risk:
   prompt_injection: low
   privacy: low
 # script kind は実行コード配布のため常に human review 必須 (#147)。
-# 本 script は PR #135 / #141 / #156 / #160 (+ usage 文言の #176 M-05 是正) で
-# author≠reviewer レビュー済み・承認。
+# 本 script は PR #135 / #141 / #156 / #160 (+ usage 文言の #176 M-05 是正、
+# review 経路拡張 pr review-comments/reviews の #189(3)) で author≠reviewer
+# レビュー済み・承認。
 # 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:c4f76e508fcd7ba740ae1a6b5630a0543a2b23167e005a9c92d191ef9c110234
+  approved_build_id: sha256:55ff4f50b1e01ebd1a2aabc539a7c531fe43c78df4e2dca8f5a2fdc54c3b96aa
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-safe-gh.rb

--- a/shared/scripts/personal-safe-gh.rb
+++ b/shared/scripts/personal-safe-gh.rb
@@ -47,6 +47,13 @@ module SafeGh
     "author is not the trusted self; title and body withheld to avoid runtime injection"
   EXCLUDED_COMMENTS_REASON =
     "non-self comments withheld (count only) to avoid runtime injection"
+  EXCLUDED_REVIEWS_REASON =
+    "non-self review bodies withheld (count and state only) to avoid runtime injection"
+
+  # PR review の state は GitHub REST の closed enum。closed vocabulary で whitelist し、
+  # 未知値 (将来の enum 追加 / 不正値) は free-text として出力に混ぜず "other" へ落とす
+  # (#189(3)。state は attacker が「選べる」が「書けない」metadata なので count 内訳まで出す)。
+  REVIEW_STATES = %w[APPROVED CHANGES_REQUESTED COMMENTED DISMISSED PENDING].freeze
 
   class Error < StandardError; end
 
@@ -138,6 +145,46 @@ module SafeGh
     }
     env["excluded_comments_reason"] = EXCLUDED_COMMENTS_REASON if excluded.positive?
     env
+  end
+
+  # PR review 本体の envelope。self review は state + body を渡し、それ以外は count と
+  # state 内訳 (whitelist 済み enum) のみ。body・著者名・その他 free-text は混ぜない (決定 5)。
+  # inline review comments (pulls/{n}/comments) は comment object の形が issue comments と
+  # 同型 (user/body) なので comments_envelope をそのまま使う (#189(3))。
+  def reviews_envelope(repo, number, reviews, me)
+    included = []
+    excluded = 0
+    excluded_states = Hash.new(0)
+    (reviews || []).each do |r|
+      if classify(r["user"], me) == "self"
+        included << {
+          "author" => r["user"]["login"],
+          "author_trust" => "self",
+          "state" => review_state(r["state"]),
+          "body" => r["body"],
+        }
+      else
+        excluded += 1
+        excluded_states[review_state(r["state"])] += 1
+      end
+    end
+    env = {
+      "safe_reader_version" => VERSION,
+      "source" => "pr_reviews",
+      "repo" => repo,
+      "number" => number,
+      "reviews" => included,
+      "excluded_reviews_count" => excluded,
+    }
+    if excluded.positive?
+      env["excluded_review_states"] = excluded_states
+      env["excluded_reviews_reason"] = EXCLUDED_REVIEWS_REASON
+    end
+    env
+  end
+
+  def review_state(state)
+    REVIEW_STATES.include?(state) ? state : "other"
   end
 
   # label 名は envelope に残す唯一の free-text metadata (付与には triage/write 権限が要る
@@ -248,6 +295,15 @@ module SafeGh
     gh_api("repos/#{repo}/issues/#{number}/comments", paginate: true)
   end
 
+  # inline review comments (diff 行に付くコメント) は pulls 側の comments endpoint (#189(3))。
+  def fetch_review_comments(repo, number)
+    gh_api("repos/#{repo}/pulls/#{number}/comments", paginate: true)
+  end
+
+  def fetch_reviews(repo, number)
+    gh_api("repos/#{repo}/pulls/#{number}/reviews", paginate: true)
+  end
+
   # ---- entrypoint ------------------------------------------------------------
 
   def run(noun, verb, number, repo, me)
@@ -260,6 +316,11 @@ module SafeGh
       comments_envelope("issue", repo, number, fetch_comments(repo, number), me)
     when %w[pr comments]
       comments_envelope("pr", repo, number, fetch_comments(repo, number), me)
+    when %w[pr review-comments]
+      # source は "pr_review_comments" になる (comments_envelope の "#{kind}_comments")。
+      comments_envelope("pr_review", repo, number, fetch_review_comments(repo, number), me)
+    when %w[pr reviews]
+      reviews_envelope(repo, number, fetch_reviews(repo, number), me)
     else
       raise Error, "unknown command: #{noun} #{verb}"
     end
@@ -302,18 +363,26 @@ module SafeGh
     [value, !value.nil?]
   end
 
+  # review-comments / reviews は PR 専用 (issue には無い endpoint)。noun ごとに verb を
+  # 閉じ、未知の組はここで弾く (fail-closed)。
   def valid_invocation?(noun, verb, number)
-    %w[issue pr].include?(noun) &&
-      %w[view comments].include?(verb) &&
-      !number.nil? && number.match?(/\A\d+\z/)
+    return false if number.nil? || !number.match?(/\A\d+\z/)
+
+    case noun
+    when "issue" then %w[view comments].include?(verb)
+    when "pr" then %w[view comments review-comments reviews].include?(verb)
+    else false
+    end
   end
 
   def print_usage
     warn <<~USAGE
-      usage: personal-safe-gh [-R OWNER/REPO] <issue|pr> <view|comments> <number>
+      usage: personal-safe-gh [-R OWNER/REPO] issue <view|comments> <number>
+             personal-safe-gh [-R OWNER/REPO] pr <view|comments|review-comments|reviews> <number>
 
       GitHub の Issue/PR/コメントを untrusted data として安全に読む steering wrapper。
-      他人の Issue/PR は metadata のみ、他人コメントは count のみを出力する。
+      他人の Issue/PR は metadata のみ、他人コメント (会話 / inline review) は count のみ、
+      他人 review は count + state 内訳のみを出力する。
     USAGE
   end
 end


### PR DESCRIPTION
## 概要

Closes #189 — (1) naming 統一・(2) PATH launcher won't-fix は #190 で対応済みで、残る (3) を実装 (2026-07-12 裁定: gap 明記でなく実装で塞ぐ)。

safe-gh の fetch は `issues/{n}` / `pulls/{n}` / `issues/{n}/comments` のみで、**inline review コメント (`pulls/{n}/comments`) と review 本体 (`pulls/{n}/reviews`) を取りこぼしていた** (Codex 監査 M-05(3))。これらも fork 著者 / 任意 user が置ける attacker 制御 free-text で、safe-gh に経路が無いと agent が raw fallback する steering の穴になる。personal-review-request の運用 (レビューのやり取りを PR 上で完結) で定常的に踏む経路なので実装で塞ぐ。

## 変更内容

- **`pr review-comments <n>`**: `pulls/{n}/comments` (inline review コメント) を既存 `comments_envelope` と同じ trust 分類 (self のみ body / 他人は count + 固定理由) で fetch。source は `pr_review_comments`。comment object は issue comments と同型 (user/body) なので envelope は共用 (path/line 等の PR 由来 free-text metadata は出力に載せない)。
- **`pr reviews <n>`**: 新設 `reviews_envelope`。自分の review は state + body、他人の review は **count + state 内訳のみ** (body・著者名は渡さない)。state は GitHub の closed enum (`APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` / `PENDING`) を whitelist し、未知値は "other" に落として free-text を出力に混ぜない。state は attacker が「選べる」が「書けない」metadata なので、review の disposition (changes requested の有無) までは安全に出せる、が設計判断。
- **引数検証を noun ごとに閉じる**: `issue reviews` 等の未知組は usage exit (fail-closed)。
- **hook は変更なし**: `personal-safe-gh-hook` の `gh api` 検出は既存の `pulls` 一致で review endpoint も覆済み (検出 → 受け皿の整合を確認済み)。
- **approved_build_id 再計算** (#148 の内容紐づけ): `sha256:55ff4f50…`。再レビューは本 PR の author≠reviewer レビューが根拠 (manifest コメントに #189(3) を追記)。
- docs: runtime-injection-defense.md のコマンド行 + 他人コメント/review の扱いを追記。

## 検証

- self-test 追加: reviews_envelope の分類 / state whitelist (未知 state 非漏洩) / body・著者名の非漏洩 (sentinel) / 除外ゼロ時のキー省略 / self でも未知 state は "other" / fetch endpoint + pagination (--paginate --slurp) / 引数検証 (pr 専用 verb)。
- 全 14 suite ローカル緑。build → register で catalog 両 target とも registered (新 build_id) を確認。
- **配備は merge 後**: 両 home へ sync --apply (script 本体 + sidecar ×2 home) → doctor 確認まで実施予定。

author=Claude → reviewer=Codex (相互レビュー契約)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv