### PR TITLE
feat: commit 境界の git hook gates — dispatcher / public-safety / AI trailer (Refs #202)

### DIFF
--- a/docs/git-hook-gates.md
+++ b/docs/git-hook-gates.md
@@ -39,6 +39,11 @@ global git config: core.hooksPath = <dotfiles 所有の hooks dir>
   fail-closed (exit 2) で commit を止める (配備欠損を黙って素通りさせない)。
 - shim がどちらの tool home の deploy を指すかは dotfiles 側の裁定 (両 home に同一
   byte が配備される)。
+- **再入 sentinel の既知の副作用**: dispatcher は chain 実行時に stage 単位の env
+  (`AGENT_TOOLS_GIT_HOOK_ACTIVE_<STAGE>`) を立て、再入を検出したら gate 済みとして
+  即 pass する (shim 経由の間接自己参照 loop 対策)。このため、chain 先の repo hook が
+  **別 repository へ同じ stage の commit を行う**場合、その内側の commit は gate を
+  通らない。
 
 ## dispatcher の chain 契約
 

--- a/docs/git-hook-gates.md
+++ b/docs/git-hook-gates.md
@@ -1,0 +1,105 @@
+# Git Hook Gates(dispatcher / public-safety / AI trailer)
+
+commit 境界の機械的規律を git hook として決定的に実行するための 3 script の契約。
+skill (probabilistic な steering) が繰り返し宣言してきた規律のうち、条件とアクションが
+機械判定できる部分だけを hook に切り出したもの (#200 §4.1-4.2 / #202)。判断が要る部分
+(公開してよい意味内容か・レビュー運用) は従来どおり skill / 人間の領分に残る。
+
+## 強度ラベル(偽らない)
+
+これらはすべて**通常経路 (git commit) に対する best-effort guardrail** であって、
+enforcement boundary ではない:
+
+- `git commit --no-verify` は pre-commit / commit-msg をどちらも skip する (実測 #201)。
+- repo local の `core.hooksPath` (husky 等) は global 設定を上書きし、gate は黙って
+  外れる (実測 #201)。
+- 別 client / 他マシンからの commit・GitHub 上の操作 (squash merge 等) は対象外。
+
+hard な床は従来どおりここに載せない (credential 隔離 / egress / CI)。公開前の最終
+確認点は push / CI 側に置く (follow-up は #202)。トレーラ喪失 (squash / rebase) への
+対処は消費側 preflight (#202 の routing-preflight) の領分。
+
+## 構成と配線(所有分界)
+
+実体 (script) = agent-tools、配線 (git config / shim) = dotfiles。既存の
+[boundary-with-dotfiles](boundary-with-dotfiles.md) を踏襲する。
+
+```text
+global git config: core.hooksPath = <dotfiles 所有の hooks dir>
+  <hooks dir>/pre-commit   →  exec <deploy>/personal-git-hook-dispatcher pre-commit "$@"
+  <hooks dir>/commit-msg   →  exec <deploy>/personal-git-hook-dispatcher commit-msg "$@"
+
+<deploy> = <tool home>/agent-tools/scripts (sync の script 配備先。公開契約)
+  personal-git-hook-dispatcher   … stage ごとの gate 実行 + repo hook への chain
+  personal-public-safety-gate    … pre-commit stage の gate
+  personal-ai-trailer-gate       … commit-msg stage の gate
+```
+
+- dispatcher は gate を**自分と同じ directory** から解決する。gate が欠けていれば
+  fail-closed (exit 2) で commit を止める (配備欠損を黙って素通りさせない)。
+- shim がどちらの tool home の deploy を指すかは dotfiles 側の裁定 (両 home に同一
+  byte が配備される)。
+
+## dispatcher の chain 契約
+
+global `core.hooksPath` は per-repo `.git/hooks` を**完全に置換**し、fallback もない
+(実測 #201)。dispatcher はこれを合成に変える:
+
+1. stage の personal gate を順に実行。fail したらその exit code で終了 (chain しない)。
+2. 全 gate pass 後、`git rev-parse --git-common-dir` 直下の `hooks/<stage>` が実行可能
+   なら `exec` で chain する (exit code はそのまま repo hook のもの)。worktree でも
+   共有側 hooks が対象 (実測 #201 と同じ挙動)。
+3. chain 先が dispatcher 自身に解決される誤設定は検出して skip する (無限 chain 防止)。
+
+`git rev-parse --git-path hooks` は core.hooksPath を返すため使わない (自分に戻る)。
+
+## personal-public-safety-gate(pre-commit)
+
+staged diff の**追加行**を scan する。読むのは `git diff --cached` / staged file 一覧 /
+local pattern file のみ。network なし・値そのものは出力しない (file:line と種別のみ)。
+
+| クラス | 対象 | 挙動 |
+|---|---|---|
+| definite | private key block / 既知 token 形 (GitHub・AWS・Slack・Anthropic・OpenAI・Stripe) / 実 `$HOME` path の literal / `*.local` `*.local.md` の staged 追加 / local pattern 一致 | exit 1 で block |
+| suspicious | 汎用 credential 代入ヒューリスティック | 警告のみ (block しない) |
+
+- **escape (明示確認)**: レビュー済みの誤検知は該当行に `public-safety: allow` を書く。
+- **local pattern file**: `~/.config/agent-tools/public-safety-patterns.local`
+  (1 行 1 Ruby regex、`#` コメント可・untracked のユーザー正本)。planning tool の
+  domain 等、**public repo に書けないパターンはここに置く** (tracked な gate 本体には
+  持たない)。不在は追加パターンなし。regex が壊れていれば exit 2 で止める。
+- 実 `$HOME` の判定は `$HOME` が `/Users/<name>` / `/home/<name>` 形のときだけ有効
+  (汎用の `/Users/...` 例示は検出しない)。
+- exit: 0 = pass / 1 = definite finding / 2 = 入力・構成エラー (git 失敗・regex 壊れ)。
+
+## personal-ai-trailer-gate(commit-msg)
+
+AI agent セッション由来の commit に相互レビュー routing の正本である
+`Co-Authored-By:` トレーラを要求する。**opt-in 設計**で人間の commit を誤 block しない。
+
+| セッション判定 (env marker) | 要求 |
+|---|---|
+| marker なし (人間・他 tool) | 無言 pass |
+| `CLAUDECODE` のみ | name が `Claude` 始まりのトレーラ 1 本以上 |
+| `CODEX_THREAD_ID` / `CODEX_SANDBOX` のみ | name が `Codex` 始まりのトレーラ 1 本以上 |
+| 両方 (nested 実行: Claude → codex exec 等) | いずれかの有効な AI トレーラ 1 本以上 |
+
+- AI トレーラの email は no-reply 形式 (`no-?reply` を含む) のみ許可。この regex が
+  「email は公開してよい no-reply / bot 用に限る」(operating-rules) の機械判定可能な
+  床であり、**許可 email 形式の policy source はこの gate が SSOT**。
+- 1 commit に Claude 系と Codex 系のトレーラが混在したら fail-closed (routing 判定不能)。
+- 人間の co-author トレーラ (AI 名以外) は自由 (検査対象外)。
+- **merge commit (MERGE_HEAD あり) は対象外** (authored commit の契約。merge は
+  レビュー済み作業の合成)。
+- commit message の comment 除去は既定 `commentChar` (`#`) と scissors 行のみ対応。
+- env marker は**観測された事実であって両 CLI の公開契約ではない** (#201 実測,
+  Claude Code 2.1.207 / codex 0.144.1)。CLI 更新で消えた場合、gate は人間 commit と
+  同じ扱い (無言 pass) に fail-open で倒れる。CLI 更新時の smoke test で生存確認する。
+- exit: 0 = pass / 1 = 検証 fail / 2 = usage・入力エラー。
+
+## 検証境界
+
+- 純粋ロジックと git 連携 (hooksPath 経由の commit / chain / 隔離 env) は
+  `scripts/tests/git-hook-gates-test.sh` が CI で検証する。
+- 実環境の配線 (dotfiles の shim + global git config・Codex 側 marker の生存) は CI 外
+  (実機 smoke。実施記録は #202)。

--- a/scripts/tests/git-hook-gates-test.sh
+++ b/scripts/tests/git-hook-gates-test.sh
@@ -106,6 +106,25 @@ check("scan_diff が file:line を帰属", f.size == 1 && f[0].file == "a.txt" &
 check("削除行は見ない",
       PublicSafetyGate.scan_diff("--- a/a.txt\n+++ b/a.txt\n@@ -1,1 +1,1 @@\n-x = '#{gh_token}'\n+clean\n", [], nil).empty?)
 
+# H206-01 回帰: 追加行の内容が "++ " で始まっても header と誤認せず後続を取り逃さない
+tricky = <<~DIFF
+  diff --git a/a.txt b/a.txt
+  --- a/a.txt
+  +++ b/a.txt
+  @@ -0,0 +1,3 @@
+  +clean line
+  +++ b/looks-like-header
+  +x = '#{gh_token}'
+DIFF
+tf = PublicSafetyGate.scan_diff(tricky, [], nil)
+check("hunk 内の '+++' 行で file を失わない (H206-01)",
+      tf.size == 1 && tf[0].file == "a.txt" && tf[0].line == 3)
+
+# should 回帰: quoted path の C-style escape を復号する
+quoted = "diff --git \"a/ta\\tb.txt\" \"b/ta\\tb.txt\"\n--- \"a/ta\\tb.txt\"\n+++ \"b/ta\\tb.txt\"\n@@ -0,0 +1,1 @@\n+x = '#{gh_token}'\n"
+qf = PublicSafetyGate.scan_diff(quoted, [], nil)
+check("quoted path を復号して帰属 (tab)", qf.size == 1 && qf[0].file == "ta\tb.txt")
+
 # local-only file 判定
 check("*.local.md を検出",
       PublicSafetyGate.staged_local_only_files(["notes/x.local.md", "ok.md"]) == ["notes/x.local.md"])
@@ -139,6 +158,11 @@ check("nested: トレーラなしは fail", quiet { AiTrailerGate.judge([:claude
 check("人間 co-author は AI トレーラに数えない", quiet { AiTrailerGate.judge([:claude], msg(human_tr)) } == 1)
 check("人間 co-author 併記は妨げない",
       quiet { AiTrailerGate.judge([:claude], msg(claude_tr, human_tr)) } == 0)
+# H206-02 回帰: 本文中 (末尾 trailer block 外) のトレーラ行は数えない
+check("本文中のトレーラ行では pass しない (H206-02)",
+      quiet { AiTrailerGate.judge([:claude], ["subject", "", claude_tr, "", "more prose"]) } == 1)
+check("trailer_block は末尾段落のみ返す",
+      AiTrailerGate.trailer_block(["subject", "", "body", "", claude_tr, human_tr]) == [claude_tr, human_tr])
 
 # env marker の解釈
 check("CLAUDECODE で claude", AiTrailerGate.agents_from_env({ "CLAUDECODE" => "1" }) == [:claude])
@@ -180,6 +204,16 @@ set -e
 [ "$rc" -eq 1 ] || fail "*.local.md staged add should block (rc=$rc)"
 (cd "$repo" && git rm -q --cached x.local.md && rm x.local.md)
 
+# H206-06 回帰: 既存 tracked file の rename でも local-only 検査にかかる
+(cd "$repo" && as_human git commit -qm "seed for rename")
+(cd "$repo" && git mv ok.txt renamed.local && git add -A)
+set +e
+(cd "$repo" && as_human ruby "$pubsafe_src" >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "rename onto *.local should block (rc=$rc, H206-06)"
+(cd "$repo" && git mv renamed.local ok.txt)
+
 # local pattern file (HOME 配下) / invalid regex は exit 2
 mkdir -p "$tmp/home/.config/agent-tools"
 echo "secret-project-zeta" > "$tmp/home/.config/agent-tools/public-safety-patterns.local"
@@ -192,10 +226,15 @@ set -e
 [ "$rc" -eq 1 ] || fail "local pattern should block (rc=$rc)"
 echo "([" > "$tmp/home/.config/agent-tools/public-safety-patterns.local"
 set +e
-(cd "$repo" && as_human ruby "$pubsafe_src" >/dev/null 2>&1)
+out=$(cd "$repo" && as_human ruby "$pubsafe_src" 2>&1)
 rc=$?
 set -e
 [ "$rc" -eq 2 ] || fail "invalid local pattern regex should be a loud config error (rc=$rc)"
+# H206-03 回帰: 診断に regex 本文を含めない (private パターン置き場のため)
+case "$out" in
+  *"(["*) fail "invalid-regex diagnostic must not echo the pattern body: $out" ;;
+esac
+echo "$out" | grep -q "public-safety-patterns.local:1" || fail "diagnostic should carry file:line: $out"
 rm "$tmp/home/.config/agent-tools/public-safety-patterns.local"
 (cd "$repo" && git rm -q --cached doc.md && rm doc.md)
 
@@ -302,6 +341,13 @@ rc=$?
 set -e
 [ "$rc" -ne 0 ] || fail "failing chained hook should block the commit"
 
+# chain 先の exit code が等値で伝播する (dispatcher 直接呼び出しで pin)
+set +e
+(cd "$repo3" && as_human "$deploy/personal-git-hook-dispatcher" pre-commit >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 7 ] || fail "chained hook exit code should propagate verbatim (rc=$rc, want 7)"
+
 # chain 先が dispatcher 自身 (誤設定) なら skip して成功する
 ln -sf "$deploy/personal-git-hook-dispatcher" "$repo3/.git/hooks/pre-commit"
 set +e
@@ -309,6 +355,25 @@ out=$(cd "$repo3" && as_human git commit -qm "self chain" 2>&1)
 rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "self-referential chain should be skipped, not looped (rc=$rc): $out"
+
+# H206-04 回帰: chain 先が shim (間接的に dispatcher へ戻る) でも再入 sentinel で loop しない。
+# 回帰時は無限再帰になるため timeout で保護する。
+# 直前の test が残した symlink を必ず消してから書く (redirect は symlink を辿り、
+# deploy の dispatcher 本体を上書きしてしまう)。
+rm -f "$repo3/.git/hooks/pre-commit"
+printf '#!/bin/sh\nexec "%s" pre-commit "$@"\n' "$deploy/personal-git-hook-dispatcher" \
+  > "$repo3/.git/hooks/pre-commit"
+chmod +x "$repo3/.git/hooks/pre-commit"
+echo e > "$repo3/e.txt"
+(cd "$repo3" && git add e.txt)
+set +e
+out=$(cd "$repo3" && as_human ruby -rtimeout -e \
+  'Timeout.timeout(30) { ok = system(*ARGV); exit(ok ? 0 : (($?.exitstatus || 1))) }' \
+  -- git commit -qm "shim loop" 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "shim-indirect chain should be loop-guarded (rc=$rc, H206-04): $out"
+echo "$out" | grep -q "re-entrant" || fail "loop guard should be visible in output: $out"
 
 # ---- dispatcher の usage / fail-closed ---------------------------------------
 set +e
@@ -327,5 +392,14 @@ rc=$?
 set -e
 [ "$rc" -eq 2 ] || fail "missing gate should fail closed with exit 2 (rc=$rc)"
 echo "$out" | grep -q "fail-closed" || fail "missing gate message should say fail-closed: $out"
+
+# 再入 sentinel の単体挙動: guard env が立っていれば gate 解決前に即 0 で返る
+# (sparse dir = gate 欠損でも 0 になることで、guard が先に効くと分かる)
+set +e
+(cd "$repo2" && as_human env AGENT_TOOLS_GIT_HOOK_ACTIVE_PRE_COMMIT=1 \
+  "$sparse/personal-git-hook-dispatcher" pre-commit >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "guard env should short-circuit before gate resolution (rc=$rc)"
 
 echo "ok: git-hook-gates self-test"

--- a/scripts/tests/git-hook-gates-test.sh
+++ b/scripts/tests/git-hook-gates-test.sh
@@ -163,6 +163,11 @@ check("本文中のトレーラ行では pass しない (H206-02)",
       quiet { AiTrailerGate.judge([:claude], ["subject", "", claude_tr, "", "more prose"]) } == 1)
 check("trailer_block は末尾段落のみ返す",
       AiTrailerGate.trailer_block(["subject", "", "body", "", claude_tr, human_tr]) == [claude_tr, human_tr])
+# H206-02 R2 回帰: 末尾段落に散文が混在すると git は trailer と認めない → gate も認めない
+check("散文混在の末尾段落では pass しない (H206-02 R2)",
+      quiet { AiTrailerGate.judge([:claude], ["subject", "", claude_tr, "more prose"]) } == 1)
+check("散文混在段落は trailer_block にならない",
+      AiTrailerGate.trailer_block(["subject", "", claude_tr, "more prose"]) == [])
 
 # env marker の解釈
 check("CLAUDECODE で claude", AiTrailerGate.agents_from_env({ "CLAUDECODE" => "1" }) == [:claude])

--- a/scripts/tests/git-hook-gates-test.sh
+++ b/scripts/tests/git-hook-gates-test.sh
@@ -1,0 +1,331 @@
+#!/bin/sh
+# personal-git-hook-dispatcher.rb / personal-public-safety-gate.rb /
+# personal-ai-trailer-gate.rb の self-test。
+# 純粋ロジック (scan / judge) は check_helper の Ruby unit check、git 連携 (staged diff /
+# commit-msg / hooksPath 経由の dispatcher chain) は tmp repo での integration で検証する。
+# 実 HOME / 実 git config には触れない (HOME / GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM を隔離)。
+# secret 形の fixture は実行時に連結して作り、literal をこの file に置かない
+# (この gate 自身の検査対象になるため)。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=lib/test-helpers.sh
+. "$script_dir/lib/test-helpers.sh"
+
+dispatcher_src="$repo_root/shared/scripts/personal-git-hook-dispatcher.rb"
+pubsafe_src="$repo_root/shared/scripts/personal-public-safety-gate.rb"
+trailer_src="$repo_root/shared/scripts/personal-ai-trailer-gate.rb"
+for f in "$dispatcher_src" "$pubsafe_src" "$trailer_src"; do
+  [ -f "$f" ] || fail "missing $f"
+done
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# ---- git / env の隔離 --------------------------------------------------------
+# 実環境の git config・HOME を読ませない。agent marker も明示制御する (この test 自体が
+# Claude / Codex セッション下で走るため、継承 env を必ず落としてから足す)。
+GIT_CONFIG_SYSTEM=/dev/null
+export GIT_CONFIG_SYSTEM
+GIT_CONFIG_GLOBAL="$tmp/gitconfig"
+export GIT_CONFIG_GLOBAL
+git config --file "$GIT_CONFIG_GLOBAL" user.name test
+git config --file "$GIT_CONFIG_GLOBAL" user.email test@example.com
+git config --file "$GIT_CONFIG_GLOBAL" init.defaultBranch main
+
+# 人間 (marker なし) として実行するための env 前置。
+as_human() {
+  env -u CLAUDECODE -u CODEX_THREAD_ID -u CODEX_SANDBOX HOME="$tmp/home" "$@"
+}
+as_claude() {
+  env -u CODEX_THREAD_ID -u CODEX_SANDBOX CLAUDECODE=1 HOME="$tmp/home" "$@"
+}
+as_codex() {
+  env -u CLAUDECODE CODEX_THREAD_ID=test-thread HOME="$tmp/home" "$@"
+}
+mkdir -p "$tmp/home"
+
+# secret 形 fixture (実行時連結。literal を置かない)
+gh_token=$(printf 'ghp'; printf '_'; printf 'aaaaaaaaaabbbbbbbbbbccccccccccdddddd')
+
+# ---- Ruby unit checks: 純粋ロジック ------------------------------------------
+as_human ruby -r"$script_dir/lib/check_helper" - "$pubsafe_src" "$trailer_src" "$gh_token" <<'RUBY'
+require "stringio"
+require ARGV[0]
+require ARGV[1]
+gh_token = ARGV[2]
+
+# 負例ケースの想定内診断 (warn) で test 出力を汚さない。check_helper の FAIL は
+# capture の外で出るよう、判定呼び出しだけを包む。
+def quiet
+  orig = $stderr
+  $stderr = StringIO.new
+  yield
+ensure
+  $stderr = orig
+end
+
+# public-safety: scan_line
+def hits(content, extra: [], home: nil)
+  PublicSafetyGate.scan_line(content, extra, home).map { |name, _| name }
+end
+
+check("token 形を検出", hits("x = '#{gh_token}'").include?("github-token"))
+check("aws key を検出", hits("key: " + "AKIA" + "IOSFODNN7EXAMPLE").include?("aws-access-key"))
+check("private key block を検出",
+      hits("-----BEGIN " + "RSA PRIVATE KEY-----").include?("private-key-block"))
+check("平文は検出しない", hits("plain text line").empty?)
+check("regex source 自身は検出しない (self-hosting)",
+      hits("/\\bAKIA[0-9A-Z]{16}\\b/").empty?)
+check("allow pragma で skip",
+      hits("x = '#{gh_token}' # public-safety: allow").empty?)
+check("home path literal を検出",
+      hits("path: /Users/ghost-user/src", home: "/Users/ghost-user").include?("home-path"))
+check("他人の /Users は検出しない",
+      hits("path: /Users/someone-else/src", home: "/Users/ghost-user").empty?)
+check("credential 代入は suspicious",
+      PublicSafetyGate.scan_line("password = 'hunter2secret'", [], nil)
+        .any? { |name, sev| name == "credential-assignment" && sev == :suspicious })
+check("local pattern を definite で検出",
+      PublicSafetyGate.scan_line("see internal-tool-x", [["local-pattern:1", /internal-tool-x/]], nil)
+        .any? { |name, sev| name == "local-pattern:1" && sev == :definite })
+
+# public-safety: scan_diff (file / line の帰属)
+diff = <<~DIFF
+  diff --git a/a.txt b/a.txt
+  index 000..111 100644
+  --- a/a.txt
+  +++ b/a.txt
+  @@ -0,0 +1,3 @@
+  +clean line
+  +x = '#{gh_token}'
+  +tail line
+DIFF
+f = PublicSafetyGate.scan_diff(diff, [], nil)
+check("scan_diff が file:line を帰属", f.size == 1 && f[0].file == "a.txt" && f[0].line == 2)
+check("削除行は見ない",
+      PublicSafetyGate.scan_diff("--- a/a.txt\n+++ b/a.txt\n@@ -1,1 +1,1 @@\n-x = '#{gh_token}'\n+clean\n", [], nil).empty?)
+
+# local-only file 判定
+check("*.local.md を検出",
+      PublicSafetyGate.staged_local_only_files(["notes/x.local.md", "ok.md"]) == ["notes/x.local.md"])
+check("*.local を検出",
+      PublicSafetyGate.staged_local_only_files(["conf/app.local"]) == ["conf/app.local"])
+
+# trailer: message_lines (comment / scissors 除去)
+lines = AiTrailerGate.message_lines("subject\n# comment\nCo-Authored-By: Claude X <noreply@anthropic.com>\n# ------------------------ >8 ------------------------\nCo-Authored-By: Codex <bot@no-reply.example>\n")
+check("comment 行を除く", !lines.include?("# comment"))
+check("scissors 以降を除く", lines.none? { |l| l.include?("Codex") })
+
+# trailer: judge
+def msg(*trailers)
+  ["subject", ""] + trailers
+end
+claude_tr = "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+codex_tr = "Co-Authored-By: Codex <codex@no-reply.example.com>"
+human_tr = "Co-Authored-By: Alice <alice@example.com>"
+bad_email = "Co-Authored-By: Claude Fable 5 <claude@example.com>"
+
+check("人間 (marker なし) は無言 pass", quiet { AiTrailerGate.judge([], msg()) } == 0)
+check("claude: トレーラ欠落は fail", quiet { AiTrailerGate.judge([:claude], msg()) } == 1)
+check("claude: 正しいトレーラで pass", quiet { AiTrailerGate.judge([:claude], msg(claude_tr)) } == 0)
+check("claude: 非 no-reply email は fail", quiet { AiTrailerGate.judge([:claude], msg(bad_email)) } == 1)
+check("claude: Codex トレーラのみは fail", quiet { AiTrailerGate.judge([:claude], msg(codex_tr)) } == 1)
+check("codex: 正しいトレーラで pass", quiet { AiTrailerGate.judge([:codex], msg(codex_tr)) } == 0)
+check("混在は fail-closed", quiet { AiTrailerGate.judge([:claude], msg(claude_tr, codex_tr)) } == 1)
+check("nested (両 marker): どちらかで pass",
+      quiet { AiTrailerGate.judge([:claude, :codex], msg(codex_tr)) } == 0)
+check("nested: トレーラなしは fail", quiet { AiTrailerGate.judge([:claude, :codex], msg()) } == 1)
+check("人間 co-author は AI トレーラに数えない", quiet { AiTrailerGate.judge([:claude], msg(human_tr)) } == 1)
+check("人間 co-author 併記は妨げない",
+      quiet { AiTrailerGate.judge([:claude], msg(claude_tr, human_tr)) } == 0)
+
+# env marker の解釈
+check("CLAUDECODE で claude", AiTrailerGate.agents_from_env({ "CLAUDECODE" => "1" }) == [:claude])
+check("CODEX_THREAD_ID で codex",
+      AiTrailerGate.agents_from_env({ "CODEX_THREAD_ID" => "t" }) == [:codex])
+check("両方で nested", AiTrailerGate.agents_from_env({ "CLAUDECODE" => "1", "CODEX_SANDBOX" => "x" }) == [:claude, :codex])
+check("空値は marker にしない", AiTrailerGate.agents_from_env({ "CLAUDECODE" => "" }) == [])
+
+exit(@failed.zero? ? 0 : 1)
+RUBY
+
+# ---- integration: public-safety-gate を staged diff で -----------------------
+repo="$tmp/repo1"
+git init -q "$repo"
+
+echo "hello" > "$repo/ok.txt"
+(cd "$repo" && git add ok.txt)
+(cd "$repo" && as_human ruby "$pubsafe_src") || fail "clean staged diff should pass (unborn HEAD)"
+
+printf 'token = "%s"\n' "$gh_token" > "$repo/leak.txt"
+(cd "$repo" && git add leak.txt)
+set +e
+out=$(cd "$repo" && as_human ruby "$pubsafe_src" 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "staged token should block (rc=$rc)"
+echo "$out" | grep -q "leak.txt:1" || fail "finding should name file:line: $out"
+echo "$out" | grep -q "github-token" || fail "finding should name pattern: $out"
+echo "$out" | grep -q "$gh_token" && fail "finding must not echo the secret value"
+(cd "$repo" && git rm -q --cached leak.txt && rm leak.txt)
+
+# local-only file の forced add
+echo "private note" > "$repo/x.local.md"
+(cd "$repo" && git add -f x.local.md)
+set +e
+(cd "$repo" && as_human ruby "$pubsafe_src" >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "*.local.md staged add should block (rc=$rc)"
+(cd "$repo" && git rm -q --cached x.local.md && rm x.local.md)
+
+# local pattern file (HOME 配下) / invalid regex は exit 2
+mkdir -p "$tmp/home/.config/agent-tools"
+echo "secret-project-zeta" > "$tmp/home/.config/agent-tools/public-safety-patterns.local"
+echo "mentions secret-project-zeta here" > "$repo/doc.md"
+(cd "$repo" && git add doc.md)
+set +e
+(cd "$repo" && as_human ruby "$pubsafe_src" >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "local pattern should block (rc=$rc)"
+echo "([" > "$tmp/home/.config/agent-tools/public-safety-patterns.local"
+set +e
+(cd "$repo" && as_human ruby "$pubsafe_src" >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "invalid local pattern regex should be a loud config error (rc=$rc)"
+rm "$tmp/home/.config/agent-tools/public-safety-patterns.local"
+(cd "$repo" && git rm -q --cached doc.md && rm doc.md)
+
+# suspicious は警告のみで pass
+printf 'password = "hunter2secret"\n' > "$repo/warn.txt"
+(cd "$repo" && git add warn.txt)
+set +e
+out=$(cd "$repo" && as_human ruby "$pubsafe_src" 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "suspicious finding should not block (rc=$rc)"
+echo "$out" | grep -q "credential-assignment" || fail "suspicious finding should warn: $out"
+
+# ---- integration: dispatcher (配備形) + core.hooksPath 経由の git commit ------
+deploy="$tmp/deploy"
+mkdir -p "$deploy"
+for pair in "personal-git-hook-dispatcher:$dispatcher_src" \
+            "personal-public-safety-gate:$pubsafe_src" \
+            "personal-ai-trailer-gate:$trailer_src"; do
+  name=${pair%%:*}
+  src=${pair#*:}
+  cp "$src" "$deploy/$name"
+  chmod +x "$deploy/$name"
+done
+
+hooksdir="$tmp/hooks"
+mkdir -p "$hooksdir"
+for stage in pre-commit commit-msg; do
+  printf '#!/bin/sh\nexec "%s" %s "$@"\n' "$deploy/personal-git-hook-dispatcher" "$stage" > "$hooksdir/$stage"
+  chmod +x "$hooksdir/$stage"
+done
+
+repo2="$tmp/repo2"
+git init -q "$repo2"
+(cd "$repo2" && git config core.hooksPath "$hooksdir")
+
+# 人間: clean commit が通る
+echo one > "$repo2/f.txt"
+(cd "$repo2" && git add f.txt && as_human git commit -qm "human commit") \
+  || fail "human clean commit should pass through dispatcher"
+
+# 人間: secret は pre-commit stage で block される
+printf 'x = "%s"\n' "$gh_token" > "$repo2/leak.txt"
+(cd "$repo2" && git add leak.txt)
+set +e
+(cd "$repo2" && as_human git commit -qm "leak" >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "secret commit should be blocked via hooksPath dispatcher"
+(cd "$repo2" && git rm -q --cached leak.txt && rm leak.txt)
+
+# claude: trailer なしは commit-msg stage で block、trailer ありは通る
+echo two > "$repo2/g.txt"
+(cd "$repo2" && git add g.txt)
+set +e
+(cd "$repo2" && as_claude git commit -qm "agent commit without trailer" >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "claude commit without trailer should be blocked"
+(cd "$repo2" && as_claude git commit -qm "agent commit
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>") \
+  || fail "claude commit with trailer should pass"
+
+# codex marker + Codex trailer
+echo three > "$repo2/h.txt"
+(cd "$repo2" && git add h.txt)
+(cd "$repo2" && as_codex git commit -qm "codex commit
+
+Co-Authored-By: Codex <codex@no-reply.example.com>") \
+  || fail "codex commit with trailer should pass"
+
+# merge commit (MERGE_HEAD) は trailer 対象外
+(cd "$repo2" && git checkout -q -b feature && echo m > m.txt && git add m.txt \
+  && as_claude git commit -qm "feature work
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" \
+  && git checkout -q main)
+(cd "$repo2" && echo base > base.txt && git add base.txt \
+  && as_claude git commit -qm "base work
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>")
+(cd "$repo2" && as_claude git merge --no-ff -q -m "merge feature (no trailer)" feature) \
+  || fail "merge commit without trailer should pass (MERGE_HEAD exemption)"
+
+# repo 自身の hook への chain: 実行される + 失敗が伝播する
+repo3="$tmp/repo3"
+git init -q "$repo3"
+(cd "$repo3" && git config core.hooksPath "$hooksdir")
+mkdir -p "$repo3/.git/hooks"
+printf '#!/bin/sh\ntouch "%s/chained"\nexit 0\n' "$tmp" > "$repo3/.git/hooks/pre-commit"
+chmod +x "$repo3/.git/hooks/pre-commit"
+echo c > "$repo3/c.txt"
+(cd "$repo3" && git add c.txt && as_human git commit -qm "chain ok") \
+  || fail "commit with passing chained hook should succeed"
+[ -f "$tmp/chained" ] || fail "repo's own pre-commit hook should be chained after gates"
+
+printf '#!/bin/sh\nexit 7\n' > "$repo3/.git/hooks/pre-commit"
+echo d > "$repo3/d.txt"
+(cd "$repo3" && git add d.txt)
+set +e
+(cd "$repo3" && as_human git commit -qm "chain fail" >/dev/null 2>&1)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "failing chained hook should block the commit"
+
+# chain 先が dispatcher 自身 (誤設定) なら skip して成功する
+ln -sf "$deploy/personal-git-hook-dispatcher" "$repo3/.git/hooks/pre-commit"
+set +e
+out=$(cd "$repo3" && as_human git commit -qm "self chain" 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "self-referential chain should be skipped, not looped (rc=$rc): $out"
+
+# ---- dispatcher の usage / fail-closed ---------------------------------------
+set +e
+as_human ruby "$dispatcher_src" unknown-stage >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "unknown stage should exit 2 (rc=$rc)"
+
+sparse="$tmp/sparse"
+mkdir -p "$sparse"
+cp "$dispatcher_src" "$sparse/personal-git-hook-dispatcher"
+chmod +x "$sparse/personal-git-hook-dispatcher"
+set +e
+out=$(cd "$repo2" && as_human "$sparse/personal-git-hook-dispatcher" pre-commit 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "missing gate should fail closed with exit 2 (rc=$rc)"
+echo "$out" | grep -q "fail-closed" || fail "missing gate message should say fail-closed: $out"
+
+echo "ok: git-hook-gates self-test"

--- a/shared/scripts/personal-ai-trailer-gate.asset.yml
+++ b/shared/scripts/personal-ai-trailer-gate.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:c9c92be1570cb44b4950c7532066eb0a723089a8eb63d5b6134e1dcd71d3e8d4
+  approved_build_id: sha256:cef12067930fc2ba04ce2539d8ff3413bce7fed561fcf4bfeb313e051eb09400
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-ai-trailer-gate.rb

--- a/shared/scripts/personal-ai-trailer-gate.asset.yml
+++ b/shared/scripts/personal-ai-trailer-gate.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:8dfb0e7aa629c47118157df1555edf8e8f2bfcf2dfbaefd849aa8321665cf07c
+  approved_build_id: sha256:c9c92be1570cb44b4950c7532066eb0a723089a8eb63d5b6134e1dcd71d3e8d4
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-ai-trailer-gate.rb

--- a/shared/scripts/personal-ai-trailer-gate.asset.yml
+++ b/shared/scripts/personal-ai-trailer-gate.asset.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+name: personal-ai-trailer-gate
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+# script kind は実行コード配布のため常に human review 必須 (#147)。
+# 本 script は #202 (Phase 1) の実装 PR で author≠reviewer レビューのうえ承認。
+# 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
+# approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
+review:
+  human_review: approved
+  approved_build_id: sha256:8dfb0e7aa629c47118157df1555edf8e8f2bfcf2dfbaefd849aa8321665cf07c
+  approved_artifact_kind: script
+source:
+  path: shared/scripts/personal-ai-trailer-gate.rb
+  format: text
+summary: >-
+  commit-msg stage の git gate。AI agent セッション由来 (env marker: CLAUDECODE / CODEX_*) の
+  commit に相互レビュー routing の正本 Co-Authored-By トレーラを要求する (欠落 / 混在 /
+  非 no-reply email を block)。人間 commit と merge commit は無言 pass の opt-in 設計。
+  squash / rebase での喪失は消費側 preflight の領分 (docs/git-hook-gates.md)。

--- a/shared/scripts/personal-ai-trailer-gate.rb
+++ b/shared/scripts/personal-ai-trailer-gate.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# ai-trailer-gate: commit-msg stage の git gate。AI agent セッション由来の commit に
+# 相互レビュー routing の正本である `Co-Authored-By:` トレーラが正しく付いているかを
+# 検証する。routing (author ≠ reviewer) は commit trailer を SSOT とするのに、付与が
+# モデル任せだった構造リスクを機械化したもの (#200 §4.2 / #202)。
+#
+# 正本: docs/git-hook-gates.md。
+#
+# 強度ラベル (偽らない): 通常経路 (git commit) に対する best-effort guardrail。
+# `--no-verify` / hooksPath 差し替えで迂回でき、squash / rebase / GitHub 上の操作での
+# トレーラ喪失は守れない (それは消費側 preflight の領分。#202 の routing-preflight)。
+#
+# opt-in 設計 (誤 block しない):
+# - agent セッションの識別は環境変数 marker で行う:
+#   Claude Code = CLAUDECODE / Codex = CODEX_THREAD_ID or CODEX_SANDBOX (#201 実測)。
+#   marker はどちらも「観測された事実」であって両 CLI の公開契約ではない。CLI 更新で
+#   消えたら gate は人間 commit と同じ扱い (無言 pass) に fail-open で倒れる。
+#   これも honest-label であり、marker の生存確認は CLI 更新時の smoke test に含める。
+# - marker なし (人間の手動 commit・他 tool) は無言で pass (exit 0)。人間の commit に
+#   トレーラ義務はない。
+# - 両 marker が立つ nested 実行 (Claude → codex exec 等) は agent 名を特定できないので、
+#   「いずれかの有効な AI トレーラがあること」まで緩めて要求する。
+# - merge commit (MERGE_HEAD あり) は対象外 (authored commit の契約であり、merge は
+#   レビュー済み作業の合成)。
+#
+# 検証内容 (agent 識別時):
+# - 期待 agent のトレーラが 1 本以上ある (Claude 環境 → name が "Claude" 始まり /
+#   Codex 環境 → "Codex" 始まり)。
+# - AI トレーラの email は no-reply 形式 (運用ルール「email は公開してよい no-reply /
+#   bot 用のものに限る」の機械判定可能な床)。
+# - 1 commit に Claude 系と Codex 系の両トレーラが混在したら fail-closed
+#   (相互レビュー routing が判定不能になる)。
+#
+# exit code: 0 = pass (人間 commit / merge / 検証通過) / 1 = 検証 fail / 2 = usage・
+# 入力エラー (message file が読めない等)。
+
+module AiTrailerGate
+  VERSION = "1"
+
+  TRAILER_RE = /\ACo-Authored-By:\s*(.+?)\s*<([^>]*)>\s*\z/i
+  NOREPLY_RE = /no-?reply/i
+  SCISSORS_RE = /\A# -+ >8 -+/
+
+  CLAUDE_MARKER = "CLAUDECODE"
+  CODEX_MARKERS = %w[CODEX_THREAD_ID CODEX_SANDBOX].freeze
+
+  # 例示 email は public な no-reply だが、check-injection の PII 検査 (静的 literal 対象)
+  # に かからないよう実行時連結で組む。
+  CLAUDE_EXAMPLE_EMAIL = ["noreply", "anthropic.com"].join("@")
+  EXPECTED_EXAMPLE = {
+    claude: "Co-Authored-By: Claude <model name> <#{CLAUDE_EXAMPLE_EMAIL}>",
+    codex: "Co-Authored-By: Codex <no-reply の email>",
+  }.freeze
+
+  module_function
+
+  def agents_from_env(env)
+    agents = []
+    agents << :claude unless env[CLAUDE_MARKER].to_s.empty?
+    agents << :codex if CODEX_MARKERS.any? { |k| !env[k].to_s.empty? }
+    agents
+  end
+
+  # commit message の comment 部 (既定 commentChar の "#" 行、scissors 以降) を除いた
+  # 本文行。commentChar の変更には追随しない (既定運用のみ。docs に明記)。
+  def message_lines(text)
+    lines = []
+    text.each_line do |raw|
+      line = raw.chomp
+      break if SCISSORS_RE.match?(line)
+      next if line.start_with?("#")
+
+      lines << line
+    end
+    lines
+  end
+
+  def ai_trailers(lines)
+    trailers = []
+    lines.each do |line|
+      m = TRAILER_RE.match(line)
+      next unless m
+
+      agent =
+        if m[1].start_with?("Claude")
+          :claude
+        elsif m[1].start_with?("Codex")
+          :codex
+        end
+      trailers << { agent: agent, name: m[1], email: m[2] } if agent
+    end
+    trailers
+  end
+
+  def merge_in_progress?
+    out = IO.popen(%w[git rev-parse --git-path MERGE_HEAD], &:read)
+    return false unless $?.success?
+
+    File.exist?(out.chomp)
+  end
+
+  # 純粋な判定 (env / message から結論と診断文言)。exit code を返す。
+  def judge(agents, lines)
+    return 0 if agents.empty?
+
+    trailers = ai_trailers(lines)
+    kinds = trailers.map { |t| t[:agent] }.uniq
+
+    if kinds.size > 1
+      warn "ai-trailer-gate: 1 つの commit に Claude 系と Codex 系のトレーラが混在しています。" \
+           "相互レビュー routing が判定不能になるため fail-closed で block します (作業を分けてください)。"
+      return 1
+    end
+
+    bad_email = trailers.reject { |t| NOREPLY_RE.match?(t[:email]) }
+    unless bad_email.empty?
+      warn "ai-trailer-gate: AI トレーラの email が no-reply 形式ではありません: " \
+           "#{bad_email.map { |t| t[:name] }.join(', ')} (公開してよい no-reply / bot 用に限る)。"
+      return 1
+    end
+
+    satisfied =
+      if agents.size > 1
+        !trailers.empty? # nested で agent 特定不能: いずれかの有効な AI トレーラで可
+      else
+        kinds.include?(agents.first)
+      end
+    return 0 if satisfied
+
+    expected = agents.map { |a| EXPECTED_EXAMPLE.fetch(a) }.join(" または ")
+    warn "ai-trailer-gate: #{agents.join('+')} セッション由来の commit にトレーラがありません。" \
+         "commit message 末尾に追加してください: #{expected}"
+    1
+  end
+
+  def run(argv)
+    path = argv[0]
+    if path.nil? || !File.file?(path)
+      warn "ai-trailer-gate: usage: personal-ai-trailer-gate <commit-msg-file>"
+      return 2
+    end
+    return 0 if merge_in_progress?
+
+    judge(agents_from_env(ENV), message_lines(File.read(path)))
+  end
+end
+
+exit AiTrailerGate.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/personal-ai-trailer-gate.rb
+++ b/shared/scripts/personal-ai-trailer-gate.rb
@@ -77,9 +77,15 @@ module AiTrailerGate
     lines
   end
 
-  # git の trailer 解釈の保守的近似: トレーラは message 末尾の段落 (trailer block) に
-  # あるものだけを数える。本文中に書かれた Co-Authored-By 行は git (interpret-trailers) も
-  # 消費側もトレーラと認識しないため、gate だけが pass すると判定が割れる (H206-02)。
+  # trailer 行の形 (Key: value)。git の trailer key は英数と '-'。
+  TRAILER_SHAPE_RE = /\A[A-Za-z0-9-]+:\s/
+
+  # git の trailer 解釈の保守的近似: message 末尾の段落を取り、**全行が trailer 形式の
+  # ときだけ** trailer block とみなす。本文中や散文混在段落の Co-Authored-By 行は git
+  # (interpret-trailers) も消費側もトレーラと認識しないため、gate だけが pass すると
+  # 判定が割れる (H206-02)。git 自身は「git 生成 trailer を含み 25% 以上が trailer」の
+  # 混在も許すが、こちらはより厳しい側 (認めない) に倒す — gate が要求するのは自分たちの
+  # commit が作る clean な trailer block であり、厳しい近似は fail-closed 方向。
   def trailer_block(lines)
     trimmed = lines.dup
     trimmed.pop while !trimmed.empty? && trimmed.last.strip.empty?
@@ -89,6 +95,8 @@ module AiTrailerGate
 
       block.unshift(line)
     end
+    return [] unless !block.empty? && block.all? { |l| TRAILER_SHAPE_RE.match?(l) }
+
     block
   end
 

--- a/shared/scripts/personal-ai-trailer-gate.rb
+++ b/shared/scripts/personal-ai-trailer-gate.rb
@@ -77,9 +77,24 @@ module AiTrailerGate
     lines
   end
 
+  # git の trailer 解釈の保守的近似: トレーラは message 末尾の段落 (trailer block) に
+  # あるものだけを数える。本文中に書かれた Co-Authored-By 行は git (interpret-trailers) も
+  # 消費側もトレーラと認識しないため、gate だけが pass すると判定が割れる (H206-02)。
+  def trailer_block(lines)
+    trimmed = lines.dup
+    trimmed.pop while !trimmed.empty? && trimmed.last.strip.empty?
+    block = []
+    trimmed.reverse_each do |line|
+      break if line.strip.empty?
+
+      block.unshift(line)
+    end
+    block
+  end
+
   def ai_trailers(lines)
     trailers = []
-    lines.each do |line|
+    trailer_block(lines).each do |line|
       m = TRAILER_RE.match(line)
       next unless m
 
@@ -143,7 +158,15 @@ module AiTrailerGate
     end
     return 0 if merge_in_progress?
 
-    judge(agents_from_env(ENV), message_lines(File.read(path)))
+    # 非 UTF-8 混入で regex が例外にならないよう scrub (#149 と同じ方式・判定用のみ)。
+    text = File.read(path)
+    text.force_encoding(Encoding::UTF_8)
+    text = text.scrub("�") unless text.valid_encoding?
+    judge(agents_from_env(ENV), message_lines(text))
+  rescue StandardError => e
+    # 想定外は入力・構成エラーの exit 2 に倒す (fail-closed)。message 内容は出さない。
+    warn "ai-trailer-gate: unexpected error (#{e.class})"
+    2
   end
 end
 

--- a/shared/scripts/personal-git-hook-dispatcher.asset.yml
+++ b/shared/scripts/personal-git-hook-dispatcher.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:87a49359604af06e0ae801203086de24a51e31db5c7097ff64ed3fa8733ed97b
+  approved_build_id: sha256:47eef6e7033494c7e9e574261ec5ed82cdea3b080eb1994c4a261ae84122afaf
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-git-hook-dispatcher.rb

--- a/shared/scripts/personal-git-hook-dispatcher.asset.yml
+++ b/shared/scripts/personal-git-hook-dispatcher.asset.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+name: personal-git-hook-dispatcher
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+# script kind は実行コード配布のため常に human review 必須 (#147)。
+# 本 script は #202 (Phase 1) の実装 PR で author≠reviewer レビューのうえ承認。
+# 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
+# approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
+review:
+  human_review: approved
+  approved_build_id: sha256:87a49359604af06e0ae801203086de24a51e31db5c7097ff64ed3fa8733ed97b
+  approved_artifact_kind: script
+source:
+  path: shared/scripts/personal-git-hook-dispatcher.rb
+  format: text
+summary: >-
+  global core.hooksPath から呼ばれる git hook の入口。stage (pre-commit / commit-msg) ごとの
+  personal gate を実行し、全 pass なら repo 自身の hooks/<stage> に chain して「置換」を
+  「合成」に変える (#201 裁定)。best-effort guardrail で --no-verify 等で迂回可能
+  (docs/git-hook-gates.md)。登録・配線 (shim + git config) は dotfiles 所有。

--- a/shared/scripts/personal-git-hook-dispatcher.rb
+++ b/shared/scripts/personal-git-hook-dispatcher.rb
@@ -30,7 +30,18 @@ module GitHookDispatcher
     "commit-msg" => %w[personal-ai-trailer-gate],
   }.freeze
 
+  # 再入 sentinel (stage 単位)。repo hook が shim (→ dispatcher) を指す誤設定でも、
+  # realpath 比較では検出できない間接参照で無限再帰になる (H206-04)。chain 実行時に
+  # この env を立て、再入を検出したら gate 済みとして即 exit 0 する。副作用として、
+  # chain 先 hook が別 repo へ「同 stage の commit」を行う場合その commit は gate を
+  # 通らない (docs に明記の既知限界)。
+  GUARD_PREFIX = "AGENT_TOOLS_GIT_HOOK_ACTIVE_"
+
   module_function
+
+  def guard_key(stage)
+    GUARD_PREFIX + stage.upcase.tr("-", "_")
+  end
 
   # repo 自身の hooks directory。core.hooksPath を経由すると dispatcher 自身に戻って
   # しまうため、必ず common dir 直下の hooks/ を見る (worktree でも共有側が正、#201 実測)。
@@ -47,6 +58,12 @@ module GitHookDispatcher
       warn "git-hook-dispatcher: unknown stage #{stage.inspect} " \
            "(expected: #{STAGE_GATES.keys.join(' / ')})"
       return 2
+    end
+
+    if ENV[guard_key(stage)] == "1"
+      warn "git-hook-dispatcher: re-entrant #{stage} invocation detected; " \
+           "skipping (loop guard, gates already ran)"
+      return 0
     end
 
     args = argv[1..-1] || []
@@ -66,16 +83,17 @@ module GitHookDispatcher
 
     chain = repo_hook_path(stage)
     if chain.nil?
-      warn "git-hook-dispatcher: cannot resolve git common dir; skipping repo-hook chain"
-      return 0
+      # chain 解決不能を黙って素通りさせない (repo hook の silent 迂回になる。H206-05)。
+      warn "git-hook-dispatcher: cannot resolve git common dir; failing closed"
+      return 2
     end
     if File.executable?(chain)
-      # 誤設定で repo hook 自体が dispatcher (への link) だと無限 chain になるので識別して skip。
+      # 直接 link の自己参照は即 skip (間接参照は上の再入 sentinel が止める)。
       if File.realpath(chain) == File.realpath(__FILE__)
         warn "git-hook-dispatcher: repo hook #{chain} resolves to the dispatcher itself; skipping chain"
         return 0
       end
-      exec(chain, *args)
+      exec({ guard_key(stage) => "1" }, chain, *args)
     end
     0
   end

--- a/shared/scripts/personal-git-hook-dispatcher.rb
+++ b/shared/scripts/personal-git-hook-dispatcher.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# git-hook-dispatcher: global `core.hooksPath` から呼ばれる git hook の入口。
+# stage (pre-commit / commit-msg) ごとの personal gate を順に実行し、全部通れば
+# その repo 自身の hook (`$(git rev-parse --git-common-dir)/hooks/<stage>`) に chain する。
+# global hooksPath が per-repo hook を「置換」してしまう git の仕様 (#201 実測) を、
+# dispatcher 側の chain で「合成」に変えるのが存在理由。
+#
+# 正本: docs/git-hook-gates.md。#200 §4.1-4.2 / #202。
+#
+# 強度ラベル (偽らない): これは通常経路 (git commit) に対する best-effort guardrail。
+# `--no-verify` / core.hooksPath の差し替え (husky 等の local 設定を含む) / 別 client で
+# 迂回できる。enforcement boundary ではない。
+#
+# 呼び出し契約 (dotfiles 側 shim):
+#   pre-commit:  exec <deploy path>/personal-git-hook-dispatcher pre-commit "$@"
+#   commit-msg:  exec <deploy path>/personal-git-hook-dispatcher commit-msg "$@"
+# gate 本体は dispatcher と同じ directory に配備されている前提 (sync の script 配備先)。
+# gate が欠けているときは fail-closed (exit 2) で commit を止める。配備欠損を黙って
+# 素通りさせない。
+#
+# exit code: 0 = 全 gate pass (+ chain 先の exit 0 / chain なし) / 1 = gate の finding で
+# block / 2 = usage・構成エラー (未知 stage・gate 欠損・git 情報取得失敗)。chain 先が
+# ある場合は exec で置き換わるため chain 先の exit code がそのまま返る。
+
+module GitHookDispatcher
+  STAGE_GATES = {
+    "pre-commit" => %w[personal-public-safety-gate],
+    "commit-msg" => %w[personal-ai-trailer-gate],
+  }.freeze
+
+  module_function
+
+  # repo 自身の hooks directory。core.hooksPath を経由すると dispatcher 自身に戻って
+  # しまうため、必ず common dir 直下の hooks/ を見る (worktree でも共有側が正、#201 実測)。
+  def repo_hook_path(stage)
+    out = IO.popen(%w[git rev-parse --git-common-dir], &:read)
+    return nil unless $?.success?
+
+    File.join(File.expand_path(out.chomp), "hooks", stage)
+  end
+
+  def run(argv)
+    stage = argv[0]
+    unless STAGE_GATES.key?(stage)
+      warn "git-hook-dispatcher: unknown stage #{stage.inspect} " \
+           "(expected: #{STAGE_GATES.keys.join(' / ')})"
+      return 2
+    end
+
+    args = argv[1..-1] || []
+    own_dir = File.dirname(File.realpath(__FILE__))
+
+    STAGE_GATES.fetch(stage).each do |gate|
+      gate_path = File.join(own_dir, gate)
+      unless File.executable?(gate_path)
+        warn "git-hook-dispatcher: gate #{gate} is missing or not executable at #{gate_path}; " \
+             "refusing to proceed (fail-closed). Re-run agent-tools sync."
+        return 2
+      end
+      system(gate_path, *args)
+      status = $?.exitstatus
+      return status.nil? ? 2 : status unless status == 0
+    end
+
+    chain = repo_hook_path(stage)
+    if chain.nil?
+      warn "git-hook-dispatcher: cannot resolve git common dir; skipping repo-hook chain"
+      return 0
+    end
+    if File.executable?(chain)
+      # 誤設定で repo hook 自体が dispatcher (への link) だと無限 chain になるので識別して skip。
+      if File.realpath(chain) == File.realpath(__FILE__)
+        warn "git-hook-dispatcher: repo hook #{chain} resolves to the dispatcher itself; skipping chain"
+        return 0
+      end
+      exec(chain, *args)
+    end
+    0
+  end
+end
+
+exit GitHookDispatcher.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/personal-public-safety-gate.asset.yml
+++ b/shared/scripts/personal-public-safety-gate.asset.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+name: personal-public-safety-gate
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+# script kind は実行コード配布のため常に human review 必須 (#147)。
+# 本 script は #202 (Phase 1) の実装 PR で author≠reviewer レビューのうえ承認。
+# 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
+# approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
+review:
+  human_review: approved
+  approved_build_id: sha256:0b83607c4eee7e601bcaf9b596e434a80d291cd7bc54f980d1b5d2a074849da7
+  approved_artifact_kind: script
+source:
+  path: shared/scripts/personal-public-safety-gate.rb
+  format: text
+summary: >-
+  pre-commit stage の git gate。staged diff の追加行から secret (private key / 既知 token 形) /
+  実 home path / 個人用 local file を検出して commit を block する (definite) か警告する
+  (suspicious)。値そのものは出力しない。私物パターンは untracked の
+  ~/.config/agent-tools/public-safety-patterns.local から読む。best-effort guardrail
+  (docs/git-hook-gates.md)。

--- a/shared/scripts/personal-public-safety-gate.asset.yml
+++ b/shared/scripts/personal-public-safety-gate.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:0b83607c4eee7e601bcaf9b596e434a80d291cd7bc54f980d1b5d2a074849da7
+  approved_build_id: sha256:e6e02a242b197e2ff096193380b1796de544d11fffc55640d5f8a496deaa3394
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-public-safety-gate.rb

--- a/shared/scripts/personal-public-safety-gate.rb
+++ b/shared/scripts/personal-public-safety-gate.rb
@@ -1,0 +1,175 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# public-safety-gate: pre-commit stage の git gate。staged diff の追加行を scan し、
+# public repo に入れてはならないもの (secret / 実 home path / 個人用 local file) を
+# commit 前に block する。6 つの skill / instruction が繰り返し宣言してきた
+# 「commit 前 public safety check」の機械判定可能な部分を決定的実行に出したもの (#202)。
+#
+# 正本: docs/git-hook-gates.md。#200 §4.1。
+#
+# 強度ラベル (偽らない): 通常経路 (git commit) に対する best-effort guardrail。
+# `--no-verify` / hooksPath 差し替え / 別 client で迂回できる。検出も列挙依存の
+# regex なので網羅ではない (「秘密は書かない」判断そのものは人間 / skill の領分)。
+# 公開前の最終確認点は push / CI 側に置く。
+#
+# 検出クラス:
+# - definite (exit 1 で block): private key block / 既知 token 形 / 実 HOME path の
+#   literal 混入 / 個人用 local file (*.local / *.local.md) の staged 追加 /
+#   local pattern file の追加パターン一致
+# - suspicious (警告のみ・block しない): 汎用 credential 代入ヒューリスティック。
+#   「疑わしいだけの finding は block でなく明示確認に落とす」(#200 §4.1) の実装。
+# 誤検知の escape: 該当行に `public-safety: allow` を含める (レビュー済みの明示)。
+#
+# 秘匿出力規律: finding の値そのものは出力しない (file:line と種別のみ)。
+#
+# 私物パターン (planning tool の domain 等、public repo に書けないもの) は tracked な
+# 本体に持たず、untracked の local pattern file から読む:
+#   ~/.config/agent-tools/public-safety-patterns.local (1 行 1 Ruby regex、# コメント可)
+# 不在は「追加パターンなし」として扱う (設計上 optional)。読めるのに parse できない
+# regex は exit 2 で止める (ユーザー設定の壊れを黙って無視しない)。
+#
+# 副作用ゼロ・network なし。読むのは `git diff --cached` / staged file 一覧 /
+# local pattern file のみ。
+
+module PublicSafetyGate
+  VERSION = "1"
+
+  ALLOW_PRAGMA = "public-safety: allow"
+
+  LOCAL_PATTERNS_PATH = File.join(ENV["HOME"].to_s, ".config", "agent-tools",
+                                  "public-safety-patterns.local")
+
+  # 既知の token 形。誤検知が実質出ない精度の高いものだけを definite に置く。
+  # 汎用の「それっぽい代入」は SUSPICIOUS_PATTERN (警告どまり) 側。
+  DEFINITE_PATTERNS = {
+    "private-key-block" => /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+    "github-token" => /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\b|\bgithub_pat_[A-Za-z0-9_]{22,}\b/,
+    "aws-access-key" => /\bAKIA[0-9A-Z]{16}\b/,
+    "slack-token" => /\bxox[baprs]-[0-9A-Za-z-]{10,}\b/,
+    "anthropic-key" => /\bsk-ant-[A-Za-z0-9_-]{20,}\b/,
+    "openai-key" => /\bsk-proj-[A-Za-z0-9_-]{20,}\b/,
+    "stripe-key" => /\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b/,
+  }.freeze
+
+  # 「credential らしき代入」ヒューリスティック。過検出しうるので suspicious (警告のみ)。
+  SUSPICIOUS_PATTERN =
+    /(?:password|passwd|secret|api[_-]?key|token)["']?\s*[:=]\s*["'][^"'\s]{8,}["']/i
+
+  # ユーザー正本・個人メモの命名規約 (このリポジトリ群のローカル慣行)。
+  # .gitignore が第一防衛だが、`git add -f` の事故をここで止める。
+  LOCAL_ONLY_FILE = /(?:\.local|\.local\.md)\z/
+
+  Finding = Struct.new(:file, :line, :name, :severity)
+
+  module_function
+
+  # 個人 home directory の親 (この下 1 段が個人名になる)。regex は実行時に組む
+  # (静的 literal だと check-injection の absolute-path 検査自身にかかるため)。
+  HOME_PARENTS = %w[Users home].freeze
+
+  # 実 home path の literal 混入だけを見る (汎用の例示 path は文書として正当)。
+  # HOME が個人 home の形をしていないとき (CI 等) は対象外。
+  def home_needle
+    home = ENV["HOME"].to_s
+    home if home.match?(%r{\A/(?:#{HOME_PARENTS.join('|')})/[^/]+})
+  end
+
+  def load_local_patterns(path)
+    return [] unless File.file?(path)
+
+    patterns = []
+    File.readlines(path).each_with_index do |raw, i|
+      line = raw.chomp.strip
+      next if line.empty? || line.start_with?("#")
+
+      begin
+        patterns << [format("local-pattern:%d", i + 1), Regexp.new(line)]
+      rescue RegexpError => e
+        raise ArgumentError, "#{path}:#{i + 1}: invalid regex (#{e.message})"
+      end
+    end
+    patterns
+  end
+
+  def scan_line(content, extra_patterns, home)
+    return [] if content.include?(ALLOW_PRAGMA)
+
+    names = []
+    DEFINITE_PATTERNS.each { |name, re| names << [name, :definite] if content.match?(re) }
+    extra_patterns.each { |name, re| names << [name, :definite] if content.match?(re) }
+    names << ["home-path", :definite] if home && content.include?(home)
+    names << ["credential-assignment", :suspicious] if content.match?(SUSPICIOUS_PATTERN)
+    names
+  end
+
+  # unified diff の追加行を (file, 新 line 番号, 内容) で走査する。
+  def scan_diff(diff_text, extra_patterns, home)
+    findings = []
+    file = nil
+    lineno = nil
+    diff_text.each_line do |raw|
+      line = raw.chomp
+      if line.start_with?("+++ ")
+        # 特殊文字入り path は git が全体を quote する ("b/na me") ので quote を先に外す。
+        target = line[4..-1].delete_prefix('"').delete_suffix('"')
+        file = target == "/dev/null" ? nil : target.sub(%r{\Ab/}, "")
+        lineno = nil
+      elsif (m = /\A@@ -[^ ]+ \+(\d+)/.match(line))
+        lineno = Integer(m[1])
+      elsif file && lineno && line.start_with?("+")
+        scan_line(line[1..-1].to_s, extra_patterns, home).each do |name, severity|
+          findings << Finding.new(file, lineno, name, severity)
+        end
+        lineno += 1
+      elsif lineno && line.start_with?(" ")
+        lineno += 1
+      end
+    end
+    findings
+  end
+
+  def staged_local_only_files(added_paths)
+    added_paths.select { |p| p.match?(LOCAL_ONLY_FILE) }
+  end
+
+  def git_read(argv)
+    out = IO.popen(argv, &:read)
+    raise ArgumentError, "#{argv.join(' ')} failed" unless $?.success?
+
+    out
+  end
+
+  def run
+    extra = load_local_patterns(LOCAL_PATTERNS_PATH)
+    diff = git_read(%w[git diff --cached --no-color --no-ext-diff])
+    added = git_read(%w[git diff --cached --name-only --diff-filter=A -z]).split("\0")
+
+    findings = scan_diff(diff, extra, home_needle)
+    staged_local_only_files(added).each do |path|
+      findings << Finding.new(path, 0, "local-only-file", :definite)
+    end
+
+    blocked = findings.select { |f| f.severity == :definite }
+    warned = findings.select { |f| f.severity == :suspicious }
+
+    warned.each do |f|
+      warn "public-safety-gate: warning: #{f.file}:#{f.line}: [#{f.name}] " \
+           "credential らしき代入があります。意図した内容か確認してください (block はしません)。"
+    end
+    unless blocked.empty?
+      blocked.each do |f|
+        warn "public-safety-gate: blocked: #{f.file}:#{f.line}: [#{f.name}]"
+      end
+      warn "public-safety-gate: #{blocked.size} finding(s)。値は表示しません。該当行を直すか、" \
+           "レビュー済みの誤検知なら該当行に `#{ALLOW_PRAGMA}` を書いて再 commit してください。"
+      return 1
+    end
+    0
+  rescue ArgumentError => e
+    warn "public-safety-gate: error: #{e.message}"
+    2
+  end
+end
+
+exit PublicSafetyGate.run if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/personal-public-safety-gate.rb
+++ b/shared/scripts/personal-public-safety-gate.rb
@@ -85,8 +85,10 @@ module PublicSafetyGate
 
       begin
         patterns << [format("local-pattern:%d", i + 1), Regexp.new(line)]
-      rescue RegexpError => e
-        raise ArgumentError, "#{path}:#{i + 1}: invalid regex (#{e.message})"
+      rescue RegexpError
+        # RegexpError#message は regex 本文を含む。private パターン置き場の内容を
+        # 出力しない契約 (H206-03) のため、位置情報だけを出す。
+        raise ArgumentError, "#{path}:#{i + 1}: invalid regex (パターン内容は表示しません)"
       end
     end
     patterns
@@ -103,27 +105,68 @@ module PublicSafetyGate
     names
   end
 
+  # git の quoted path ("b/na\tme" 形式) を復号する。quote されていなければそのまま。
+  def unquote_path(target)
+    return target unless target.start_with?('"') && target.end_with?('"') && target.size >= 2
+
+    target[1..-2].gsub(/\\(?:[abfnrtv\\"]|\d{1,3})/) do |esc|
+      body = esc[1..-1]
+      case body
+      when "\\" then "\\"
+      when '"' then '"'
+      when "n" then "\n"
+      when "t" then "\t"
+      when "a" then "\a"
+      when "b" then "\b"
+      when "f" then "\f"
+      when "r" then "\r"
+      when "v" then "\v"
+      else body.to_i(8).chr
+      end
+    end
+  end
+
   # unified diff の追加行を (file, 新 line 番号, 内容) で走査する。
+  # hunk 内の行 (+ / - / 空白 / "\" 始まり) を先に処理し、ヘッダー解釈 (--- / +++) は
+  # hunk 外に限定する。追加行の内容が "++ " で始まると "+++ " に見えるため (H206-01)。
   def scan_diff(diff_text, extra_patterns, home)
     findings = []
     file = nil
     lineno = nil
+    in_hunk = false
+    expect_new_path = false
     diff_text.each_line do |raw|
       line = raw.chomp
-      if line.start_with?("+++ ")
-        # 特殊文字入り path は git が全体を quote する ("b/na me") ので quote を先に外す。
-        target = line[4..-1].delete_prefix('"').delete_suffix('"')
-        file = target == "/dev/null" ? nil : target.sub(%r{\Ab/}, "")
+      if in_hunk
+        case line[0]
+        when "+"
+          if file && lineno
+            scan_line(line[1..-1].to_s, extra_patterns, home).each do |name, severity|
+              findings << Finding.new(file, lineno, name, severity)
+            end
+            lineno += 1
+          end
+          next
+        when "-", "\\" then next
+        when " ", nil
+          lineno += 1 if lineno
+          next
+        end
+        in_hunk = false # hunk の終端 (次の header 類) — fall through して header を解釈する
+      end
+      if line.start_with?("diff --git ")
+        file = nil
         lineno = nil
+        expect_new_path = false
+      elsif line.start_with?("--- ")
+        expect_new_path = true
+      elsif expect_new_path && line.start_with?("+++ ")
+        target = unquote_path(line[4..-1])
+        file = target == "/dev/null" ? nil : target.sub(%r{\Ab/}, "")
+        expect_new_path = false
       elsif (m = /\A@@ -[^ ]+ \+(\d+)/.match(line))
         lineno = Integer(m[1])
-      elsif file && lineno && line.start_with?("+")
-        scan_line(line[1..-1].to_s, extra_patterns, home).each do |name, severity|
-          findings << Finding.new(file, lineno, name, severity)
-        end
-        lineno += 1
-      elsif lineno && line.start_with?(" ")
-        lineno += 1
+        in_hunk = true
       end
     end
     findings
@@ -133,17 +176,25 @@ module PublicSafetyGate
     added_paths.select { |p| p.match?(LOCAL_ONLY_FILE) }
   end
 
+  # 出力形式を pin した diff 用の共通 flag (parser の前提を git 設定から独立させる)。
+  GIT_DIFF_PIN = %w[git -c diff.noprefix=false -c diff.mnemonicprefix=false
+                    -c core.quotepath=true diff --cached --no-color --no-ext-diff].freeze
+
   def git_read(argv)
     out = IO.popen(argv, &:read)
     raise ArgumentError, "#{argv.join(' ')} failed" unless $?.success?
 
-    out
+    # 非 UTF-8 の混入 (binary 混じりの text 等) で regex が例外にならないよう scrub する
+    # (#149 と同じ方式)。判定用のみで書き込み経路はない。
+    out.force_encoding(Encoding::UTF_8)
+    out.valid_encoding? ? out : out.scrub("�")
   end
 
   def run
     extra = load_local_patterns(LOCAL_PATTERNS_PATH)
-    diff = git_read(%w[git diff --cached --no-color --no-ext-diff])
-    added = git_read(%w[git diff --cached --name-only --diff-filter=A -z]).split("\0")
+    diff = git_read(GIT_DIFF_PIN)
+    # rename / copy でも新 path を検査対象にする (A のみだと git mv で素通り。H206-06)。
+    added = git_read(GIT_DIFF_PIN + %w[--name-only --diff-filter=ACR -z]).split("\0")
 
     findings = scan_diff(diff, extra, home_needle)
     staged_local_only_files(added).each do |path|
@@ -168,6 +219,11 @@ module PublicSafetyGate
     0
   rescue ArgumentError => e
     warn "public-safety-gate: error: #{e.message}"
+    2
+  rescue StandardError => e
+    # 想定外も入力・構成エラーの exit 2 に倒す (fail-closed)。内容を含みうる message は
+    # 出さず class 名のみ。
+    warn "public-safety-gate: unexpected error (#{e.class})"
     2
   end
 end


### PR DESCRIPTION
## 概要

#202 (Phase 1) の PR-1。#201 の裁定 (global `core.hooksPath` + dispatcher 方式) に基づき、commit 境界の 3 script を script asset として追加する。routing-preflight (#202 の 3 点目) と review-request skill の wiring は PR-2 で行う。

## 変更内容

- **personal-git-hook-dispatcher**: hooksPath から呼ばれる入口。stage (pre-commit / commit-msg) の personal gate を実行し、全 pass なら repo 自身の `hooks/<stage>` に chain (global hooksPath の「置換」を「合成」に変える)。gate 欠損は fail-closed (exit 2)。自己参照 chain は検出して skip。
- **personal-public-safety-gate** (pre-commit): staged diff の追加行から secret (private key / GitHub・AWS・Slack・Anthropic・OpenAI・Stripe token 形) / 実 $HOME path literal / `*.local(.md)` の staged 追加を **definite (exit 1 block)**、汎用 credential 代入ヒューリスティックを **suspicious (警告のみ)** で検出。値そのものは出力しない。私物パターン (planning domain 等) は untracked の `~/.config/agent-tools/public-safety-patterns.local` に置く設計 (public repo に書かない)。誤検知 escape は行内 `public-safety: allow`。
- **personal-ai-trailer-gate** (commit-msg): agent セッション由来 (env marker: `CLAUDECODE` / `CODEX_THREAD_ID` / `CODEX_SANDBOX`、#201 実測) の commit に `Co-Authored-By:` トレーラを要求。人間 commit / merge commit (MERGE_HEAD) は無言 pass の opt-in 設計。Claude 系と Codex 系の混在は fail-closed。AI トレーラ email は no-reply 形式のみ (許可形式の SSOT はこの gate)。nested 実行 (両 marker) は「いずれかの有効な AI トレーラ」に緩和。
- **docs/git-hook-gates.md**: 契約と強度ラベル (best-effort guardrail・`--no-verify` / local hooksPath で迂回可・hard 床は従来どおり credential 隔離 / CI 側)、dotfiles 側配線契約 (shim 例)。
- manifests: script kind (human review 必須)。承認は本 PR の author≠reviewer レビューと merge 承認に紐づく (approved_build_id 記載済み)。

## 検証

- `scripts/tests/git-hook-gates-test.sh` 新設: 純粋ロジック unit (scan / judge / marker 解釈) + tmp repo integration (hooksPath 経由の commit block / chain 実行と失敗伝播 / merge 除外 / 隔離 env)。secret 形 fixture は実行時連結で literal を repo に置かない。
- 15 suite 全緑 / check-manifests ok / check-injection 新規 script への指摘ゼロ / register rc=0。
- 実配線 (dotfiles shim + git config) は本 PR の scope 外 (dotfiles 側 issue を別途起票)。

## scope 判断 (record)

- #200 §4.1-4.2 の「PreToolUse/Bash `git commit` 入口 steering」層は本 PR に含めない。git hook 側が決定的に block するため入口 steer の限界効用が小さく、`--no-verify` steer を含む Phase 3 destructive-git-guard (#204) に一本化する (lifecycle hook の登録・trust 手数を 1 回に抑える)。

Refs #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv