### PR TITLE
fix: Stop の警告を会話継続から分離する

### DIFF
--- a/docs/quality-loop-hooks.md
+++ b/docs/quality-loop-hooks.md
@@ -70,19 +70,32 @@
   (モデルに修正の続行を促す)。
 - **無限ループ対策 (仕様)**:
   - `stop_hook_active: true` (この turn で既に継続済み) では**絶対に block しない**
-    (check は走らせ、結果は additionalContext の警告で返す)。
+    (新しい scope なら check は走らせ、失敗は `systemMessage` のユーザー向け警告で返す)。
   - 同一 scope 指紋の再 Stop は check を**再実行しない** (pass 済み = 無言 / fail 済み =
-    非ブロッキング警告のみ。block は新しい scope に 1 回だけ → 直せない失敗は人間に戻る)。
-  - check コマンド不在・spawn 失敗は「警告に降格」して block しない (cache もしないので
-    環境が直れば次の Stop で再試行)。
+    ユーザー向け警告のみ。block は新しい scope に 1 回だけ → 直せない失敗は人間に戻る)。
+  - check コマンド不在・spawn 失敗はユーザー向け警告に降格して block しない。未実行の
+    check は cache 内で `missing` として分離し、同一 scope でも次の Stop で再試行する。
+    復旧して全 check が pass になれば無言になる。
+- 警告は **exit 0 + `{"systemMessage":"..."}`** のみを出力する (本文は 2000 文字で打ち切り /
+  非 UTF-8 は scrub)。構成エラーの警告も同じ経路を使う。モデルへの追加指示や継続要求は
+  出さず、他の Stop hook の判断も上書きしない。
+- 出力契約の一次情報 (2026-09-05 確認):
+  [Claude Code](https://code.claude.com/docs/en/hooks#json-output) と
+  [Codex](https://developers.openai.com/codex/hooks#common-output-fields) は `systemMessage` を
+  ユーザー向け警告として扱う。Claude Code の
+  [Stop `additionalContext`](https://code.claude.com/docs/en/hooks#stop-decision-control) は
+  会話を継続させるため、この hook の警告経路には使わない。配線は同期 command hook を前提とする。
 - state: `~/.cache/agent-tools/changed-scope-qa/<repo path の sha256>.json`。
   test 用 override: `AGENT_TOOLS_QA_STATE_DIR` / 設定は `AGENT_TOOLS_CHECKS_CONFIG`。
-- Codex 側は Stop の matcher が無視される点 (#201) 以外は同型を期待。`stop_hook_active` /
-  block 挙動の Codex 実測は配備時 (#201 からの carry-over)。
+- Codex 側は Stop の matcher が無視される (#201)。`stop_hook_active` と exit 2 による
+  継続要求は[公式 Stop 契約](https://developers.openai.com/codex/hooks#stop)にも記載されている。
+  実際の発火・ユーザーへの警告到達は配備先ごとの実機 smoke で確認する。
 
 ## 検証境界
 
 - 純粋ロジックと git 連携・cache・ループ対策は `scripts/tests/quality-loop-hooks-test.sh`
   が CI で検証する (設定 / state / HOME / git config を隔離・fake check 使用)。
+- Stop の回帰テストは warning JSON に `systemMessage` だけがあり、継続を要求する
+  field がないことを検証する。fixture 検証は実 runner の継続回数や UI 表示の観測ではない。
 - 実配線 (settings.json / hooks.json への登録・Codex payload / Stop の実測) は CI 外
   (dotfiles 側 issue + 実機 smoke。実施記録は #203)。

--- a/docs/quality-loop-hooks.md
+++ b/docs/quality-loop-hooks.md
@@ -11,7 +11,8 @@
   想定外はすべて exit 0 で透過し、編集操作を壊さない。
 - **changed-scope-qa は best-effort gate**。hook 無効化・別経路で迂回できる。block は
   「新しい変更 scope に対して 1 回だけ」で、無限ループ対策 (下記) を仕様に含む。
-- どちらも登録 (+ Codex は trust) が済むまで無警告で不活性 (fail-open の帰結)。
+- どちらも登録 (+ Codex は trust) が済むまで不活性 (fail-open の帰結)。
+  未 trust 時の警告など時点付き仕様は [runtime 正本](runtime-injection-defense.md) を参照。
   配線は dotfiles 所有 (boundary-with-dotfiles)。
 
 ## check コマンドの発見(自動推測しない・#203 裁定)
@@ -65,8 +66,9 @@
 - **検査対象の帰属 (#203 裁定)**: agent の変更とユーザーの手元変更を区別せず、working
   tree の **dirty scope 全体** (tracked の変更 + untracked) を対象にする。ユーザー自身の
   書きかけ変更も検査対象になる (明記)。
-- dirty かつ宣言 repo なら `qa_checks` を実行。全 pass → scope 指紋 (status + diff の
-  sha256) と結果を state に cache して無言 pass。失敗 → **exit 2 + stderr 要約で block**
+- dirty かつ宣言 repo なら `qa_checks` を実行。全 pass → scope 指紋 (HEAD / status / tracked diff /
+  untracked 内容 / check 定義を含む sha256) と結果を state に cache して無言 pass。
+  失敗 → **exit 2 + stderr 要約で block**
   (モデルに修正の続行を促す)。
 - **無限ループ対策 (仕様)**:
   - `stop_hook_active: true` (この turn で既に継続済み) では**絶対に block しない**
@@ -89,7 +91,7 @@
   test 用 override: `AGENT_TOOLS_QA_STATE_DIR` / 設定は `AGENT_TOOLS_CHECKS_CONFIG`。
 - Codex 側は Stop の matcher が無視される (#201)。`stop_hook_active` と exit 2 による
   継続要求は[公式 Stop 契約](https://developers.openai.com/codex/hooks#stop)にも記載されている。
-  実際の発火・ユーザーへの警告到達は配備先ごとの実機 smoke で確認する。
+  実機 smoke の確認範囲は下記。配備先ごとの登録・trust は別途必要。
 
 ## 検証境界
 
@@ -99,3 +101,32 @@
   field がないことを検証する。fixture 検証は実 runner の継続回数や UI 表示の観測ではない。
 - 実配線 (settings.json / hooks.json への登録・Codex payload / Stop の実測) は CI 外
   (dotfiles 側 issue + 実機 smoke。実施記録は #203)。
+
+### Stop の実機確認 (2026-09-06 / #237)
+
+Claude Code 2.1.259 (`claude-opus-5`) と Codex 0.153.4 (`gpt-6-astra`) で、
+同じ候補 source と一時 Git fixture・専用 checks/state を使い、native runner が呼んだ
+Stop と実際の応答を照合した。モデルからの tool 呼び出しはなく、synthetic stdin の
+テストとは別に確認している。
+
+| case | 両 host の Stop exit / active | 最終 text 応答数 | check 実行数 |
+|---|---|---|---|
+| command 不在 | `0 / false` | 1 | 0 |
+| 初回 failure → 同一 scope の再 Stop | `2 → 0 / false → true` | 2 | 1 |
+| successful check | `0 / false` | 1 | 1 |
+
+Claude は warning と再 Stop の後に `system/informational` の notice が各 1 回届き、
+成功時は QA notice なしで終了した。Codex は上表を `exec --json` で確認したが、
+`systemMessage` は JSON 出力にも通常の `exec` 出力にも現れなかった。別の TUI 実行で
+command 不在と既存の失敗 scope cache による警告が `Hook` 通知として表示され、
+各 1 応答・再 block なしで終了したことを確認した。Codex の `exec` による警告表示は
+確認済みの機能とは扱わない。Claude の対話 UI 描画も検査範囲外。
+
+Codex の検証環境には既存 plugin の timeout 調整と optional Code Mode host 不在の
+起動診断があったため、strict な JSON verifier の初回判定は inconclusive だった。
+hook receipt と対応 session の実 trace を照合して上表を確認し、元の evidence は保持した。
+検証用に追加した Codex project / 単独 hook の信頼設定は公式 API で撤回し、別 process で
+他の設定・hooks の不変を確認した。通常の配線や設定を更新した検証ではない。
+
+成功時 cache、変更 scope、command 復旧時の再試行は regression / synthetic test の
+確認範囲であり、上表の実機観測へ広げて主張しない。

--- a/docs/quality-loop-hooks.md
+++ b/docs/quality-loop-hooks.md
@@ -109,7 +109,7 @@ Claude Code 2.1.259 (`claude-opus-5`) と Codex 0.153.4 (`gpt-6-astra`) で、
 Stop と実際の応答を照合した。モデルからの tool 呼び出しはなく、synthetic stdin の
 テストとは別に確認している。
 
-| case | 両 host の Stop exit / active | 最終 text 応答数 | check 実行数 |
+| case | 両 host の Stop exit / active | 最終 text 応答数 | check 実行数 (Codex) |
 |---|---|---|---|
 | command 不在 | `0 / false` | 1 | 0 |
 | 初回 failure → 同一 scope の再 Stop | `2 → 0 / false → true` | 2 | 1 |

--- a/scripts/tests/quality-loop-hooks-test.sh
+++ b/scripts/tests/quality-loop-hooks-test.sh
@@ -64,6 +64,14 @@ run_qa() { # $1=stop_hook_active  cwd 前提: repo 内
     | env AGENT_TOOLS_CHECKS_CONFIG="$conf" AGENT_TOOLS_QA_STATE_DIR="$tmp/qa-state" \
         HOME="$tmp/home" ruby "$qa_src"
 }
+assert_qa_warning() {
+  printf '%s' "$1" | ruby -rjson -e '
+    data = JSON.parse(STDIN.read)
+    abort "Stop warning must contain only a user-facing systemMessage" unless
+      data.is_a?(Hash) && data.keys == ["systemMessage"] &&
+      data["systemMessage"].is_a?(String) && !data["systemMessage"].empty?
+  ' || fail "warning must not request continuation: $1"
+}
 mkdir -p "$tmp/home"
 
 # ---- fast-edit-check ----------------------------------------------------------
@@ -146,7 +154,16 @@ out=$(cd "$repo" && run_qa false 2>/dev/null)
 rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "same failing scope must not re-block (rc=$rc)"
+assert_qa_warning "$out"
 echo "$out" | grep -q "未解消" || fail "should warn non-blockingly on cached failure: $out"
+
+# 継続後の Stop を繰り返しても、モデルへの追加 feedback を発行しない (#231)。
+: > "$tmp/check-argv.log"
+for attempt in 1 2; do
+  out=$(cd "$repo" && run_qa true) || fail "continued cached failure should exit 0"
+  assert_qa_warning "$out"
+done
+[ ! -s "$tmp/check-argv.log" ] || fail "cached failure should not rerun checks"
 
 # stop_hook_active=true では新 scope の失敗でも block しない
 echo again >> "$repo/base.txt"
@@ -155,20 +172,39 @@ out=$(cd "$repo" && run_qa true 2>/dev/null)
 rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "stop_hook_active must never block (rc=$rc)"
+assert_qa_warning "$out"
 echo "$out" | grep -q "再 block しません" || fail "should report failure non-blockingly: $out"
 rm "$tmp/check-fail"
 
-# check コマンド不在 -> 警告降格・block しない・cache しない
+# check コマンド不在 -> 警告降格・block しない・missing として再試行する
 ruby -rjson -e '
-File.write(ARGV[1], JSON.generate({ARGV[0] => {"qa_checks" => [{"name" => "gone", "command" => ["/nonexistent/check"]}]}}))
-' "$repo_real" "$conf"
+File.write(ARGV[1], JSON.generate({ARGV[0] => {"qa_checks" => [{"name" => "gone", "command" => [ARGV[2]]}]}}))
+' "$repo_real" "$conf" "$tmp/gone-check"
 echo yet >> "$repo/base.txt"
 set +e
 out=$(cd "$repo" && run_qa false 2>/dev/null)
 rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "missing check tool must not block (rc=$rc)"
+assert_qa_warning "$out"
 echo "$out" | grep -q "実行できません" || fail "missing tool should warn: $out"
+out=$(cd "$repo" && run_qa false) || fail "cached missing check should exit 0"
+assert_qa_warning "$out"
+
+# scope / 宣言を変えずに missing check を復旧すると、再試行して無言 pass へ戻る。
+cat > "$tmp/gone-check" <<EOF
+#!/bin/sh
+printf 'ran\n' >> "$tmp/gone-argv.log"
+exit 0
+EOF
+chmod +x "$tmp/gone-check"
+out=$(cd "$repo" && run_qa false) || fail "recovered check should pass"
+[ -z "$out" ] || fail "recovered check should be silent: $out"
+[ -s "$tmp/gone-argv.log" ] || fail "recovered check should run on the same scope"
+: > "$tmp/gone-argv.log"
+out=$(cd "$repo" && run_qa false) || fail "recovered cached pass should exit 0"
+[ -z "$out" ] || fail "recovered cached pass should be silent: $out"
+[ ! -s "$tmp/gone-argv.log" ] || fail "recovered cached pass should not rerun checks"
 
 # 宣言なし repo -> 無言 no-op
 out=$(cd "$other" && run_qa false) || fail "undeclared repo qa should exit 0"
@@ -237,6 +273,7 @@ out=$(cd "$repo" && run_qa false 2>/dev/null)
 rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "cache-hit must not re-block (rc=$rc)"
+assert_qa_warning "$out"
 [ -s "$tmp/later-argv.log" ] || fail "missing check must be retried on cache hit (R1)"
 echo "$out" | grep -q "未解消" || fail "unresolved failure should still be warned: $out"
 rm "$tmp/check-fail"
@@ -252,7 +289,16 @@ out=$(cd "$repo" && run_qa false 2>/dev/null)
 rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "EACCES must not block (rc=$rc)"
+assert_qa_warning "$out"
 echo "$out" | grep -q "実行できません" || fail "EACCES should warn as missing (R1): $out"
+
+# 不正な check 宣言しかない場合も、構成エラーはユーザー警告に留める。
+ruby -rjson -e '
+File.write(ARGV[1], JSON.generate({ARGV[0] => {"qa_checks" => [{"command" => "not-an-array"}]}}))
+' "$repo_real" "$conf"
+out=$(cd "$repo" && run_qa false) || fail "invalid check declaration should exit 0"
+assert_qa_warning "$out"
+echo "$out" | grep -q "設定エラー" || fail "invalid declaration should warn: $out"
 
 # ---- R1 回帰: fast-edit-check の不正 entry 可視化と総量 truncate ---------------
 ruby -rjson -e '

--- a/shared/scripts/personal-changed-scope-qa.asset.yml
+++ b/shared/scripts/personal-changed-scope-qa.asset.yml
@@ -14,7 +14,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:52ccd219a458112d3d8d0c0c2cbc645738d3a589a3905b001c1aef44a353c8d6
+  approved_build_id: sha256:0cd5a6d886e19a77fd9c651c745188ec10bb6e2839572f2e8a77755fbdea0713
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-changed-scope-qa.rb

--- a/shared/scripts/personal-changed-scope-qa.asset.yml
+++ b/shared/scripts/personal-changed-scope-qa.asset.yml
@@ -10,6 +10,7 @@ risk:
   privacy: low
 # script kind は実行コード配布のため常に human review 必須 (#147)。
 # 本 script は #203 (Phase 2) の実装 PR で author≠reviewer レビューのうえ承認。
+# Stop 警告経路の分離・実機検証・現行内容の再承認は PR #237 を参照。
 # 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:

--- a/shared/scripts/personal-changed-scope-qa.rb
+++ b/shared/scripts/personal-changed-scope-qa.rb
@@ -199,13 +199,9 @@ module ChangedScopeQa
     text.length > OUTPUT_CAP ? text[0, OUTPUT_CAP] + "\n…(truncated)" : text
   end
 
-  def emit_context(message)
-    puts JSON.generate(
-      "hookSpecificOutput" => {
-        "hookEventName" => "Stop",
-        "additionalContext" => truncate(message),
-      }
-    )
+  # Stop の additionalContext は Claude を再継続させる。警告はユーザーにだけ届ける。
+  def emit_warning(message)
+    puts JSON.generate("systemMessage" => truncate(message))
   end
 
   def failure_summary(failures)
@@ -214,7 +210,7 @@ module ChangedScopeQa
 
   # 同一 scope の cache hit。block は消費済みなので二度と block しない。
   # missing として保持した check だけ再試行し (環境が直れば拾う)、state を更新して
-  # [exit code, 非ブロッキング context (nil 可)] を返す。
+  # [exit code, ユーザー向け警告 (nil 可)] を返す。
   def handle_cached(root, fingerprint, state, checks)
     missing_names = state["missing"].is_a?(Array) ? state["missing"] : []
     return [0, nil] if state["outcome"] == "pass" && missing_names.empty?
@@ -262,7 +258,7 @@ module ChangedScopeQa
 
     code = gate(root, checks, already_continued, notes) unless checks.empty?
     code ||= 0
-    emit_context(notes.join("\n")) unless notes.empty? || code != 0
+    emit_warning(notes.join("\n")) unless notes.empty? || code != 0
     code
   rescue StandardError
     0 # fail-open: hook 内部の想定外でセッションを塞がない


### PR DESCRIPTION
同一 scope の失敗や check 起動失敗を、Stop の `additionalContext` ではなく `systemMessage` のユーザー向け警告で返します。初回 failure の exit 2、成功時 silent、cache と復旧時の再試行は維持します。

Closes #231

## 検証

- quality-loop-hooks 回帰テスト：旧実装で失敗、修正後 pass。cached failure、継続済み新 scope、missing/EACCES、同一 scope での復旧、不正宣言を検証。
- Claude Code 2.1.259 / `claude-opus-5`：warning・初回 block→再 Stop・success の native 3 ケース。応答数 1/2/1、warning notice は warning と再 Stop 時のみ各 1 回。
- Codex 0.153.4 / `gpt-6-astra`：同じ 3 ケースで Stop exit `0` / `2→0` / `0`、応答数 1/2/1。`exec` は警告を表示しなかったため、別 TUI で command 不在と失敗 scope cache の `Hook` 通知を実表示確認。各 1 応答で終了。
- 全 native ケースの対象 source を固定し、実 hook receipt と session trace を照合。モデルの tool 呼び出しなし。一時 project / 単独 hook の信頼設定は撤回し、他設定・hooks 不変を別 process で確認。
- Codex 起動時の既存 plugin timeout 調整 / optional Code Mode host 不在診断は記録。strict JSON verifier の初回 inconclusive と、後の手動 trace 照合を区別。
- quality-loop-hooks / register self-tests、manifest validation、build、register、diff check は pass。42 artifacts registered、human review required 0。

## レビュー

初回 Claude 独立レビューは must 0。指摘の native smoke と承認 hash を完了し、scope 指紋の説明と未 trust 時の古い「無警告」表記も修正しました。ユーザーのレビュー結果を条件とする作業・マージ承認に基づき、対象 script の canonical build_id を `sha256:0cd5a6d886e19a77fd9c651c745188ec10bb6e2839572f2e8a77755fbdea0713` に更新しています。

最終 head `1de166aa1e5e7bbc7baf76cdb46f33420690bf96` は Claude APPROVE（must 0 / should 0）、CI は両 Ruby 環境で成功、未解決 review thread 0。残る変更外 nit は #243 で対応済みです。実機確認は上記ケースに限定し、すべての配備環境や Codex exec の警告表示が確認済みとは主張しません。