### PR TITLE
feat: 品質ループ hook — fast-edit-check / changed-scope-qa (Refs #203)

### DIFF
--- a/docs/quality-loop-hooks.md
+++ b/docs/quality-loop-hooks.md
@@ -1,0 +1,88 @@
+# Quality Loop Hooks(fast-edit-check / changed-scope-qa)
+
+編集直後の機械フィードバックと turn 終了時の QA gate を担う 2 つの lifecycle hook body の
+契約 (#200 §4.4-4.5 / #203)。skill (production-rail の self-check) が「発火すれば」やる
+品質確認のうち、機械判定できる部分を決定的実行に出したもの。品質の意味判断 (要求一致・
+最小差分・何が十分な検証か) は従来どおり skill / モデルの領分に残る。
+
+## 強度ラベル(偽らない)
+
+- **fast-edit-check は steering / fail-open**。block しない・自動 fix しない。hook 内部の
+  想定外はすべて exit 0 で透過し、編集操作を壊さない。
+- **changed-scope-qa は best-effort gate**。hook 無効化・別経路で迂回できる。block は
+  「新しい変更 scope に対して 1 回だけ」で、無限ループ対策 (下記) を仕様に含む。
+- どちらも登録 (+ Codex は trust) が済むまで無警告で不活性 (fail-open の帰結)。
+  配線は dotfiles 所有 (boundary-with-dotfiles)。
+
+## check コマンドの発見(自動推測しない・#203 裁定)
+
+宣言の正本は**ユーザー所有の untracked 中央設定**:
+
+```text
+~/.config/agent-tools/checks.local.json   (JSON・ユーザーが手で管理)
+```
+
+```json
+{
+  "/Users/<you>/src/some-repo": {
+    "edit_checks": [
+      {"name": "ruby-syntax", "pattern": "\\.rb$", "command": ["ruby", "-c"]}
+    ],
+    "qa_checks": [
+      {"name": "manifests", "command": ["scripts/check-manifests.sh", "--quiet"]}
+    ]
+  }
+}
+```
+
+- キーは repo root の**実 path** (`File.realpath`)。宣言がある repo でだけ動き、無い repo
+  では両 hook とも**無言 no-op** (opt-in 設計)。
+- **repo 内の宣言ファイルは読まない**: clone した第三者 repo が「編集・終了のたびに実行
+  される任意コマンド」を宣言できてしまうため。宣言の所有をユーザーに固定するのが
+  この配置の主目的 (中央 local 設定は `.agent-context.local.md` と同じユーザー正本
+  パターン)。
+- JSON なのは standalone 配布 script に psych 3/4 分岐 (yaml_util の領分) を持ち込まない
+  ため。
+- `edit_checks.command` には対象ファイルの絶対 path が 1 引数として追記される。
+  `qa_checks.command` は引数追記なし。どちらも **cwd = repo root** で実行される。
+- 宣言する check の目安: edit_checks は「1 ファイル・数百 ms」(編集のたびに同期実行)、
+  qa_checks は「repo 全体で数秒・決定的」(Stop のたびに走りうる。決定性は cache の前提)。
+
+## personal-fast-edit-check(PostToolUse / `Edit|Write`)
+
+- payload の `tool_input.file_path` から対象ファイルを取り、その repo の `edit_checks` の
+  うち `pattern` (Ruby regex) がファイル名に一致するものを実行する。
+- 失敗時のみ `hookSpecificOutput.additionalContext` で失敗要約 (上限 2000 文字 /
+  非 UTF-8 は scrub) をモデルに返す。成功は無言 (ノイズ規律)。
+- 設定ファイルが壊れているときは無言で握り潰さず、設定エラーを additionalContext で
+  1 行知らせる (それでも exit 0)。
+- **Codex parity の honest-label**: Claude Code の payload 形 (`tool_input.file_path`) は
+  #201 実測済み。Codex (apply_patch) の payload 形は未実測で、file_path が取れなければ
+  無言 no-op に倒れる。配備時に実測して追従する。
+
+## personal-changed-scope-qa(Stop)
+
+- **検査対象の帰属 (#203 裁定)**: agent の変更とユーザーの手元変更を区別せず、working
+  tree の **dirty scope 全体** (tracked の変更 + untracked) を対象にする。ユーザー自身の
+  書きかけ変更も検査対象になる (明記)。
+- dirty かつ宣言 repo なら `qa_checks` を実行。全 pass → scope 指紋 (status + diff の
+  sha256) と結果を state に cache して無言 pass。失敗 → **exit 2 + stderr 要約で block**
+  (モデルに修正の続行を促す)。
+- **無限ループ対策 (仕様)**:
+  - `stop_hook_active: true` (この turn で既に継続済み) では**絶対に block しない**
+    (check は走らせ、結果は additionalContext の警告で返す)。
+  - 同一 scope 指紋の再 Stop は check を**再実行しない** (pass 済み = 無言 / fail 済み =
+    非ブロッキング警告のみ。block は新しい scope に 1 回だけ → 直せない失敗は人間に戻る)。
+  - check コマンド不在・spawn 失敗は「警告に降格」して block しない (cache もしないので
+    環境が直れば次の Stop で再試行)。
+- state: `~/.cache/agent-tools/changed-scope-qa/<repo path の sha256>.json`。
+  test 用 override: `AGENT_TOOLS_QA_STATE_DIR` / 設定は `AGENT_TOOLS_CHECKS_CONFIG`。
+- Codex 側は Stop の matcher が無視される点 (#201) 以外は同型を期待。`stop_hook_active` /
+  block 挙動の Codex 実測は配備時 (#201 からの carry-over)。
+
+## 検証境界
+
+- 純粋ロジックと git 連携・cache・ループ対策は `scripts/tests/quality-loop-hooks-test.sh`
+  が CI で検証する (設定 / state / HOME / git config を隔離・fake check 使用)。
+- 実配線 (settings.json / hooks.json への登録・Codex payload / Stop の実測) は CI 外
+  (dotfiles 側 issue + 実機 smoke。実施記録は #203)。

--- a/scripts/tests/quality-loop-hooks-test.sh
+++ b/scripts/tests/quality-loop-hooks-test.sh
@@ -174,4 +174,97 @@ echo "$out" | grep -q "実行できません" || fail "missing tool should warn:
 out=$(cd "$other" && run_qa false) || fail "undeclared repo qa should exit 0"
 [ -z "$out" ] || fail "undeclared repo qa should be silent: $out"
 
+# ---- R1 回帰: fingerprint の網羅 (untracked 内容 / check 定義) ------------------
+# 状態リセット (config を fake-suite に戻し、working tree を clean に)
+ruby -rjson -e '
+File.write(ARGV[2], JSON.generate({ARGV[0] => {"qa_checks" => [{"name" => "fake-suite", "command" => [ARGV[1]]}]}}))
+' "$repo_real" "$tmp/fake-check" "$conf"
+(cd "$repo" && git add -A && git commit -qm clean)
+
+# untracked の「内容変更」で cache が無効化される (status 上は同じ ?? path)
+echo v1 > "$repo/u.txt"
+(cd "$repo" && run_qa false >/dev/null) || fail "untracked v1 should pass"
+: > "$tmp/check-argv.log"
+(cd "$repo" && run_qa false >/dev/null) || fail "cache hit should pass"
+[ ! -s "$tmp/check-argv.log" ] || fail "same untracked content should hit cache"
+echo v2 > "$repo/u.txt"
+(cd "$repo" && run_qa false >/dev/null) || fail "untracked v2 should pass"
+[ -s "$tmp/check-argv.log" ] || fail "untracked content change must invalidate cache (R1)"
+
+# check 定義の変更で cache が無効化される
+ruby -rjson -e '
+File.write(ARGV[2], JSON.generate({ARGV[0] => {"qa_checks" => [{"name" => "fake-suite-2", "command" => [ARGV[1]]}]}}))
+' "$repo_real" "$tmp/fake-check" "$conf"
+: > "$tmp/check-argv.log"
+(cd "$repo" && run_qa false >/dev/null) || fail "renamed check should pass"
+[ -s "$tmp/check-argv.log" ] || fail "check definition change must invalidate cache (R1)"
+
+# ---- R1 回帰: missing と実 failure の混在 (missing の分離保持と再試行) ----------
+cat > "$tmp/later-tool" <<EOF
+#!/bin/sh
+printf 'ran\n' >> "$tmp/later-argv.log"
+exit 0
+EOF
+# (まだ +x を付けない = EACCES の spawn 失敗)
+ruby -rjson -e '
+File.write(ARGV[3], JSON.generate({ARGV[0] => {"qa_checks" => [
+  {"name" => "failing", "command" => [ARGV[1]]},
+  {"name" => "later", "command" => [ARGV[2]]}
+]}}))
+' "$repo_real" "$tmp/fake-check" "$tmp/later-tool" "$conf"
+touch "$tmp/check-fail"
+echo mix >> "$repo/u.txt"
+set +e
+err=$(cd "$repo" && run_qa false 2>&1 >/dev/null)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "real failure should still block despite missing check (rc=$rc)"
+echo "$err" | grep -q "未実行の check: later" || fail "block message should list missing: $err"
+
+# 環境が直る (実行可能になる) と、同一 scope の cache-hit でも missing だけ再試行される
+chmod +x "$tmp/later-tool"
+set +e
+out=$(cd "$repo" && run_qa false 2>/dev/null)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "cache-hit must not re-block (rc=$rc)"
+[ -s "$tmp/later-argv.log" ] || fail "missing check must be retried on cache hit (R1)"
+echo "$out" | grep -q "未解消" || fail "unresolved failure should still be warned: $out"
+rm "$tmp/check-fail"
+
+# ---- R1 回帰: EACCES (実行権限なし) も spawn 失敗として警告降格 -----------------
+: > "$tmp/noexec"
+ruby -rjson -e '
+File.write(ARGV[2], JSON.generate({ARGV[0] => {"qa_checks" => [{"name" => "noexec", "command" => [ARGV[1]]}]}}))
+' "$repo_real" "$tmp/noexec" "$conf"
+echo eaccess >> "$repo/u.txt"
+set +e
+out=$(cd "$repo" && run_qa false 2>/dev/null)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "EACCES must not block (rc=$rc)"
+echo "$out" | grep -q "実行できません" || fail "EACCES should warn as missing (R1): $out"
+
+# ---- R1 回帰: fast-edit-check の不正 entry 可視化と総量 truncate ---------------
+ruby -rjson -e '
+File.write(ARGV[2], JSON.generate({ARGV[0] => {"edit_checks" => [
+  {"name" => "bad-entry", "pattern" => "\\.rb$", "command" => "not-an-array"},
+  {"name" => "broken-re", "pattern" => "([", "command" => [ARGV[1]]},
+  {"name" => "big1", "pattern" => "\\.rb$", "command" => [ARGV[1]]},
+  {"name" => "big2", "pattern" => "\\.rb$", "command" => [ARGV[1]]}
+]}}))
+' "$repo_real" "$tmp/big-fail" "$conf"
+cat > "$tmp/big-fail" <<'EOF'
+#!/bin/sh
+awk 'BEGIN { for (i = 0; i < 60; i++) printf "%s\n", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }'
+exit 1
+EOF
+chmod +x "$tmp/big-fail"
+out=$(run_edit "$repo/a.rb") || fail "edit-check with invalid entries should exit 0"
+echo "$out" | grep -q "設定エラー" || fail "invalid entries should be surfaced (R1): $out"
+echo "$out" | grep -q "bad-entry\|edit_checks\[0\]" || fail "invalid entry should be named: $out"
+echo "$out" | grep -q "broken-re" || fail "broken regex entry should be named: $out"
+[ "${#out}" -lt 3500 ] || fail "total output should be capped (R1): length=${#out}"
+echo "$out" | grep -q "truncated" || fail "total cap should be visible: $out"
+
 echo "ok: quality-loop-hooks self-test"

--- a/scripts/tests/quality-loop-hooks-test.sh
+++ b/scripts/tests/quality-loop-hooks-test.sh
@@ -1,0 +1,177 @@
+#!/bin/sh
+# personal-fast-edit-check.rb / personal-changed-scope-qa.rb の self-test。
+# 設定は AGENT_TOOLS_CHECKS_CONFIG、state は AGENT_TOOLS_QA_STATE_DIR で隔離し、
+# 実 HOME / 実 config には触れない。check コマンドは tmp 内の記録付き fake を使う。
+# hook payload は stdin JSON fixture。network access なし。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=lib/test-helpers.sh
+. "$script_dir/lib/test-helpers.sh"
+
+edit_src="$repo_root/shared/scripts/personal-fast-edit-check.rb"
+qa_src="$repo_root/shared/scripts/personal-changed-scope-qa.rb"
+for f in "$edit_src" "$qa_src"; do
+  [ -f "$f" ] || fail "missing $f"
+done
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+GIT_CONFIG_SYSTEM=/dev/null
+export GIT_CONFIG_SYSTEM
+GIT_CONFIG_GLOBAL="$tmp/gitconfig"
+export GIT_CONFIG_GLOBAL
+git config --file "$GIT_CONFIG_GLOBAL" user.name test
+git config --file "$GIT_CONFIG_GLOBAL" user.email test@example.com
+git config --file "$GIT_CONFIG_GLOBAL" init.defaultBranch main
+
+repo="$tmp/repo"
+git init -q "$repo"
+echo base > "$repo/base.txt"
+(cd "$repo" && git add base.txt && git commit -qm seed)
+repo_real=$(ruby -e 'puts File.realpath(ARGV[0])' "$repo")
+
+# 記録付き fake check: 引数を log に書き、FAKE_CHECK_RC で成否を制御
+cat > "$tmp/fake-check" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$tmp/check-argv.log"
+if [ -f "$tmp/check-fail" ]; then
+  echo "lint error: something is wrong"
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$tmp/fake-check"
+
+conf="$tmp/checks.local.json"
+ruby -rjson -e '
+root = ARGV[0]; fake = ARGV[1]
+File.write(ARGV[2], JSON.generate({
+  root => {
+    "edit_checks" => [{"name" => "fake-lint", "pattern" => "\\.rb$", "command" => [fake]}],
+    "qa_checks" => [{"name" => "fake-suite", "command" => [fake]}],
+  }
+}))
+' "$repo_real" "$tmp/fake-check" "$conf"
+
+run_edit() { # $1=file_path (payload)  env: config
+  printf '{"hook_event_name":"PostToolUse","tool_name":"Write","tool_input":{"file_path":"%s"}}' "$1" \
+    | env AGENT_TOOLS_CHECKS_CONFIG="$conf" HOME="$tmp/home" ruby "$edit_src"
+}
+run_qa() { # $1=stop_hook_active  cwd 前提: repo 内
+  printf '{"hook_event_name":"Stop","stop_hook_active":%s}' "$1" \
+    | env AGENT_TOOLS_CHECKS_CONFIG="$conf" AGENT_TOOLS_QA_STATE_DIR="$tmp/qa-state" \
+        HOME="$tmp/home" ruby "$qa_src"
+}
+mkdir -p "$tmp/home"
+
+# ---- fast-edit-check ----------------------------------------------------------
+echo 'puts 1' > "$repo/a.rb"
+
+# pass: check 成功 -> 無出力・exit 0・check は実行されている
+out=$(run_edit "$repo/a.rb") || fail "edit-check should exit 0 on pass"
+[ -z "$out" ] || fail "pass should be silent: $out"
+grep -q "a.rb" "$tmp/check-argv.log" || fail "check should have received the file"
+
+# fail: additionalContext に要約・exit 0 (block しない)
+touch "$tmp/check-fail"
+out=$(run_edit "$repo/a.rb") || fail "edit-check must not block on failure"
+echo "$out" | grep -q '"hookEventName":"PostToolUse"' || fail "should emit PostToolUse context: $out"
+echo "$out" | grep -q "fake-lint" || fail "should name the failed check: $out"
+echo "$out" | grep -q "lint error" || fail "should include check output: $out"
+rm "$tmp/check-fail"
+
+# pattern 不一致 (.txt) -> 無言 no-op
+echo x > "$repo/b.txt"
+out=$(run_edit "$repo/b.txt") || fail "no-match should exit 0"
+[ -z "$out" ] || fail "no-match should be silent: $out"
+
+# 宣言なし repo -> 無言 no-op
+other="$tmp/other"
+git init -q "$other" && echo 'puts 1' > "$other/x.rb"
+out=$(run_edit "$other/x.rb") || fail "undeclared repo should exit 0"
+[ -z "$out" ] || fail "undeclared repo should be silent: $out"
+
+# repo 外 file -> 無言 no-op
+echo 'puts 1' > "$tmp/loose.rb"
+out=$(run_edit "$tmp/loose.rb") || fail "non-repo file should exit 0"
+[ -z "$out" ] || fail "non-repo file should be silent: $out"
+
+# 壊れた設定 -> 設定エラーを steer (無言で握り潰さない)・exit 0
+echo '{broken' > "$tmp/broken.json"
+out=$(printf '{"tool_input":{"file_path":"%s"}}' "$repo/a.rb" \
+  | env AGENT_TOOLS_CHECKS_CONFIG="$tmp/broken.json" HOME="$tmp/home" ruby "$edit_src") \
+  || fail "broken config should still exit 0"
+echo "$out" | grep -q "設定エラー" || fail "broken config should be surfaced: $out"
+
+# 設定ファイル自体なし -> 無言 no-op
+out=$(printf '{"tool_input":{"file_path":"%s"}}' "$repo/a.rb" \
+  | env AGENT_TOOLS_CHECKS_CONFIG="$tmp/nonexistent.json" HOME="$tmp/home" ruby "$edit_src") \
+  || fail "absent config should exit 0"
+[ -z "$out" ] || fail "absent config should be silent: $out"
+
+# ---- changed-scope-qa ---------------------------------------------------------
+# clean tree -> 無言 no-op (check は走らない)
+: > "$tmp/check-argv.log"
+(cd "$repo" && git add -A && git commit -qm wip)
+out=$(cd "$repo" && run_qa false) || fail "clean tree should exit 0"
+[ -z "$out" ] || fail "clean tree should be silent: $out"
+[ ! -s "$tmp/check-argv.log" ] || fail "clean tree should not run checks"
+
+# dirty + check pass -> 無言 pass・cache に pass 記録
+echo change >> "$repo/base.txt"
+out=$(cd "$repo" && run_qa false) || fail "dirty+pass should exit 0"
+[ -z "$out" ] || fail "dirty+pass should be silent: $out"
+[ -s "$tmp/check-argv.log" ] || fail "dirty tree should run checks"
+
+# 同一 scope の再 Stop -> cache hit で check を再実行しない
+: > "$tmp/check-argv.log"
+out=$(cd "$repo" && run_qa false) || fail "cached pass should exit 0"
+[ ! -s "$tmp/check-argv.log" ] || fail "same scope should not rerun checks (cache)"
+
+# scope が変わり check fail -> exit 2 で block・stderr に要約
+touch "$tmp/check-fail"
+echo more >> "$repo/base.txt"
+set +e
+err=$(cd "$repo" && run_qa false 2>&1 >/dev/null)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "new dirty scope with failing check should block (rc=$rc)"
+echo "$err" | grep -q "fake-suite" || fail "block message should name the check: $err"
+
+# 同一 scope の失敗を再 block しない (非ブロッキング警告に降格)
+set +e
+out=$(cd "$repo" && run_qa false 2>/dev/null)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "same failing scope must not re-block (rc=$rc)"
+echo "$out" | grep -q "未解消" || fail "should warn non-blockingly on cached failure: $out"
+
+# stop_hook_active=true では新 scope の失敗でも block しない
+echo again >> "$repo/base.txt"
+set +e
+out=$(cd "$repo" && run_qa true 2>/dev/null)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "stop_hook_active must never block (rc=$rc)"
+echo "$out" | grep -q "再 block しません" || fail "should report failure non-blockingly: $out"
+rm "$tmp/check-fail"
+
+# check コマンド不在 -> 警告降格・block しない・cache しない
+ruby -rjson -e '
+File.write(ARGV[1], JSON.generate({ARGV[0] => {"qa_checks" => [{"name" => "gone", "command" => ["/nonexistent/check"]}]}}))
+' "$repo_real" "$conf"
+echo yet >> "$repo/base.txt"
+set +e
+out=$(cd "$repo" && run_qa false 2>/dev/null)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "missing check tool must not block (rc=$rc)"
+echo "$out" | grep -q "実行できません" || fail "missing tool should warn: $out"
+
+# 宣言なし repo -> 無言 no-op
+out=$(cd "$other" && run_qa false) || fail "undeclared repo qa should exit 0"
+[ -z "$out" ] || fail "undeclared repo qa should be silent: $out"
+
+echo "ok: quality-loop-hooks self-test"

--- a/scripts/tests/quality-loop-hooks-test.sh
+++ b/scripts/tests/quality-loop-hooks-test.sh
@@ -191,6 +191,15 @@ echo v2 > "$repo/u.txt"
 (cd "$repo" && run_qa false >/dev/null) || fail "untracked v2 should pass"
 [ -s "$tmp/check-argv.log" ] || fail "untracked content change must invalidate cache (R1)"
 
+# untracked symlink の向き先変更で cache が無効化される (dangling でも。R2 回帰)
+ln -s missing-a "$repo/lnk"
+(cd "$repo" && run_qa false >/dev/null) || fail "dangling symlink v1 should pass"
+: > "$tmp/check-argv.log"
+ln -sf missing-b "$repo/lnk"
+(cd "$repo" && run_qa false >/dev/null) || fail "dangling symlink v2 should pass"
+[ -s "$tmp/check-argv.log" ] || fail "symlink retarget must invalidate cache (R2)"
+rm "$repo/lnk"
+
 # check 定義の変更で cache が無効化される
 ruby -rjson -e '
 File.write(ARGV[2], JSON.generate({ARGV[0] => {"qa_checks" => [{"name" => "fake-suite-2", "command" => [ARGV[1]]}]}}))

--- a/shared/scripts/personal-changed-scope-qa.asset.yml
+++ b/shared/scripts/personal-changed-scope-qa.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:0d5850c338bbd610e95bdadd2f97987ca90a8ba380a377a3c3797964ba598ecc
+  approved_build_id: sha256:ab472df8a206095964fa497bb4536e7f2dad7cb7d7b3d15990e54d78e66ce3b8
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-changed-scope-qa.rb

--- a/shared/scripts/personal-changed-scope-qa.asset.yml
+++ b/shared/scripts/personal-changed-scope-qa.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:ab472df8a206095964fa497bb4536e7f2dad7cb7d7b3d15990e54d78e66ce3b8
+  approved_build_id: sha256:52ccd219a458112d3d8d0c0c2cbc645738d3a589a3905b001c1aef44a353c8d6
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-changed-scope-qa.rb

--- a/shared/scripts/personal-changed-scope-qa.asset.yml
+++ b/shared/scripts/personal-changed-scope-qa.asset.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+name: personal-changed-scope-qa
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+# script kind は実行コード配布のため常に human review 必須 (#147)。
+# 本 script は #203 (Phase 2) の実装 PR で author≠reviewer レビューのうえ承認。
+# 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
+# approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
+review:
+  human_review: approved
+  approved_build_id: sha256:0d5850c338bbd610e95bdadd2f97987ca90a8ba380a377a3c3797964ba598ecc
+  approved_artifact_kind: script
+source:
+  path: shared/scripts/personal-changed-scope-qa.rb
+  format: text
+summary: >-
+  Stop hook body。turn 終了時に dirty scope (帰属なし・working tree 全体) へ repo 宣言の
+  QA check が未実行 / stale なら一度だけ block して続行させる gate。scope 指紋 + 結果を
+  cache し同一 scope を再検査しない / stop_hook_active 時と同一失敗の再発は非ブロッキング
+  警告に降格 / check 不在も警告降格 (無限ループ対策・#200 §4.5)。宣言の無い repo では
+  無言 no-op。docs/quality-loop-hooks.md が正本。

--- a/shared/scripts/personal-changed-scope-qa.rb
+++ b/shared/scripts/personal-changed-scope-qa.rb
@@ -128,7 +128,15 @@ module ChangedScopeQa
       full = File.join(root, path)
       digest =
         begin
-          File.file?(full) ? Digest::SHA256.file(full).hexdigest : "non-file"
+          if File.symlink?(full)
+            # File.file? / SHA256.file はリンク先を評価する (dangling だと常に non-file)。
+            # リンクの向き先そのものを指紋に含め、種別も区別する (R2 指摘)。
+            "symlink:" + Digest::SHA256.hexdigest(File.readlink(full))
+          elsif File.file?(full)
+            Digest::SHA256.file(full).hexdigest
+          else
+            "non-file"
+          end
         rescue StandardError
           "unreadable"
         end

--- a/shared/scripts/personal-changed-scope-qa.rb
+++ b/shared/scripts/personal-changed-scope-qa.rb
@@ -1,0 +1,215 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# changed-scope-qa: Stop hook body。turn の終わりに「tracked な変更があるのに repo 宣言の
+# QA check (lint / typecheck / 対象テスト) が未実行 or stale」なら、一度だけ block して
+# 続行させる品質 gate (#200 §4.5 / #203)。「check を忘れたまま終了」を防ぐ。
+#
+# 正本: docs/quality-loop-hooks.md。
+#
+# 強度ラベル (偽らない): 通常経路に対する best-effort gate。hook 無効化・別経路で迂回
+# できる。品質の意味判断 (何が十分な検証か) は production-rail / モデルの領分のまま。
+#
+# check の発見は fast-edit-check と同じ中央 local 設定 (checks.local.json) の qa_checks。
+# 宣言が無い repo・repo 外・変更なしでは無言 no-op (opt-in 設計)。qa_checks は
+# 「repo 全体で数秒・決定的」な suite だけを宣言する (Stop のたびに走りうる)。
+#
+# 設定例 (checks.local.json):
+#   {
+#     "/Users/<you>/src/some-repo": {
+#       "qa_checks": [
+#         {"name": "manifests", "command": ["scripts/check-manifests.sh", "--quiet"]}
+#       ]
+#     }
+#   }
+#   command は cwd = repo root で実行される。
+#
+# 無限ループ対策 (仕様・#200 §4.5):
+# - `stop_hook_active` が true (この turn で既に継続済み) のときは **block しない**。
+#   check は走らせ、結果は additionalContext の警告で返すだけ (人間に判断が戻る)。
+# - dirty scope の hash + check 結果を state file に cache し、**同一 scope を再検査しない**
+#   (pass 済み → 無言 pass / fail 済み → 非ブロッキング警告のみ。block は新しい scope に
+#   対して 1 回だけ)。
+# - check コマンド不在・spawn 失敗は「警告に降格」して block しない (tool 欠損で
+#   セッションを塞がない)。
+#
+# 検査対象の帰属 (#203 裁定): agent の変更とユーザーの手元変更を区別せず、**working tree の
+# dirty scope 全体** (tracked の変更 + untracked) を対象にする。単純さを優先し、ユーザー
+# 自身の書きかけ変更も検査対象になることを明記する。
+#
+# state: ~/.cache/agent-tools/changed-scope-qa/<repo path の sha256>.json
+# (AGENT_TOOLS_QA_STATE_DIR で override 可・test 用)。check は決定的である前提
+# (同一 scope の再実行を cache が省くため)。
+
+require "json"
+require "digest"
+
+module ChangedScopeQa
+  VERSION = "1"
+
+  CONFIG_PATH_ENV = "AGENT_TOOLS_CHECKS_CONFIG"
+  DEFAULT_CONFIG = File.join(ENV["HOME"].to_s, ".config", "agent-tools", "checks.local.json")
+  STATE_DIR_ENV = "AGENT_TOOLS_QA_STATE_DIR"
+  DEFAULT_STATE_DIR = File.join(ENV["HOME"].to_s, ".cache", "agent-tools", "changed-scope-qa")
+
+  OUTPUT_CAP = 2000
+
+  module_function
+
+  def config_path
+    ENV[CONFIG_PATH_ENV].to_s.empty? ? DEFAULT_CONFIG : ENV[CONFIG_PATH_ENV]
+  end
+
+  def state_dir
+    ENV[STATE_DIR_ENV].to_s.empty? ? DEFAULT_STATE_DIR : ENV[STATE_DIR_ENV]
+  end
+
+  def load_config
+    return nil unless File.file?(config_path)
+
+    data = JSON.parse(File.read(config_path))
+    data.is_a?(Hash) ? data : nil
+  rescue JSON::ParserError
+    nil # 設定エラーの steer は fast-edit-check 側が担う (二重に騒がない)
+  end
+
+  def repo_root
+    out = IO.popen(%w[git rev-parse --show-toplevel], err: File::NULL, &:read)
+    return nil unless $?.success?
+
+    File.realpath(out.chomp)
+  rescue Errno::ENOENT, Errno::EACCES
+    nil
+  end
+
+  def qa_checks(entry)
+    checks = entry.is_a?(Hash) ? entry["qa_checks"] : nil
+    return [] unless checks.is_a?(Array)
+
+    checks.select do |c|
+      c.is_a?(Hash) && c["command"].is_a?(Array) && !c["command"].empty? &&
+        c["command"].all? { |a| a.is_a?(String) }
+    end
+  end
+
+  # dirty scope の指紋。tracked の変更 (staged + unstaged) と untracked の一覧を含む。
+  # 空文字列 = clean。
+  def scope_fingerprint(root)
+    status = IO.popen(["git", "-C", root, "status", "--porcelain", "-z"], &:read)
+    return nil unless $?.success?
+    return "" if status.empty?
+
+    diff = IO.popen(["git", "-C", root, "diff", "HEAD", "--no-color", "--no-ext-diff"],
+                    err: File::NULL, &:read)
+    # unborn HEAD 等で diff が失敗しても status だけで指紋は成立する (弱い指紋に降格)
+    Digest::SHA256.hexdigest(status + "\0" + diff.to_s)
+  end
+
+  def state_path(root)
+    File.join(state_dir, Digest::SHA256.hexdigest(root) + ".json")
+  end
+
+  def read_state(root)
+    path = state_path(root)
+    return nil unless File.file?(path)
+
+    data = JSON.parse(File.read(path))
+    data.is_a?(Hash) ? data : nil
+  rescue JSON::ParserError
+    nil
+  end
+
+  def write_state(root, fingerprint, outcome)
+    require "fileutils"
+    FileUtils.mkdir_p(state_dir)
+    File.write(state_path(root), JSON.generate("fingerprint" => fingerprint, "outcome" => outcome))
+  end
+
+  def run_check(check, root)
+    out = IO.popen(check["command"], chdir: root, err: %i[child out], &:read)
+    status = $?.exitstatus
+    { name: check["name"] || check["command"].first, ok: status == 0,
+      output: out.to_s, spawn_failed: status.nil? }
+  rescue Errno::ENOENT
+    { name: check["name"] || check["command"].first, ok: false, output: "", spawn_failed: true }
+  end
+
+  def truncate(text)
+    text = text.dup
+    text.force_encoding(Encoding::UTF_8)
+    text = text.scrub("�") unless text.valid_encoding?
+    text.length > OUTPUT_CAP ? text[0, OUTPUT_CAP] + "\n…(truncated)" : text
+  end
+
+  def emit_context(message)
+    puts JSON.generate(
+      "hookSpecificOutput" => {
+        "hookEventName" => "Stop",
+        "additionalContext" => message,
+      }
+    )
+  end
+
+  def run
+    payload = JSON.parse($stdin.read) rescue {}
+    already_continued = payload["stop_hook_active"] == true
+
+    config = load_config
+    return 0 if config.nil?
+
+    root = repo_root
+    return 0 if root.nil?
+
+    checks = qa_checks(config[root])
+    return 0 if checks.empty?
+
+    fingerprint = scope_fingerprint(root)
+    return 0 if fingerprint.nil? || fingerprint.empty? # clean or 判定不能 → gate しない
+
+    state = read_state(root)
+    if state && state["fingerprint"] == fingerprint
+      case state["outcome"]
+      when "pass"
+        return 0
+      else
+        # 同一 scope の失敗は再 block しない (人間判断へ)。無言だと状態が見えないので
+        # 非ブロッキングの一言だけ残す。
+        emit_context("changed-scope-qa: 前回と同一の変更 scope で未解消の check 失敗があります " \
+                     "(再 block はしません。人間の判断に委ねます)。")
+        return 0
+      end
+    end
+
+    results = checks.map { |c| run_check(c, root) }
+    missing = results.select { |r| r[:spawn_failed] }
+    failures = results.reject { |r| r[:ok] || r[:spawn_failed] }
+
+    unless missing.empty?
+      emit_context("changed-scope-qa: check を実行できませんでした (コマンド不在?): " \
+                   "#{missing.map { |r| r[:name] }.join(', ')} — block はしません。")
+      # 実行不能は cache しない (環境が直れば次の Stop で再試行される)
+      return 0 if failures.empty?
+    end
+
+    if failures.empty?
+      write_state(root, fingerprint, "pass")
+      return 0
+    end
+
+    write_state(root, fingerprint, "fail")
+    summary = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
+    if already_continued
+      emit_context("changed-scope-qa: check がまだ失敗しています (この turn では再 block " \
+                   "しません):\n#{summary}")
+      return 0
+    end
+
+    warn "changed-scope-qa: 変更 scope に対する repo 宣言の check が失敗しています。" \
+         "終了する前に修正してください:\n#{summary}"
+    2
+  rescue StandardError
+    0 # fail-open: hook 内部の想定外でセッションを塞がない
+  end
+end
+
+exit ChangedScopeQa.run if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/personal-changed-scope-qa.rb
+++ b/shared/scripts/personal-changed-scope-qa.rb
@@ -26,12 +26,17 @@
 #
 # 無限ループ対策 (仕様・#200 §4.5):
 # - `stop_hook_active` が true (この turn で既に継続済み) のときは **block しない**。
-#   check は走らせ、結果は additionalContext の警告で返すだけ (人間に判断が戻る)。
-# - dirty scope の hash + check 結果を state file に cache し、**同一 scope を再検査しない**
-#   (pass 済み → 無言 pass / fail 済み → 非ブロッキング警告のみ。block は新しい scope に
-#   対して 1 回だけ)。
-# - check コマンド不在・spawn 失敗は「警告に降格」して block しない (tool 欠損で
-#   セッションを塞がない)。
+# - scope 指紋 + 結果を state file に cache し、**同一 scope への block は 1 回だけ**。
+#   pass 済み scope は無言 pass / fail 済み scope は非ブロッキング警告のみ。
+# - check コマンドの spawn 失敗 (不在 ENOENT・権限 EACCES・不正形式 ENOEXEC) は
+#   「警告に降格」して block しない。spawn 失敗した check は cache で確定させず、
+#   state に missing として分離保持して cache-hit 時にもそれだけ再試行する
+#   (環境が直れば拾われる。実 failure の再 block はしない)。
+#
+# scope 指紋 (false pass を防ぐため QA の実入力を全部含める):
+#   HEAD sha + `git status --porcelain -z -uall` + `git diff HEAD` + untracked file の
+#   内容 digest + 宣言 check 定義の JSON。untracked の内容変更・dirty を保った branch
+#   切替・check 定義の変更のどれでも指紋が変わり、再検査される。
 #
 # 検査対象の帰属 (#203 裁定): agent の変更とユーザーの手元変更を区別せず、**working tree の
 # dirty scope 全体** (tracked の変更 + untracked) を対象にする。単純さを優先し、ユーザー
@@ -82,27 +87,70 @@ module ChangedScopeQa
     nil
   end
 
-  def qa_checks(entry)
-    checks = entry.is_a?(Hash) ? entry["qa_checks"] : nil
-    return [] unless checks.is_a?(Array)
-
-    checks.select do |c|
-      c.is_a?(Hash) && c["command"].is_a?(Array) && !c["command"].empty? &&
-        c["command"].all? { |a| a.is_a?(String) }
-    end
+  def check_name(check)
+    check["name"] || check["command"].first
   end
 
-  # dirty scope の指紋。tracked の変更 (staged + unstaged) と untracked の一覧を含む。
-  # 空文字列 = clean。
-  def scope_fingerprint(root)
-    status = IO.popen(["git", "-C", root, "status", "--porcelain", "-z"], &:read)
+  # [有効 check, 不正 entry の名前]。不正 entry は黙って除外せず警告で可視化する。
+  def qa_checks(entry)
+    checks = entry.is_a?(Hash) ? entry["qa_checks"] : nil
+    return [[], []] unless checks.is_a?(Array)
+
+    valid = []
+    invalid = []
+    checks.each_with_index do |c, i|
+      if c.is_a?(Hash) && c["command"].is_a?(Array) && !c["command"].empty? &&
+         c["command"].all? { |a| a.is_a?(String) }
+        valid << c
+      else
+        invalid << "qa_checks[#{i}]"
+      end
+    end
+    [valid, invalid]
+  end
+
+  # status --porcelain -z -uall の untracked ("?? ") entry の内容 digest。
+  # rename / copy entry は path が 2 要素 (新\0旧) なので旧側を読み飛ばす。
+  def untracked_digest(status_z, root)
+    tokens = status_z.split("\0")
+    parts = []
+    i = 0
+    while i < tokens.length
+      token = tokens[i]
+      i += 1
+      next if token.nil? || token.length < 4
+
+      xy = token[0, 2]
+      path = token[3..-1]
+      i += 1 if xy.start_with?("R", "C") # 旧 path token を消費
+      next unless xy == "??"
+
+      full = File.join(root, path)
+      digest =
+        begin
+          File.file?(full) ? Digest::SHA256.file(full).hexdigest : "non-file"
+        rescue StandardError
+          "unreadable"
+        end
+      parts << "#{path}=#{digest}"
+    end
+    parts.join("\n")
+  end
+
+  # dirty scope の指紋。nil = 判定不能 / 空 = clean。
+  def scope_fingerprint(root, checks)
+    status = IO.popen(["git", "-C", root, "status", "--porcelain", "-z", "-uall"], &:read)
     return nil unless $?.success?
     return "" if status.empty?
 
     diff = IO.popen(["git", "-C", root, "diff", "HEAD", "--no-color", "--no-ext-diff"],
                     err: File::NULL, &:read)
-    # unborn HEAD 等で diff が失敗しても status だけで指紋は成立する (弱い指紋に降格)
-    Digest::SHA256.hexdigest(status + "\0" + diff.to_s)
+    head = IO.popen(["git", "-C", root, "rev-parse", "HEAD"], err: File::NULL, &:read)
+    head = "unborn" unless $?.success?
+    Digest::SHA256.hexdigest(
+      [head.to_s.chomp, status, diff.to_s, untracked_digest(status, root),
+       JSON.generate(checks)].join("\0")
+    )
   end
 
   def state_path(root)
@@ -119,19 +167,21 @@ module ChangedScopeQa
     nil
   end
 
-  def write_state(root, fingerprint, outcome)
+  def write_state(root, fingerprint, outcome, missing)
     require "fileutils"
     FileUtils.mkdir_p(state_dir)
-    File.write(state_path(root), JSON.generate("fingerprint" => fingerprint, "outcome" => outcome))
+    File.write(state_path(root),
+               JSON.generate("fingerprint" => fingerprint, "outcome" => outcome,
+                             "missing" => missing))
   end
 
   def run_check(check, root)
     out = IO.popen(check["command"], chdir: root, err: %i[child out], &:read)
     status = $?.exitstatus
-    { name: check["name"] || check["command"].first, ok: status == 0,
-      output: out.to_s, spawn_failed: status.nil? }
-  rescue Errno::ENOENT
-    { name: check["name"] || check["command"].first, ok: false, output: "", spawn_failed: true }
+    { name: check_name(check), ok: status == 0, output: out.to_s, spawn_failed: status.nil? }
+  rescue Errno::ENOENT, Errno::EACCES, Errno::ENOEXEC => e
+    # 不在だけでなく権限喪失・不正形式も spawn 失敗として可視化する (無言の恒久不活性を防ぐ)
+    { name: check_name(check), ok: false, output: "(#{e.class})", spawn_failed: true }
   end
 
   def truncate(text)
@@ -145,14 +195,48 @@ module ChangedScopeQa
     puts JSON.generate(
       "hookSpecificOutput" => {
         "hookEventName" => "Stop",
-        "additionalContext" => message,
+        "additionalContext" => truncate(message),
       }
     )
   end
 
+  def failure_summary(failures)
+    failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
+  end
+
+  # 同一 scope の cache hit。block は消費済みなので二度と block しない。
+  # missing として保持した check だけ再試行し (環境が直れば拾う)、state を更新して
+  # [exit code, 非ブロッキング context (nil 可)] を返す。
+  def handle_cached(root, fingerprint, state, checks)
+    missing_names = state["missing"].is_a?(Array) ? state["missing"] : []
+    return [0, nil] if state["outcome"] == "pass" && missing_names.empty?
+
+    retried = checks.select { |c| missing_names.include?(check_name(c)) }
+                    .map { |c| run_check(c, root) }
+    still_missing = retried.select { |r| r[:spawn_failed] }.map { |r| r[:name] }
+    new_failures = retried.reject { |r| r[:ok] || r[:spawn_failed] }
+
+    if state["outcome"] == "fail" || !new_failures.empty?
+      write_state(root, fingerprint, "fail", still_missing)
+      [0, "changed-scope-qa: 前回と同一の変更 scope で未解消の check 失敗があります " \
+          "(再 block はしません。人間の判断に委ねます)。" +
+          (new_failures.empty? ? "" : "\n#{failure_summary(new_failures)}")]
+    elsif still_missing.empty?
+      write_state(root, fingerprint, "pass", [])
+      [0, nil]
+    else
+      write_state(root, fingerprint, "pass", still_missing)
+      [0, "changed-scope-qa: check を実行できませんでした: " \
+          "#{still_missing.join(', ')} — block はしません。"]
+    end
+  end
+
+  # stdout の JSON emission は 1 回だけに保つ (複数 JSON 行は runner の parse を壊しうる)。
+  # notes に非ブロッキングの伝達事項を集め、最後にまとめて 1 回 emit する。
   def run
     payload = JSON.parse($stdin.read) rescue {}
     already_continued = payload["stop_hook_active"] == true
+    notes = []
 
     config = load_config
     return 0 if config.nil?
@@ -160,55 +244,66 @@ module ChangedScopeQa
     root = repo_root
     return 0 if root.nil?
 
-    checks = qa_checks(config[root])
-    return 0 if checks.empty?
+    checks, invalid = qa_checks(config[root])
+    return 0 if checks.empty? && invalid.empty?
 
-    fingerprint = scope_fingerprint(root)
+    unless invalid.empty?
+      notes << "changed-scope-qa: 設定エラー: 不正な check 宣言を無視しました: " \
+               "#{invalid.join(', ')} (#{config_path})"
+    end
+
+    code = gate(root, checks, already_continued, notes) unless checks.empty?
+    code ||= 0
+    emit_context(notes.join("\n")) unless notes.empty? || code != 0
+    code
+  rescue StandardError
+    0 # fail-open: hook 内部の想定外でセッションを塞がない
+  end
+
+  # gate 本体。非ブロッキングの伝達事項は notes に追記し、block するときだけ
+  # stderr + exit 2 を使う (block 時は stdout JSON が無視されるため notes は出さない)。
+  def gate(root, checks, already_continued, notes)
+    fingerprint = scope_fingerprint(root, checks)
     return 0 if fingerprint.nil? || fingerprint.empty? # clean or 判定不能 → gate しない
 
     state = read_state(root)
     if state && state["fingerprint"] == fingerprint
-      case state["outcome"]
-      when "pass"
-        return 0
-      else
-        # 同一 scope の失敗は再 block しない (人間判断へ)。無言だと状態が見えないので
-        # 非ブロッキングの一言だけ残す。
-        emit_context("changed-scope-qa: 前回と同一の変更 scope で未解消の check 失敗があります " \
-                     "(再 block はしません。人間の判断に委ねます)。")
-        return 0
-      end
+      code, message = handle_cached(root, fingerprint, state, checks)
+      notes << message if message
+      return code
     end
 
     results = checks.map { |c| run_check(c, root) }
     missing = results.select { |r| r[:spawn_failed] }
     failures = results.reject { |r| r[:ok] || r[:spawn_failed] }
-
-    unless missing.empty?
-      emit_context("changed-scope-qa: check を実行できませんでした (コマンド不在?): " \
-                   "#{missing.map { |r| r[:name] }.join(', ')} — block はしません。")
-      # 実行不能は cache しない (環境が直れば次の Stop で再試行される)
-      return 0 if failures.empty?
-    end
+    missing_names = missing.map { |r| r[:name] }
 
     if failures.empty?
-      write_state(root, fingerprint, "pass")
+      if missing.empty?
+        write_state(root, fingerprint, "pass", [])
+      else
+        # 実行できた check は全 pass だが未実行が残る: pass + missing で保持し、
+        # cache-hit 時に missing だけ再試行される (block はしない)
+        notes << "changed-scope-qa: check を実行できませんでした: " \
+                 "#{missing_names.join(', ')} — block はしません。"
+        write_state(root, fingerprint, "pass", missing_names)
+      end
       return 0
     end
 
-    write_state(root, fingerprint, "fail")
-    summary = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
+    # 実 failure あり: この scope への block を 1 回だけ消費する (missing は分離保持)
+    write_state(root, fingerprint, "fail", missing_names)
+    summary = failure_summary(failures)
+    summary += "\n(未実行の check: #{missing_names.join(', ')})" unless missing.empty?
     if already_continued
-      emit_context("changed-scope-qa: check がまだ失敗しています (この turn では再 block " \
-                   "しません):\n#{summary}")
+      notes << "changed-scope-qa: check がまだ失敗しています (この turn では再 block " \
+               "しません):\n#{summary}"
       return 0
     end
 
-    warn "changed-scope-qa: 変更 scope に対する repo 宣言の check が失敗しています。" \
-         "終了する前に修正してください:\n#{summary}"
+    warn truncate("changed-scope-qa: 変更 scope に対する repo 宣言の check が失敗しています。" \
+                  "終了する前に修正してください:\n#{summary}")
     2
-  rescue StandardError
-    0 # fail-open: hook 内部の想定外でセッションを塞がない
   end
 end
 

--- a/shared/scripts/personal-fast-edit-check.asset.yml
+++ b/shared/scripts/personal-fast-edit-check.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:a0b8a6692c4a296043108ba8d914ca03dd5786cf3f4ed57af36035e3ef4093ba
+  approved_build_id: sha256:2ed788f160bc923d9cbe1098c29edf26bda61c6b34cad8e21b94ad77f4403fe0
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-fast-edit-check.rb

--- a/shared/scripts/personal-fast-edit-check.asset.yml
+++ b/shared/scripts/personal-fast-edit-check.asset.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+name: personal-fast-edit-check
+kind: script
+visibility: personal
+targets:
+  - codex
+  - claude-code
+risk:
+  prompt_injection: low
+  privacy: low
+# script kind は実行コード配布のため常に human review 必須 (#147)。
+# 本 script は #203 (Phase 2) の実装 PR で author≠reviewer レビューのうえ承認。
+# 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
+# approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
+review:
+  human_review: approved
+  approved_build_id: sha256:a0b8a6692c4a296043108ba8d914ca03dd5786cf3f4ed57af36035e3ef4093ba
+  approved_artifact_kind: script
+source:
+  path: shared/scripts/personal-fast-edit-check.rb
+  format: text
+summary: >-
+  PostToolUse (Edit|Write) hook body。編集直後の変更ファイル 1 個に、ユーザー所有の中央
+  local 設定 (checks.local.json) で宣言された高速 check を実行し、失敗要約だけを
+  additionalContext で返す steering (fail-open・block しない・自動 fix しない)。宣言の
+  無い repo では無言 no-op。repo 内の宣言は読まない (第三者 repo の任意コマンド宣言を
+  防ぐ)。docs/quality-loop-hooks.md が正本。

--- a/shared/scripts/personal-fast-edit-check.rb
+++ b/shared/scripts/personal-fast-edit-check.rb
@@ -1,0 +1,154 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# fast-edit-check: PostToolUse (Edit|Write) hook body。編集直後の変更ファイル 1 個に
+# repo 宣言済みの高速 check (syntax / lint) を実行し、失敗要約だけを
+# hookSpecificOutput.additionalContext でモデルに返す steering hook (#200 §4.4 / #203)。
+# 「書いた直後に機械が指摘 → その場で直す」ループの機械判定部分を担う。
+#
+# 正本: docs/quality-loop-hooks.md。
+#
+# 強度ラベル (偽らない): steering / fail-open。block しない (permissionDecision を
+# 付けない)。hook 内部の想定外はすべて exit 0 で透過する (編集操作を壊さない)。
+# 品質の意味判断 (要求一致・最小差分) は production-rail skill の領分のまま。
+#
+# check コマンドの発見 (自動推測しない・#203 裁定):
+# - 宣言の正本は **ユーザー所有の untracked 中央設定** ~/.config/agent-tools/checks.local.json。
+#   repo の実 path をキーに edit_checks (pattern + command) を宣言した repo でだけ動き、
+#   宣言が無い repo では無言 no-op。
+# - repo 内の宣言ファイルは**読まない**: clone した第三者 repo が「編集のたびに実行される
+#   任意コマンド」を宣言できてしまうため (宣言の所有をユーザーに固定する)。
+# - 設定形式が JSON なのは、standalone 配布 script に psych 3/4 分岐 (yaml_util の領分) を
+#   持ち込まないため。
+#
+# 設定例 (checks.local.json):
+#   {
+#     "/Users/<you>/src/some-repo": {
+#       "edit_checks": [
+#         {"name": "ruby-syntax", "pattern": "\\.rb$", "command": ["ruby", "-c"]}
+#       ]
+#     }
+#   }
+#   command には対象ファイルの絶対 path が 1 引数として追記され、cwd = repo root で実行される。
+#   edit_checks は「1 ファイル・数百 ms」の高速 check だけを宣言する (PostToolUse は編集の
+#   たびに同期で走る)。
+#
+# payload 互換: Claude Code の PostToolUse payload (tool_input.file_path) は #201 で実測済み。
+# Codex (apply_patch) の payload 形は未実測で、file_path が取れない場合は無言 no-op に
+# 倒れる (fail-open)。配備時に実測して追従する (honest-label)。
+
+require "json"
+
+module FastEditCheck
+  VERSION = "1"
+
+  CONFIG_PATH_ENV = "AGENT_TOOLS_CHECKS_CONFIG"
+  DEFAULT_CONFIG = File.join(ENV["HOME"].to_s, ".config", "agent-tools", "checks.local.json")
+
+  # モデルに返す失敗出力の上限 (context を溢れさせない)。
+  OUTPUT_CAP = 2000
+
+  module_function
+
+  def config_path
+    ENV[CONFIG_PATH_ENV].to_s.empty? ? DEFAULT_CONFIG : ENV[CONFIG_PATH_ENV]
+  end
+
+  # 設定を読む。無い = opt-in していない (nil)。壊れている = 警告文字列を返す
+  # (無言で握り潰すとユーザーが設定ミスに気づけない)。
+  def load_config
+    return nil unless File.file?(config_path)
+
+    data = JSON.parse(File.read(config_path))
+    return "checks.local.json のトップレベルが object ではありません" unless data.is_a?(Hash)
+
+    data
+  rescue JSON::ParserError
+    "checks.local.json を JSON として解釈できません"
+  end
+
+  def repo_root_for(file)
+    dir = File.dirname(file)
+    return nil unless File.directory?(dir)
+
+    out = IO.popen(["git", "-C", dir, "rev-parse", "--show-toplevel"], err: File::NULL, &:read)
+    return nil unless $?.success?
+
+    File.realpath(out.chomp)
+  rescue Errno::ENOENT, Errno::EACCES
+    nil
+  end
+
+  def checks_for(entry, file)
+    checks = entry.is_a?(Hash) ? entry["edit_checks"] : nil
+    return [] unless checks.is_a?(Array)
+
+    checks.select do |c|
+      c.is_a?(Hash) && c["pattern"].is_a?(String) && c["command"].is_a?(Array) &&
+        c["command"].all? { |a| a.is_a?(String) } && !c["command"].empty? &&
+        begin
+          Regexp.new(c["pattern"]).match?(file)
+        rescue RegexpError
+          false
+        end
+    end
+  end
+
+  def run_check(check, file, repo_root)
+    out = IO.popen(check["command"] + [file], chdir: repo_root, err: %i[child out], &:read)
+    status = $?.exitstatus
+    { name: check["name"] || check["command"].first, ok: status == 0,
+      output: out.to_s, spawn_failed: status.nil? }
+  rescue Errno::ENOENT
+    { name: check["name"] || check["command"].first, ok: false,
+      output: "(check コマンドが見つかりません)", spawn_failed: true }
+  end
+
+  def truncate(text)
+    text = text.dup
+    text.force_encoding(Encoding::UTF_8)
+    text = text.scrub("�") unless text.valid_encoding?
+    text.length > OUTPUT_CAP ? text[0, OUTPUT_CAP] + "\n…(truncated)" : text
+  end
+
+  def emit(message)
+    puts JSON.generate(
+      "hookSpecificOutput" => {
+        "hookEventName" => "PostToolUse",
+        "additionalContext" => message,
+      }
+    )
+  end
+
+  def run
+    payload = JSON.parse($stdin.read)
+    file = payload.dig("tool_input", "file_path")
+    return 0 unless file.is_a?(String) && File.file?(file)
+
+    config = load_config
+    return 0 if config.nil?
+    if config.is_a?(String)
+      emit("fast-edit-check: 設定エラー: #{config} (#{config_path})")
+      return 0
+    end
+
+    repo_root = repo_root_for(file)
+    return 0 if repo_root.nil?
+
+    entry = config[repo_root]
+    checks = entry ? checks_for(entry, file) : []
+    return 0 if checks.empty?
+
+    failures = checks.map { |c| run_check(c, file, repo_root) }.reject { |r| r[:ok] }
+    return 0 if failures.empty?
+
+    body = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
+    emit("fast-edit-check: #{File.basename(file)} への編集が repo 宣言の check に失敗しました。" \
+         "いま直してください (自動修正はしません):\n#{body}")
+    0
+  rescue StandardError
+    0 # fail-open: hook 内部の想定外で編集操作を壊さない
+  end
+end
+
+exit FastEditCheck.run if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/personal-fast-edit-check.rb
+++ b/shared/scripts/personal-fast-edit-check.rb
@@ -79,19 +79,28 @@ module FastEditCheck
     nil
   end
 
+  # 宣言 entry を [file に一致する有効 check, 不正 entry の名前] に分類する。
+  # 不正 entry (構造不備・壊れた regex) は黙って除外せず設定エラーとして可視化する
+  # (「設定済みなのに動かない」を診断可能にする)。
   def checks_for(entry, file)
     checks = entry.is_a?(Hash) ? entry["edit_checks"] : nil
-    return [] unless checks.is_a?(Array)
+    return [[], []] unless checks.is_a?(Array)
 
-    checks.select do |c|
-      c.is_a?(Hash) && c["pattern"].is_a?(String) && c["command"].is_a?(Array) &&
-        c["command"].all? { |a| a.is_a?(String) } && !c["command"].empty? &&
-        begin
-          Regexp.new(c["pattern"]).match?(file)
-        rescue RegexpError
-          false
-        end
+    matched = []
+    invalid = []
+    checks.each_with_index do |c, i|
+      unless c.is_a?(Hash) && c["pattern"].is_a?(String) && c["command"].is_a?(Array) &&
+             !c["command"].empty? && c["command"].all? { |a| a.is_a?(String) }
+        invalid << "edit_checks[#{i}]"
+        next
+      end
+      begin
+        matched << c if Regexp.new(c["pattern"]).match?(file)
+      rescue RegexpError
+        invalid << (c["name"] || "edit_checks[#{i}]") + " (壊れた regex)"
+      end
     end
+    [matched, invalid]
   end
 
   def run_check(check, file, repo_root)
@@ -99,9 +108,11 @@ module FastEditCheck
     status = $?.exitstatus
     { name: check["name"] || check["command"].first, ok: status == 0,
       output: out.to_s, spawn_failed: status.nil? }
-  rescue Errno::ENOENT
+  rescue Errno::ENOENT, Errno::EACCES, Errno::ENOEXEC => e
+    # コマンド不在だけでなく実行権限喪失・不正な実行形式も spawn 失敗として可視化する
+    # (包括 rescue の無言 exit 0 に落とすと check の恒久不活性に気づけない)
     { name: check["name"] || check["command"].first, ok: false,
-      output: "(check コマンドが見つかりません)", spawn_failed: true }
+      output: "(check を実行できません: #{e.class})", spawn_failed: true }
   end
 
   def truncate(text)
@@ -136,15 +147,24 @@ module FastEditCheck
     return 0 if repo_root.nil?
 
     entry = config[repo_root]
-    checks = entry ? checks_for(entry, file) : []
-    return 0 if checks.empty?
+    checks, invalid = entry ? checks_for(entry, file) : [[], []]
+
+    parts = []
+    unless invalid.empty?
+      parts << "fast-edit-check: 設定エラー: 不正な check 宣言を無視しました: " \
+               "#{invalid.join(', ')} (#{config_path})"
+    end
 
     failures = checks.map { |c| run_check(c, file, repo_root) }.reject { |r| r[:ok] }
-    return 0 if failures.empty?
+    unless failures.empty?
+      body = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
+      parts << "fast-edit-check: #{File.basename(file)} への編集が repo 宣言の check に失敗しました。" \
+               "いま直してください (自動修正はしません):\n#{body}"
+    end
+    return 0 if parts.empty?
 
-    body = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
-    emit("fast-edit-check: #{File.basename(file)} への編集が repo 宣言の check に失敗しました。" \
-         "いま直してください (自動修正はしません):\n#{body}")
+    # 上限は check 単位だけでなく合計にも適用する (複数失敗で context を溢れさせない)
+    emit(truncate(parts.join("\n")))
     0
   rescue StandardError
     0 # fail-open: hook 内部の想定外で編集操作を壊さない


### PR DESCRIPTION
## 概要

#203 (Phase 2)。当初の課題「lint / QA をフックでうまく使えていない」に直接応える 2 本。編集直後の機械フィードバック (steering) と turn 終了時の QA gate (条件付き block) を lifecycle hook に出す。

## 変更内容

- **personal-fast-edit-check** (PostToolUse / `Edit|Write`): 変更ファイル 1 個に repo 宣言の高速 check (例: `ruby -c`) を実行し、**失敗時のみ** additionalContext で要約 (2000 字上限・scrub) を返す。fail-open (内部エラーで編集を壊さない)・block しない・自動 --fix しない・成功は無言。壊れた設定だけは 1 行 steer (無言で握り潰さない)。
- **personal-changed-scope-qa** (Stop): dirty scope に repo 宣言の QA check が未実行 / stale なら **exit 2 で一度だけ block**。無限ループ対策を仕様に内蔵: scope 指紋 (status+diff sha256) と結果を cache して同一 scope を再検査しない / `stop_hook_active` では絶対に block しない / 同一失敗の再発・check 不在は非ブロッキング警告に降格。
- **check 発見の設計 (#203 の前提タスク・裁定記録)**: ユーザー所有の untracked 中央設定 `~/.config/agent-tools/checks.local.json` が正本。宣言の無い repo は両 hook とも無言 no-op (opt-in)。**repo 内の宣言は読まない** — clone した第三者 repo が「編集のたびに実行される任意コマンド」を宣言できてしまうため (宣言の所有をユーザーに固定)。JSON は psych 3/4 分岐を standalone script に持ち込まないため。
- **帰属の裁定 (#200 §4.5 の宿題)**: agent / ユーザーの変更を区別せず dirty 全体を検査 (単純さ優先・ユーザーの書きかけも対象になることを明記)。
- docs/quality-loop-hooks.md: 契約正本。Codex parity は honest-label (apply_patch payload 未実測 → file_path 不在なら無言 no-op に倒れる。Stop の stop_hook_active 実測は配備時 = #201 carry-over)。

## 検証

- `quality-loop-hooks-test.sh` 新設: 設定 / state / HOME / git config 隔離 + 記録付き fake check。pass 無言 / 失敗 steer / pattern 不一致 / 宣言なし repo / repo 外 / 壊れた設定 / clean tree / cache hit (再実行なし) / 新 scope の block / 同一失敗の非 block / stop_hook_active 非 block / check 不在の警告降格を固定。
- 17 suite 全緑 / check-manifests 21 ok / register rc=0。manifest 承認は本 PR のレビュー + merge 承認に紐づく。
- 実配線 (登録 + Codex 実測) は merge 後に dotfiles issue へ hand-off。

Refs #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqz3c5ope2oVauyyWZNkyv