### PR TITLE
fix: Codex apply_patch の変更ファイルを高速チェックする

### DIFF
--- a/docs/quality-loop-hooks.md
+++ b/docs/quality-loop-hooks.md
@@ -49,17 +49,27 @@
 - 宣言する check の目安: edit_checks は「1 ファイル・数百 ms」(編集のたびに同期実行)、
   qa_checks は「repo 全体で数秒・決定的」(Stop のたびに走りうる。決定性は cache の前提)。
 
-## personal-fast-edit-check(PostToolUse / `Edit|Write`)
+## personal-fast-edit-check(PostToolUse / `Edit|Write|apply_patch`)
 
-- payload の `tool_input.file_path` から対象ファイルを取り、その repo の `edit_checks` の
-  うち `pattern` (Ruby regex) がファイル名に一致するものを実行する。
+- Claude Code は `tool_input.file_path`、Codex は `tool_name: "apply_patch"` の
+  `tool_input.command` から対象を取る。Codex の成功判定は `PostToolUse` event に加え、
+  `tool_response` 文字列の先頭が `Exit code: 0` の行であることを確認する。
+- Codex の通常 patch (`*** Begin Patch` / `*** End Patch`) 全体を検査し、Add / Update の
+  対象、Move の移動先を `cwd` 基準の絶対 path にする。1 patch 内の重複は除き、Delete と
+  現存しないファイルは高速 check の対象外にする。各ファイルの repo の `edit_checks` の
+  うち `pattern` (Ruby regex) が一致するものだけを実行する。
+- 失敗した tool result、`cwd` 不在、壊れた / 未対応 patch は無言 skip。
+  shell wrapper や `*** Environment ID` による別環境指定を local path と推測しない。
 - 失敗時のみ `hookSpecificOutput.additionalContext` で失敗要約 (上限 2000 文字 /
   非 UTF-8 は scrub) をモデルに返す。成功は無言 (ノイズ規律)。
 - 設定ファイルが壊れているときは無言で握り潰さず、設定エラーを additionalContext で
   1 行知らせる (それでも exit 0)。
-- **Codex parity の honest-label**: Claude Code の payload 形 (`tool_input.file_path`) は
-  #201 実測済み。Codex (apply_patch) の payload 形は未実測で、file_path が取れなければ
-  無言 no-op に倒れる。配備時に実測して追従する。
+- **互換性の根拠**: [Codex Hooks](https://learn.chatgpt.com/docs/hooks#posttooluse)、
+  Codex 0.153.4 の [patch parser](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/apply-patch/src/parser.rs)、
+  [hook response](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/tools/context.rs)、
+  [出力形式](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/tools/mod.rs) に基づく。
+  Claude Code の payload は #201 実測済み。Codex はこの形式の fixture を stdin に渡して
+  check 実行と additionalContext を検証する。実機からモデルへの警告到達は別途 smoke が必要。
 
 ## personal-changed-scope-qa(Stop)
 

--- a/docs/quality-loop-hooks.md
+++ b/docs/quality-loop-hooks.md
@@ -73,8 +73,17 @@
   Codex 0.153.4 の [patch parser](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/apply-patch/src/parser.rs)、
   [hook response](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/tools/context.rs)、
   [出力形式](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/tools/mod.rs) に基づく。
-  Claude Code の payload は #201 実測済み。Codex はこの形式の fixture を stdin に渡して
-  check 実行と additionalContext を検証する。実機からモデルへの警告到達は別途 smoke が必要。
+  Claude Code の payload は #201 実測済み。Codex の複数 file / Add / Update / Delete /
+  Move / 不正 payload は stdin fixture で check 実行と additionalContext を検証する。
+- **Codex native smoke (2026-09-06 / #239)**: Codex 0.153.4 (公式同版 Code Mode host) /
+  `gpt-6-astra` で、1 ファイルへの実 `apply_patch` 2 回を観測した。最初の更新による
+  Ruby 構文エラーで check が 1 回失敗し、その場で生成した識別子を含む additionalContext が
+  モデルへ届いた。モデルが同じ識別子を返してファイルを修復し、次の check は 1 回成功して
+  無出力だった。実 hook payload・check receipt・session trace を照合し、他の tool 呼出しや
+  check / 観測 log の直接参照が無いことを確認した。
+  一時 project / hook の信頼設定は撤回し、別 process の readback で当該 permission の不在と
+  他設定・hooks の不変を確認した。実測はこの 1 ファイルの Update / repair に限る。
+  複数 file・Add / Delete / Move の native 実測や、全配備環境・モデル性能の検証ではない。
 
 ## personal-changed-scope-qa(Stop)
 
@@ -115,7 +124,7 @@
 - Stop の回帰テストは warning JSON に `systemMessage` だけがあり、継続を要求する
   field がないことを検証する。fixture 検証は実 runner の継続回数や UI 表示の観測ではない。
 - 実配線 (settings.json / hooks.json への登録・Codex payload / Stop の実測) は CI 外
-  (dotfiles 側 issue + 実機 smoke。実施記録は #203)。
+  (dotfiles 側 issue + 実機 smoke。実施記録は #203 / #237 / #239)。
 
 ### Stop の実機確認 (2026-09-06 / #237)
 

--- a/docs/quality-loop-hooks.md
+++ b/docs/quality-loop-hooks.md
@@ -58,10 +58,15 @@
   対象、Move の移動先を `cwd` 基準の絶対 path にする。1 patch 内の重複は除き、Delete と
   現存しないファイルは高速 check の対象外にする。各ファイルの repo の `edit_checks` の
   うち `pattern` (Ruby regex) が一致するものだけを実行する。
+  1 patch の対象ファイルごとに check を直列・同期実行するため、全体の待ち時間は
+  「対象ファイル数 × 一致する check の所要時間」に応じて増える。出力上限に達しても
+  後続の check は省略しない。
 - 失敗した tool result、`cwd` 不在、壊れた / 未対応 patch は無言 skip。
   shell wrapper や `*** Environment ID` による別環境指定を local path と推測しない。
 - 失敗時のみ `hookSpecificOutput.additionalContext` で失敗要約 (上限 2000 文字 /
   非 UTF-8 は scrub) をモデルに返す。成功は無言 (ノイズ規律)。
+  複数ファイルの失敗は repo 相対 path で対象を識別し、不正な check 宣言の警告は
+  同じ repo について 1 回だけ返す。
 - 設定ファイルが壊れているときは無言で握り潰さず、設定エラーを additionalContext で
   1 行知らせる (それでも exit 0)。
 - **互換性の根拠**: [Codex Hooks](https://learn.chatgpt.com/docs/hooks#posttooluse)、

--- a/scripts/tests/fast-edit-check-payload-test.rb
+++ b/scripts/tests/fast-edit-check-payload-test.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "tmpdir"
+
+script = File.expand_path(ARGV.fetch(0))
+require script
+
+def assert(condition, message)
+  raise message unless condition
+end
+
+def patch_payload(cwd, patch)
+  {
+    "hook_event_name" => "PostToolUse", "tool_name" => "apply_patch", "cwd" => cwd,
+    "tool_input" => { "command" => patch },
+    "tool_response" => "Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess. Updated files.\n",
+  }
+end
+
+Dir.mktmpdir("fast-edit-payload-") do |tmp|
+  repo = File.join(tmp, "repo with spaces")
+  other = File.join(tmp, "undeclared")
+  [repo, other].each { |path| assert(system("git", "init", "-q", path), "git init failed") }
+  repo = File.realpath(repo)
+  FileUtils.mkdir_p(File.join(repo, "nested"))
+  %w[a.rb new.rb old.rb moved.rb deleted.rb untouched.rb].each do |name|
+    File.write(File.join(repo, name), "puts 1\n")
+  end
+  unusual_name = "名前 $(literal).rb"
+  File.write(File.join(repo, unusual_name), "puts 1\n")
+  File.write(File.join(other, "other.rb"), "puts 1\n")
+  log = File.join(tmp, "checks.jsonl")
+  checker = File.join(tmp, "check.rb")
+  File.write(checker, <<~'RUBY')
+    require "json"
+    File.open(ENV.fetch("AGENT_TOOLS_TEST_CHECK_LOG"), "a") do |f|
+      f.puts JSON.generate({ "argv" => ARGV, "cwd" => Dir.pwd })
+    end
+    if ENV["AGENT_TOOLS_TEST_CHECK_FAIL"] == "1"
+      STDOUT.write("lint failure " + "\xff" * 2500)
+      exit 1
+    end
+  RUBY
+  config = File.join(tmp, "checks.json")
+  File.write(config, JSON.generate({ repo => { "edit_checks" => [
+    { "name" => "fixture-lint", "pattern" => "\\.rb$", "command" => [RbConfig.ruby, checker] },
+  ] } }))
+
+  invoke = lambda do |payload, fail_check = false|
+    File.write(log, "")
+    out, err, status = Open3.capture3(
+      { "AGENT_TOOLS_CHECKS_CONFIG" => config, "AGENT_TOOLS_TEST_CHECK_LOG" => log,
+        "AGENT_TOOLS_TEST_CHECK_FAIL" => fail_check ? "1" : "0" },
+      RbConfig.ruby, script, stdin_data: JSON.generate(payload), chdir: other
+    )
+    assert(status.success?, "hook must fail open: #{err}")
+    calls = File.readlines(log).map { |line| JSON.parse(line) }
+    [out, calls]
+  end
+
+  patch = <<~PATCH
+    *** Begin Patch
+    *** Update File: a.rb
+    @@
+    -puts 0
+    +puts 1
+    @@ second chunk
+     unchanged
+    +added
+    *** End of File
+    *** Add File: new.rb
+    +*** Update File: untouched.rb
+    +literal file content, not another patch header
+    *** Update File: old.rb
+    *** Move to: moved.rb
+    @@
+    -old
+    +new
+    *** Delete File: deleted.rb
+    *** Update File: ./a.rb
+    @@
+    -puts 0
+    +puts 1
+    *** Update File: #{unusual_name}
+    @@
+    -old
+    +new
+    *** End Patch
+  PATCH
+  payload = patch_payload(repo, patch)
+  out, calls = invoke.call(payload)
+  expected = ["a.rb", "new.rb", "moved.rb", unusual_name].map { |name| File.join(repo, name) }
+  assert(out.empty?, "passing checks must be silent")
+  assert(calls.map { |call| call["argv"] } == expected.map { |path| [path] },
+         "check each existing destination once, preserve a path as one argument")
+  assert(calls.all? { |call| call["cwd"] == repo }, "checks must run from each declared repo root")
+
+  blank_context = <<~PATCH
+    *** Begin Patch
+    *** Update File: a.rb
+    @@
+    -puts 0
+    +puts 1
+
+     unchanged
+    *** End Patch
+  PATCH
+  out, calls = invoke.call(patch_payload(repo, blank_context))
+  assert(out.empty? && calls.map { |call| call["argv"] } == [[expected.first]],
+         "Codex accepts an empty context line without the space prefix")
+
+  out, calls = invoke.call(payload, true)
+  context = JSON.parse(out).fetch("hookSpecificOutput")
+  assert(context["hookEventName"] == "PostToolUse", "feedback must reach PostToolUse additionalContext")
+  message = context.fetch("additionalContext")
+  assert(message.include?("fixture-lint") && message.include?("lint failure"), "failed check must be identified")
+  assert(message.valid_encoding? && message.length <= FastEditCheck::OUTPUT_CAP + 20,
+         "multi-file failures must share the existing total output cap and UTF-8 scrub")
+  assert(calls.length == expected.length, "output cap must not skip later checks")
+  assert(!JSON.parse(out).key?("decision"), "feedback must not block edits")
+
+  relative = patch_payload(File.join(repo, "nested"), <<~PATCH)
+    *** Begin Patch
+    *** Update File: ../a.rb
+    @@
+    -old
+    +new
+    *** Update File: #{File.join(repo, "new.rb")}
+    @@
+    -old
+    +new
+    *** Update File: ../missing.rb
+    @@
+    -old
+    +new
+    *** Update File: #{File.join(other, "other.rb")}
+    @@
+    -old
+    +new
+    *** End Patch
+  PATCH
+  out, calls = invoke.call(relative)
+  assert(out.empty?, "passing relative-path checks must be silent")
+  assert(calls.map { |call| call["argv"] } == expected.first(2).map { |path| [path] },
+         "resolve paths against payload cwd, skip absent files and undeclared repos")
+
+  # Claude Code keeps its existing file_path contract, without Codex response metadata.
+  %w[Write Edit].each do |tool|
+    out, calls = invoke.call({ "tool_name" => tool, "tool_input" => { "file_path" => expected.first } })
+    assert(out.empty? && calls.map { |call| call["argv"] } == [[expected.first]], "Claude #{tool} regressed")
+  end
+
+  invalid_payloads = [nil, [], {}, payload.merge("tool_input" => []),
+                      payload.merge("hook_event_name" => "PreToolUse"),
+                      payload.merge("cwd" => nil), payload.merge("cwd" => "relative"),
+                      payload.merge("cwd" => File.join(tmp, "absent"))]
+  [nil, true, { "success" => true }, "Success", "Exit code: 1\nExit code: 0\n",
+   "Exit code: 01\n", "patch rejected by user"].each do |response|
+    invalid_payloads << payload.merge("tool_response" => response)
+  end
+  invalid_patches = [nil, [], "", "not a patch", patch.sub("*** End Patch", ""),
+                     patch + "unexpected trailer\n", patch.sub("*** Begin Patch", "*** Begin Patch\n*** Environment ID: remote"),
+                     "*** Begin Patch\n*** Add File: a.rb\nnot added content\n*** End Patch",
+                     "*** Begin Patch\n*** Delete File: a.rb\n+content\n*** End Patch",
+                     "*** Begin Patch\n*** Update File: a.rb\n*** Move to: new.rb\n*** End Patch",
+                     "*** Begin Patch\n*** Update File: a.rb\n@@\n*** End Patch",
+                     "*** Begin Patch\n*** Update File: a.rb\n@@\n+new\n@@\n*** End Patch",
+                     "*** Begin Patch\n*** Update File: a.rb\n*** End of File\n+new\n*** End Patch",
+                     "*** Begin Patch\n*** Add File: a.rb\n+new\n*** Unexpected\n*** End Patch"]
+  invalid_patches.each { |command| invalid_payloads << payload.merge("tool_input" => { "command" => command }) }
+  invalid_payloads.each_with_index do |bad, i|
+    out, calls = invoke.call(bad)
+    assert(out.empty? && calls.empty?, "invalid/failed payload #{i} must silently skip all checks")
+  end
+end
+
+puts "ok: fast-edit-check payload adapter"

--- a/scripts/tests/fast-edit-check-payload-test.rb
+++ b/scripts/tests/fast-edit-check-payload-test.rb
@@ -42,6 +42,9 @@ Dir.mktmpdir("fast-edit-payload-") do |tmp|
     if ENV["AGENT_TOOLS_TEST_CHECK_FAIL"] == "1"
       STDOUT.write("lint failure " + "\xff" * 2500)
       exit 1
+    elsif ENV["AGENT_TOOLS_TEST_CHECK_FAIL"] == "short"
+      puts "brief lint failure"
+      exit 1
     end
   RUBY
   config = File.join(tmp, "checks.json")
@@ -53,7 +56,7 @@ Dir.mktmpdir("fast-edit-payload-") do |tmp|
     File.write(log, "")
     out, err, status = Open3.capture3(
       { "AGENT_TOOLS_CHECKS_CONFIG" => config, "AGENT_TOOLS_TEST_CHECK_LOG" => log,
-        "AGENT_TOOLS_TEST_CHECK_FAIL" => fail_check ? "1" : "0" },
+        "AGENT_TOOLS_TEST_CHECK_FAIL" => fail_check == "short" ? "short" : (fail_check ? "1" : "0") },
       RbConfig.ruby, script, stdin_data: JSON.generate(payload), chdir: other
     )
     assert(status.success?, "hook must fail open: #{err}")
@@ -121,6 +124,39 @@ Dir.mktmpdir("fast-edit-payload-") do |tmp|
          "multi-file failures must share the existing total output cap and UTF-8 scrub")
   assert(calls.length == expected.length, "output cap must not skip later checks")
   assert(!JSON.parse(out).key?("decision"), "feedback must not block edits")
+
+  # A multi-file patch reports one config error per repo and identifies same-name targets.
+  %w[lib test].each do |dir|
+    FileUtils.mkdir_p(File.join(repo, dir))
+    File.write(File.join(repo, dir, "a.rb"), "puts 1\n")
+  end
+  same_names = patch_payload(repo, <<~PATCH)
+    *** Begin Patch
+    *** Update File: lib/a.rb
+    @@
+    -old
+    +new
+    *** Update File: test/a.rb
+    @@
+    -old
+    +new
+    *** End Patch
+  PATCH
+  valid_config = File.read(config)
+  invalid_config = JSON.parse(valid_config)
+  invalid_config.fetch(repo).fetch("edit_checks") << {
+    "name" => "invalid-regex", "pattern" => "[", "command" => [RbConfig.ruby, checker],
+  }
+  File.write(config, JSON.generate(invalid_config))
+  out, calls = invoke.call(same_names, "short")
+  message = JSON.parse(out).fetch("hookSpecificOutput").fetch("additionalContext")
+  assert(message.scan("不正な check 宣言を無視しました").length == 1,
+         "a repo config error must not repeat for each edited file")
+  assert(message.include?("lib/a.rb への編集") && message.include?("test/a.rb への編集"),
+         "multi-file failures with the same basename must identify their repo-relative paths")
+  assert(calls.length == 2 && message.scan("brief lint failure").length == 2,
+         "invalid config entries must not hide valid check failures")
+  File.write(config, valid_config)
 
   relative = patch_payload(File.join(repo, "nested"), <<~PATCH)
     *** Begin Patch

--- a/scripts/tests/quality-loop-hooks-test.sh
+++ b/scripts/tests/quality-loop-hooks-test.sh
@@ -322,4 +322,6 @@ echo "$out" | grep -q "broken-re" || fail "broken regex entry should be named: $
 [ "${#out}" -lt 3500 ] || fail "total output should be capped (R1): length=${#out}"
 echo "$out" | grep -q "truncated" || fail "total cap should be visible: $out"
 
+ruby "$script_dir/fast-edit-check-payload-test.rb" "$edit_src"
+
 echo "ok: quality-loop-hooks self-test"

--- a/shared/scripts/personal-fast-edit-check.asset.yml
+++ b/shared/scripts/personal-fast-edit-check.asset.yml
@@ -20,7 +20,7 @@ source:
   path: shared/scripts/personal-fast-edit-check.rb
   format: text
 summary: >-
-  PostToolUse (Edit|Write) hook body。編集直後の変更ファイル 1 個に、ユーザー所有の中央
+  PostToolUse (Edit|Write|apply_patch) hook body。編集直後の変更ファイルに、ユーザー所有の中央
   local 設定 (checks.local.json) で宣言された高速 check を実行し、失敗要約だけを
   additionalContext で返す steering (fail-open・block しない・自動 fix しない)。宣言の
   無い repo では無言 no-op。repo 内の宣言は読まない (第三者 repo の任意コマンド宣言を

--- a/shared/scripts/personal-fast-edit-check.asset.yml
+++ b/shared/scripts/personal-fast-edit-check.asset.yml
@@ -10,11 +10,13 @@ risk:
   privacy: low
 # script kind は実行コード配布のため常に human review 必須 (#147)。
 # 本 script は #203 (Phase 2) の実装 PR で author≠reviewer レビューのうえ承認。
+# #239 の Codex adapter は Claude 独立レビューと native smoke 後、ユーザーの条件付き
+# 作業・マージ承認に基づき内容紐づけ承認を更新。AI review 単独による承認ではない。
 # 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:2ed788f160bc923d9cbe1098c29edf26bda61c6b34cad8e21b94ad77f4403fe0
+  approved_build_id: sha256:010ef36e9b3dfd7972c13f4d9d8889a15e45be5c973b7af746b362d11c67dbde
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-fast-edit-check.rb

--- a/shared/scripts/personal-fast-edit-check.rb
+++ b/shared/scripts/personal-fast-edit-check.rb
@@ -214,21 +214,24 @@ module FastEditCheck
     end
 
     parts = []
+    reported_config_errors = {}
     files.each do |file|
       repo_root = repo_root_for(file)
       next if repo_root.nil?
 
       entry = config[repo_root]
       checks, invalid = entry ? checks_for(entry, file) : [[], []]
-      unless invalid.empty?
+      unless invalid.empty? || reported_config_errors[repo_root]
         parts << "fast-edit-check: 設定エラー: 不正な check 宣言を無視しました: " \
                  "#{invalid.join(', ')} (#{config_path})"
+        reported_config_errors[repo_root] = true
       end
 
       failures = checks.map { |c| run_check(c, file, repo_root) }.reject { |r| r[:ok] }
       unless failures.empty?
         body = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
-        parts << "fast-edit-check: #{File.basename(file)} への編集が repo 宣言の check に失敗しました。" \
+        label = files.length > 1 ? file.delete_prefix(repo_root + File::SEPARATOR) : File.basename(file)
+        parts << "fast-edit-check: #{label} への編集が repo 宣言の check に失敗しました。" \
                  "いま直してください (自動修正はしません):\n#{body}"
       end
     end

--- a/shared/scripts/personal-fast-edit-check.rb
+++ b/shared/scripts/personal-fast-edit-check.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# fast-edit-check: PostToolUse (Edit|Write) hook body。編集直後の変更ファイル 1 個に
+# fast-edit-check: PostToolUse (Edit|Write|apply_patch) hook body。編集直後の変更ファイルに
 # repo 宣言済みの高速 check (syntax / lint) を実行し、失敗要約だけを
 # hookSpecificOutput.additionalContext でモデルに返す steering hook (#200 §4.4 / #203)。
 # 「書いた直後に機械が指摘 → その場で直す」ループの機械判定部分を担う。
@@ -33,9 +33,8 @@
 #   edit_checks は「1 ファイル・数百 ms」の高速 check だけを宣言する (PostToolUse は編集の
 #   たびに同期で走る)。
 #
-# payload 互換: Claude Code の PostToolUse payload (tool_input.file_path) は #201 で実測済み。
-# Codex (apply_patch) の payload 形は未実測で、file_path が取れない場合は無言 no-op に
-# 倒れる (fail-open)。配備時に実測して追従する (honest-label)。
+# payload 互換: Claude Code は tool_input.file_path、Codex は成功した apply_patch の
+# tool_input.command を読む。未知の payload / patch は無言 no-op (fail-open)。
 
 require "json"
 
@@ -52,6 +51,77 @@ module FastEditCheck
 
   def config_path
     ENV[CONFIG_PATH_ENV].to_s.empty? ? DEFAULT_CONFIG : ENV[CONFIG_PATH_ENV]
+  end
+
+  def valid_update_body?(lines)
+    has_lines = false
+    lines.each_with_index do |line, i|
+      if line == "*** End of File"
+        return false unless has_lines && i == lines.length - 1
+      elsif line == "@@" || line.start_with?("@@ ")
+        return false if i.positive? && !has_lines
+
+        has_lines = false
+      else
+        return false unless line.empty? || line.match?(/\A[ +\-]/)
+
+        has_lines = true
+      end
+    end
+    has_lines
+  end
+
+  # 完全な通常 patch だけを解釈する。patch を実行したり、未知の shell wrapper / remote
+  # environment を local cwd と推定したりしない。解釈不能なら全体を skip する。
+  def patch_paths(command)
+    return [] unless command.is_a?(String) && !command.include?("\0")
+
+    lines = command.strip.lines(chomp: true)
+    return [] unless lines.shift == "*** Begin Patch" && lines.pop == "*** End Patch"
+
+    paths = []
+    until lines.empty?
+      header = lines.shift.match(/\A\*\*\* (Add|Update|Delete) File: (\S.*)\z/)
+      return [] unless header
+
+      operation, path = header.captures
+      if operation == "Update" && lines.first.to_s.start_with?("*** Move to: ")
+        move = lines.shift.match(/\A\*\*\* Move to: (\S.*)\z/)
+        return [] unless move
+
+        path = move[1]
+      end
+      body = []
+      body << lines.shift until lines.empty? || lines.first.match?(/\A\*\*\* (?:Add|Update|Delete) File: /)
+      valid = case operation
+              when "Add" then body.all? { |line| line.start_with?("+") }
+              when "Update" then valid_update_body?(body)
+              when "Delete" then body.empty?
+              end
+      return [] unless valid
+
+      paths << path unless operation == "Delete"
+    end
+    paths
+  end
+
+  def edited_files(payload)
+    return [] unless payload.is_a?(Hash) && payload["tool_input"].is_a?(Hash)
+
+    if payload["tool_name"] == "apply_patch"
+      response = payload["tool_response"]
+      cwd = payload["cwd"]
+      # Codex 0.153.4 の ApplyPatchToolOutput は exit status を先頭に持つ文字列。
+      # PostToolUse という event 名だけで成功したと推定しない。
+      return [] unless payload["hook_event_name"] == "PostToolUse" &&
+                       response.is_a?(String) && response.start_with?("Exit code: 0\n") &&
+                       cwd.is_a?(String) && cwd.start_with?(File::SEPARATOR) && File.directory?(cwd)
+
+      files = patch_paths(payload["tool_input"]["command"]).map { |path| File.absolute_path(path, cwd) }
+    else
+      files = [payload["tool_input"]["file_path"]]
+    end
+    files.select { |file| file.is_a?(String) && File.file?(file) }.uniq
   end
 
   # 設定を読む。無い = opt-in していない (nil)。壊れている = 警告文字列を返す
@@ -133,8 +203,8 @@ module FastEditCheck
 
   def run
     payload = JSON.parse($stdin.read)
-    file = payload.dig("tool_input", "file_path")
-    return 0 unless file.is_a?(String) && File.file?(file)
+    files = edited_files(payload)
+    return 0 if files.empty?
 
     config = load_config
     return 0 if config.nil?
@@ -143,23 +213,24 @@ module FastEditCheck
       return 0
     end
 
-    repo_root = repo_root_for(file)
-    return 0 if repo_root.nil?
-
-    entry = config[repo_root]
-    checks, invalid = entry ? checks_for(entry, file) : [[], []]
-
     parts = []
-    unless invalid.empty?
-      parts << "fast-edit-check: 設定エラー: 不正な check 宣言を無視しました: " \
-               "#{invalid.join(', ')} (#{config_path})"
-    end
+    files.each do |file|
+      repo_root = repo_root_for(file)
+      next if repo_root.nil?
 
-    failures = checks.map { |c| run_check(c, file, repo_root) }.reject { |r| r[:ok] }
-    unless failures.empty?
-      body = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
-      parts << "fast-edit-check: #{File.basename(file)} への編集が repo 宣言の check に失敗しました。" \
-               "いま直してください (自動修正はしません):\n#{body}"
+      entry = config[repo_root]
+      checks, invalid = entry ? checks_for(entry, file) : [[], []]
+      unless invalid.empty?
+        parts << "fast-edit-check: 設定エラー: 不正な check 宣言を無視しました: " \
+                 "#{invalid.join(', ')} (#{config_path})"
+      end
+
+      failures = checks.map { |c| run_check(c, file, repo_root) }.reject { |r| r[:ok] }
+      unless failures.empty?
+        body = failures.map { |r| "[#{r[:name]}]\n#{truncate(r[:output])}" }.join("\n")
+        parts << "fast-edit-check: #{File.basename(file)} への編集が repo 宣言の check に失敗しました。" \
+                 "いま直してください (自動修正はしません):\n#{body}"
+      end
     end
     return 0 if parts.empty?
 


### PR DESCRIPTION
Codex の成功した `apply_patch` payload から変更対象を抽出し、編集直後の check を実行します。Add / Update / Move と複数 file を扱い、Delete・失敗 payload・解釈できない patch は無言 skip します。Claude の file_path 経路、失敗要約の上限、fail-open を維持し、設定エラーの重複と同名 file の曖昧な診断も解消します。

Closes #232

## 検証・レビュー

- payload fixture と quality-loop-hooks tests：対象抽出、check 実行 / skip、additionalContext の有無、出力上限、既存 Claude 経路を検証。
- Codex 0.153.4 / `gpt-6-astra` の native 実測：1 file の実 apply_patch → Ruby syntax failure → ランダム receipt を含む feedback → モデルの修正 → silent pass。実 tool は apply_patch 2 回のみで、実 hook input と native session を照合。一時 trust は撤回し、他設定・hooks 不変を確認。
- native 実測は上記の Update / repair に限定。Add / Delete / Move / multi-file の全 native 経路や全配備環境は検証済みとしない。通常の配線は dotfiles 側の管理。
- source はレビュー・実測した `be241b9` から byte 不変。ユーザーの条件付き承認に基づき canonical build_id `sha256:010ef36e9b3dfd7972c13f4d9d8889a15e45be5c973b7af746b362d11c67dbde` を manifest に反映し、#239 の参照を記録。
- local checks / build / register / register-test が成功。42 artifacts registered、human review required 0。
- 最終 head `1dbb1a86bad5c6bde6379cea47ec5b110f670290` は Claude APPROVE（must 0 / should 0 / 任意 nit 1）。同 head の CI は system Ruby / Ruby 3.4 とも成功、未解決 review thread 0。

#237 の trust 記述と Stop 実機記録は保持しています。