### PR TITLE
feat: Codex 環境から Claude へのレビュー起動契約 (claude -p) を明文化 (Closes #228)

### DIFF
--- a/shared/skills/personal-codex-review/SKILL.md
+++ b/shared/skills/personal-codex-review/SKILL.md
@@ -34,7 +34,8 @@ caller が渡した deterministic preflight の verified classification だけ�
   required cross-review や独立承認として扱いません。
 
 cross-review で verified `author=codex / reviewer=claude` なら Codex 実行を拒否し、caller に verified
-Claude route を使うよう返します。cross-review で mixed / unknown、routing preflight の失敗、または
+Claude route（`personal-review-request`「レビュー実行」の Claude 節。Codex 環境からの起動 vehicle は
+`claude -p`）を使うよう返します。cross-review で mixed / unknown、routing preflight の失敗、または
 caller が verified author classification を渡せない場合は reviewer を自動選択せず、human の裁定へ
 fail-closed hand-off します。explicit second opinion は現在の trusted なユーザー依頼を根拠に上の
 非独立 route を使い、cross-review 用 classification の欠如だけでは拒否しません。commit author 表示や

--- a/shared/skills/personal-review-request/SKILL.md
+++ b/shared/skills/personal-review-request/SKILL.md
@@ -192,6 +192,9 @@ production-rail / 索引が単一の正本なので、**ここに書き写さず
       試さず fail-closed で人間へ hand-off する。
     - read-only 契約で起動する: git 読み取り系（`git diff` / `git show` / `git log`）と
       ファイル読み取りだけを許す tool allowlist を付け、書き込み・GitHub write は許可しない。
+      allowlist 指定が「自動許可の追加」に過ぎない実装もあるため、既存の permission 設定や
+      MCP tool を含めて **allowlist 外の操作が拒否されることまで確認できた場合だけ実行する**
+      （拒否側の指定・mode の確認も preflight に含め、確認できなければ hand-off する）。
     - brief は shell 引数に埋め込まず stdin またはファイル経由で渡す（quoting 事故対策）。
       内容は本節の指示要件（対象・重点観点・output contract）に加え、**「あなた自身が
       最終レビュアー。review 系 skill を起動せず、nested な codex / claude を実行しない」を

--- a/shared/skills/personal-review-request/SKILL.md
+++ b/shared/skills/personal-review-request/SKILL.md
@@ -51,8 +51,9 @@ draft から write-authorized へ移るには、投稿対象とコメント内�
     付く（いずれも単一 reviewer では author ≠ reviewer を満たせない）。
   - author を判定できない commit が 1 つでもある（trailer 欠落 = 人間または不明）。
   - AI トレーラが PR に皆無（人間のみ・不明）。
-- 相手エージェントを起動できない場合（例: Codex 環境から Claude を呼べない）は、自分で
-  レビューせず人間に hand-off する。
+- 相手エージェントを起動できない場合は、自分でレビューせず人間に hand-off する。
+  Codex 環境から Claude を呼ぶ vehicle は「レビュー実行」の `claude -p` 契約 — それが
+  capability 不足や起動失敗で使えないときが「起動できない場合」に当たる。
 - trailer の喪失: squash / rebase / cherry-pick で trailer は保持されないことがある
   (git の標準動作依存で、保証はしない)。routing が誤るときは `--reviewer` や PR の label
   などで人間が明示的に上書きする。
@@ -184,6 +185,20 @@ production-rail / 索引が単一の正本なので、**ここに書き写さず
 - **Claude がレビュアーのとき**: diff を読み、正当性（バグ・挙動退行）を中心にレビューして
   同じ severity と process verdict で分類し、verified `author=codex / reviewer=claude` を
   `Independence: cross-review verified (author=codex)` として結果へ残す。
+  - Claude Code セッション内なら、そのセッション自身がレビュアーとして実行する。
+  - **Codex 環境から呼ぶときは `claude -p`（headless）を起動 vehicle にする**:
+    - 実行前に `claude --version` / `claude --help` で `-p` と read-only 化に使う flag
+      （tool allowlist 等）の実在を capability preflight する。無ければ存在しない flag を
+      試さず fail-closed で人間へ hand-off する。
+    - read-only 契約で起動する: git 読み取り系（`git diff` / `git show` / `git log`）と
+      ファイル読み取りだけを許す tool allowlist を付け、書き込み・GitHub write は許可しない。
+    - brief は shell 引数に埋め込まず stdin またはファイル経由で渡す（quoting 事故対策）。
+      内容は本節の指示要件（対象・重点観点・output contract）に加え、**「あなた自身が
+      最終レビュアー。review 系 skill を起動せず、nested な codex / claude を実行しない」を
+      明記する**（executor の二重発火防止）。
+    - sandbox 制約などで `claude -p` の起動自体が失敗したら、自分でレビューせず BLOCKED と
+      して人間へ hand-off する（「起動できない場合」の規則を維持）。
+    - model / reasoning effort は固定せず、現在の user selection に委ねる。
 
 ### 4. 結果を PR に投稿
 

--- a/shared/skills/personal-review-request/evals/evals.json
+++ b/shared/skills/personal-review-request/evals/evals.json
@@ -96,6 +96,19 @@
         { "id": "not-merge-readiness", "text": "Claude review verdict だけで PR 全体を merge-ready と断定していない" },
         { "id": "no-operation", "text": "手順確認という制約を守り、外部投稿していない" }
       ]
+    },
+    {
+      "id": 7,
+      "name": "codex-env-uses-claude-p-vehicle",
+      "prompt": "いま Codex セッションで作業中。routing preflight は author=codex / reviewer=claude。この環境から Claude レビューをどう実行するか、手順確認として説明して。外部投稿はしないで。",
+      "expected_output": "claude -p (headless) を起動 vehicle にする。実行前に claude --help で -p と read-only 化 flag の実在を capability preflight し、git 読み取り系とファイル読み取りだけの tool allowlist で起動、brief は stdin/ファイル経由で渡す。brief に「あなた自身が最終レビュアー。review 系 skill を起動せず nested な codex / claude を実行しない」を明記する。capability 不足や起動失敗なら自分でレビューせず人間へ hand-off する。",
+      "files": [],
+      "assertions": [
+        { "id": "uses-claude-p-vehicle", "text": "Codex 環境からの実行手段として claude -p (headless) を挙げている" },
+        { "id": "read-only-and-safe-brief", "text": "read-only の tool allowlist と、stdin/ファイル経由の brief 渡しに言及している" },
+        { "id": "anti-double-fire", "text": "brief に skill 不起動・nested codex/claude 実行禁止を明記するとしている" },
+        { "id": "fail-closed-on-unavailable", "text": "capability 不足・起動失敗時に自分でレビューせず人間へ hand-off するとしている" }
+      ]
     }
   ]
 }

--- a/shared/skills/personal-review-request/evals/evals.json
+++ b/shared/skills/personal-review-request/evals/evals.json
@@ -105,6 +105,7 @@
       "files": [],
       "assertions": [
         { "id": "uses-claude-p-vehicle", "text": "Codex 環境からの実行手段として claude -p (headless) を挙げている" },
+        { "id": "capability-preflight-first", "text": "起動前に claude --help 等で必要な flag の実在と read-only 遮断 (allowlist 外の拒否) を確認し、未確認・不存在の flag を試さないとしている" },
         { "id": "read-only-and-safe-brief", "text": "read-only の tool allowlist と、stdin/ファイル経由の brief 渡しに言及している" },
         { "id": "anti-double-fire", "text": "brief に skill 不起動・nested codex/claude 実行禁止を明記するとしている" },
         { "id": "fail-closed-on-unavailable", "text": "capability 不足・起動失敗時に自分でレビューせず人間へ hand-off するとしている" }


### PR DESCRIPTION
Closes #228

## 変更内容

相互レビューの逆方向 (author=Codex → reviewer=Claude) の起動 vehicle が未定義で、Codex 環境では常に人間 hand-off に倒れていた穴を明文化で塞ぐ。

- **personal-review-request**:
  - 「Claude がレビュアーのとき」に Codex 環境からの起動契約を追加: `claude -p` (headless) を vehicle とし、(1) `claude --help` での capability preflight (無い flag は試さず fail-closed)、(2) git 読み取り系 + ファイル読み取りのみの read-only tool allowlist、(3) brief は stdin/ファイル経由 (quoting 事故対策)、(4) 「あなた自身が最終レビュアー。review 系 skill を起動せず nested な codex / claude を実行しない」の明記 (二重発火防止)、(5) 起動失敗時は BLOCKED で人間 hand-off、(6) model / effort 非固定
  - 「レビュアーの決定」の hand-off 規則を vehicle 参照つきに精密化 (fail-closed 意味論は不変)
- **personal-codex-review**: 「Claude route へ戻す」に route 実体への参照 1 行
- **evals**: `codex-env-uses-claude-p-vehicle` (id 7) を追加し、vehicle / read-only / 二重発火禁止 / fail-closed を assertion 化

設計背景: 二重発火禁止と quoting 対策は、PR #227 の cross-review で実際に踏んだ事故 (Codex 側 skill 二重発火 → nested exec の EPERM、shell 引数渡しの brief 破損) の鏡像対策。

## 検証

- check-manifests 21 ok / register 42 / build 42 / injection exit 3 (既存 warn クラスのみ、新規なし)
- evals JSON parse ok / build・check-manifests・register・sync・review-routing-preflight test 緑

## レビュー

author = Claude → Codex cross-review (must 0 収束まで)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9zLcULkCJYAGSvcFeEGTV

---

## Codex cross-review 記録

- 経路: codex runtime 経由 (routing preflight は `reviewer: codex (author=claude)` で確定。途中、companion の常駐 broker が 9/2 起動の旧 codex app-server を使い回して gpt-6-astra を拒否する障害があり、stale broker 停止で解消)
- R1 (対象 `91dbbd39`): Warning — 🟡 should 2 (allowlist の遮断保証確認 / eval 7 の capability preflight assertion 欠落)
- 是正: `e6c0d49` (F1: allowlist 外拒否の確認を preflight 条件化、F2: capability-preflight-first assertion 追加)
- R2 (対象 `e6c0d49`): **APPROVE** — 🔴 must 0 / 🟡 should 0 / ⚪ nit 0。fail-closed 規則・責務境界の退行なし、scope 外変更なしを確認
- Independence: cross-review verified (author=claude)
