### PR TITLE
fix: Codex skill の必須 frontmatter を登録前に検証する

### DIFF
--- a/adapters/claude-code/README.md
+++ b/adapters/claude-code/README.md
@@ -29,6 +29,10 @@ generated/claude-code/scripts/
   YAML frontmatter を持たない場合のみ、manifest の `name` と `summary` から frontmatter を
   生成する。directory asset は `asset.yml` と source-only dir (現状 `evals/`) を除く
   全 files を copy する (非配置 dir は build_id にも含めない)。
+  既存 frontmatter は directory / 単一 source とも YAML と manifest name の一致を検証する。
+  Claude-only skill は frontmatter 不在・description 省略を許可する。Codex にも skill として
+  配る場合は Codex の必須項目を満たす必要がある。詳細は
+  [Asset Manifest Schema](../../docs/asset-manifest-schema.md)。
 - **instruction**: 単一ファイルを `CLAUDE.md` に生成し、本体先頭に 1 行コメント marker を
   付ける。directory 形式の instruction は非対応。
 - **script**: 単一実行ファイルを byte 保持で copy し (mode 0755)、隣に sidecar marker を

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -29,6 +29,10 @@ generated/codex/scripts/
   YAML frontmatter を持たない場合のみ、manifest の `name` と `summary` から frontmatter を
   生成する。directory asset は `asset.yml` と source-only dir (現状 `evals/`) を除く
   全 files を copy する (非配置 dir は build_id にも含めない)。
+  Codex に skill として配る source の既存 frontmatter は、manifest と一致する `name` と
+  非空 string の `description` を登録前に検証する。directory の frontmatter 不在は拒否し、
+  単一 source の frontmatter 不在は上記の生成経路を使う。詳細は
+  [Asset Manifest Schema](../../docs/asset-manifest-schema.md)。
 - **instruction**: 単一ファイルを `AGENTS.md` に生成し、本体先頭に 1 行コメント marker を
   付ける。directory 形式の instruction は非対応。
 - **script**: 単一実行ファイルを byte 保持で copy し (mode 0755)、隣に sidecar marker を

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -34,9 +34,9 @@ shared/skills/personal-example/
   evals/           # 任意。source として版管理するが配置先には載せない
 ```
 
-### directory skill の Phase 1 制約
+### skill source の制約
 
-skill を directory 形式で持つときの配置・安全ルール (Phase 1):
+directory 形式の配置ルールと、両 source 形式に共通する frontmatter 契約 (Phase 1):
 
 - `SKILL.md` / `references/` / `assets/` は配置先 (`<tool home>/skills/personal-<name>/`)
   に載せる (ランタイム skill の一部)。
@@ -77,7 +77,7 @@ skill を directory 形式で持つときの配置・安全ルール (Phase 1):
   その asset 自身の manifest 以外の manifest を置くと fail-closed で拒否する (子 asset が独立
   配布されつつ親の evals/ 抑止で injection check を回避する経路を断つ)。
 
-asset 本体に frontmatter を埋め込まない理由:
+manifest metadata を asset 本体の frontmatter と分ける理由:
 
 - target tool が独自 frontmatter を持つ可能性がある。
 - shared metadata と target-specific metadata を混ぜない。
@@ -213,6 +213,7 @@ rules:
 - absolute path は禁止。
 - private planning tool の URL は書かない。
 - source path は `shared/` 配下に置く。
+- skill に生成する source は、形式によらず上記の [skill source の制約](#skill-source-の制約) に従う。
 
 ## Optional fields
 

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -70,7 +70,9 @@ skill を directory 形式で持つときの配置・安全ルール (Phase 1):
   [Claude Code の省略規則](https://code.claude.com/docs/en/skills#frontmatter-reference) に沿い、
   Claude-only skill の frontmatter 不在・description 省略は許可する。判定は manifest の
   kind ではなく target ごとの解決済み artifact_kind に従い、instruction / script は対象外。
-  build / register はこの静的検証を共有する。runtime loader を起動した検証ではない。
+  build / register はこの静的検証を共有する。根拠は 2026-09-06 に確認した上記公式契約:
+  Claude Code は全 frontmatter field が任意で、name の省略時は directory 名、description の
+  省略時は本文の先頭段落を使う。runtime loader を起動した検証ではない。
 - **asset source の入れ子・重複所有を禁止**する (#177 H-01)。directory asset の source dir 配下に
   その asset 自身の manifest 以外の manifest を置くと fail-closed で拒否する (子 asset が独立
   配布されつつ親の evals/ 抑止で injection check を回避する経路を断つ)。

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -59,11 +59,18 @@ skill を directory 形式で持つときの配置・安全ルール (Phase 1):
 - **directory skill は `SKILL.md` を entrypoint として必須**にする (#187 M-01)。build は
   directory skill の `SKILL.md` を無改変でコピーする (単一ファイル skill と違い frontmatter を
   生成しない) ため、無いと entrypoint 欠落の inert skill が配布される。
-- **`SKILL.md` の frontmatter `name` は manifest name と一致必須** (#187 M-01)。build が
-  `SKILL.md` を無改変で配るので、frontmatter で別 identity / 広域 trigger を宣言すると「レビュー
-  された identity ≠ 実配備 identity」になる。frontmatter が在る (先頭が `---`) のに閉じ marker
-  欠落 / YAML parse 不能 (alias 等) / 非 mapping / name 欠落なら **fail-closed** で拒否する
-  (validator が読めない frontmatter を target parser が別 identity として解決する差を塞ぐ)。
+- **skill の既存 frontmatter `name` は manifest name と一致必須** (#187 M-01, #234)。
+  directory の `SKILL.md` と、既存 frontmatter を持つ単一 source に共通で適用する。
+  frontmatter が在る (先頭が `---` 行) のに閉じ marker 欠落 / YAML parse 不能 (alias 等) /
+  非 mapping / name 欠落・空・型不正なら **fail-closed** で拒否する。LF / CRLF に対応する。
+- **Codex に skill として生成する場合、非空 string の `description` も必須** (#234)。
+  [Codex の skill 契約](https://learn.chatgpt.com/docs/build-skills) に合わせ、frontmatter の無い
+  directory skill は拒否する。frontmatter の無い単一 source は既存どおり build が manifest の
+  name と summary (無ければ description、さらに無ければ name) から補完する。
+  [Claude Code の省略規則](https://code.claude.com/docs/en/skills#frontmatter-reference) に沿い、
+  Claude-only skill の frontmatter 不在・description 省略は許可する。判定は manifest の
+  kind ではなく target ごとの解決済み artifact_kind に従い、instruction / script は対象外。
+  build / register はこの静的検証を共有する。runtime loader を起動した検証ではない。
 - **asset source の入れ子・重複所有を禁止**する (#177 H-01)。directory asset の source dir 配下に
   その asset 自身の manifest 以外の manifest を置くと fail-closed で拒否する (子 asset が独立
   配布されつつ親の evals/ 抑止で injection check を回避する経路を断つ)。

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -452,14 +452,11 @@ module CheckManifests
 
       # directory skill は SKILL.md を entrypoint として必ず持つ (M-01)。build は directory
       # skill の SKILL.md を生成しない (copy_directory_asset が verbatim コピー) ため、無いと
-      # entrypoint 欠落の inert skill が配布される。さらに SKILL.md の frontmatter name は
-      # manifest name と一致必須にする: build が SKILL.md を無改変で配るので、frontmatter で
-      # 別 identity / 広域 trigger を宣言すると「レビューされた identity ≠ 実配備 identity」に
-      # なる (#43 の外部 skill 配布で効く供給側ギャップ)。
+      # entrypoint 欠落の inert skill が配布される。frontmatter は validate_source が成功した
+      # 後に target 別の共通入口で検証する。
       skill_md = File.join(dir, "SKILL.md")
       unless File.file?(skill_md)
         error(path, "directory skill must contain a SKILL.md entrypoint")
-        return
       end
     end
 
@@ -488,6 +485,8 @@ module CheckManifests
 
     # 既存 frontmatter は両 source 形式とも無改変で配るため同じ境界で検証する。
     # 無い単一 source は build が補完するが、directory は補完されず Codex では必須。
+    # frontmatter で別 identity を宣言すると「レビューされた identity ≠ 実配備 identity」に
+    # なるため、manifest name との一致を必須にする (#43 の外部 skill 配布で効く供給側ギャップ)。
     # YAML を読めない場合は target parser との identity 解釈差を fail-closed で止める。
     def validate_skill_frontmatter(path, skill_md, manifest_name, required:, require_description:)
       content = File.read(skill_md)

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -484,42 +484,46 @@ module CheckManifests
     end
 
     # 既存 frontmatter は両 source 形式とも無改変で配るため同じ境界で検証する。
+    # 開始 marker は Build::Runner#skill_markdown と同じ LF / CRLF 判定を保つ。
     # 無い単一 source は build が補完するが、directory は補完されず Codex では必須。
+    # frontmatter 不在は source による identity 主張が無く、Claude-only directory は
+    # loader が directory 名へ fallback するため name 照合を行わない。
     # frontmatter で別 identity を宣言すると「レビューされた identity ≠ 実配備 identity」に
     # なるため、manifest name との一致を必須にする (#43 の外部 skill 配布で効く供給側ギャップ)。
     # YAML を読めない場合は target parser との identity 解釈差を fail-closed で止める。
     def validate_skill_frontmatter(path, skill_md, manifest_name, required:, require_description:)
+      source_path = rel(skill_md)
       content = File.read(skill_md)
       unless content.start_with?("---\n", "---\r\n")
-        error(path, "Codex SKILL.md must contain YAML frontmatter with name and description") if required
+        error(path, "Codex #{source_path} must contain YAML frontmatter with name and description") if required
         return
       end
 
       parts = content.sub(/\A---\r?\n/, "").split(/^---\r?\n/, 2)
       if parts.length < 2
-        error(path, "SKILL.md frontmatter is missing its closing --- marker")
+        error(path, "#{source_path} frontmatter is missing its closing --- marker")
         return
       end
       fm = begin
         YamlUtil.load(parts[0], skill_md)
       rescue Psych::Exception => e
-        error(path, "SKILL.md frontmatter has a YAML error: #{e.message}")
+        error(path, "#{source_path} frontmatter has a YAML error: #{e.message}")
         return
       end
       unless fm.is_a?(Hash)
-        error(path, "SKILL.md frontmatter must be a YAML mapping")
+        error(path, "#{source_path} frontmatter must be a YAML mapping")
         return
       end
       fm_name = fm["name"]
       unless fm_name.is_a?(String) && !fm_name.strip.empty?
-        error(path, "SKILL.md frontmatter must declare a non-empty string name")
+        error(path, "#{source_path} frontmatter must declare a non-empty string name")
         return
       end
       if manifest_name.is_a?(String) && fm_name != manifest_name
-        error(path, "SKILL.md frontmatter name #{fm_name.inspect} does not match manifest name #{manifest_name.inspect}")
+        error(path, "#{source_path} frontmatter name #{fm_name.inspect} does not match manifest name #{manifest_name.inspect}")
       end
       if require_description && !(fm["description"].is_a?(String) && !fm["description"].strip.empty?)
-        error(path, "Codex SKILL.md frontmatter must declare a non-empty string description")
+        error(path, "Codex #{source_path} frontmatter must declare a non-empty string description")
       end
     end
 

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -106,7 +106,11 @@ module CheckManifests
       validate_visibility(path, data["visibility"]) if data.key?("visibility")
       validate_targets(path, data["targets"]) if data.key?("targets")
       validate_risk(path, data["risk"]) if data.key?("risk")
-      validate_source(path, data["source"]) if data.key?("source")
+      if data.key?("source")
+        source_error_count = @errors.size
+        validate_source(path, data["source"])
+        check_skill_frontmatter(data, path) if @errors.size == source_error_count
+      end
       validate_review(path, data["review"]) if data.key?("review")
       validate_compatibility(path, data["compatibility"]) if data.key?("compatibility")
       validate_text_field(path, "summary", data["summary"]) if data.key?("summary")
@@ -457,19 +461,40 @@ module CheckManifests
         error(path, "directory skill must contain a SKILL.md entrypoint")
         return
       end
-      validate_skill_frontmatter_name(path, skill_md, data["name"])
     end
 
-    # SKILL.md 先頭の YAML frontmatter name を manifest name と照合する。
-    # frontmatter が **無ければ** identity を主張していない (target も dir 名等に fallback する)
-    # ので照合しない。frontmatter が **在る** (build と同じ start_with?("---\n","---\r\n") 判定)
-    # 場合は fail-closed で読む: 閉じ marker 欠落 / YAML parse 失敗 (alias 含む) / 非 mapping /
-    # name が非空 String でない — をすべて error にする (CM-181-02)。build は directory skill の
-    # SKILL.md を無改変で配るため、validator が読めない frontmatter を target parser が別 identity
-    # として解決する差 (alias 等) を fail-open で通すと identity bypass になる。
-    def validate_skill_frontmatter_name(path, skill_md, manifest_name)
+    # source の検証後だけ呼び、未検証 path や symlink の先を読まない。
+    # kind ではなく生成先で判定し、Codex の instruction には skill の必須項目を課さない。
+    def check_skill_frontmatter(data, path)
+      targets = data["targets"]
+      return unless targets.is_a?(Array)
+
+      asset = { kind: data["kind"], compatibility: data["compatibility"] }
+      skill_targets = targets.select do |tool|
+        TARGETS.include?(tool) && ArtifactTargets.resolve(asset, tool) == "skill"
+      end
+      return if skill_targets.empty?
+
+      source = data["source"]
+      directory = source["format"] == "directory"
+      skill_md = File.join(@root, source["path"])
+      skill_md = File.join(skill_md, "SKILL.md") if directory
+      return unless File.file?(skill_md)
+
+      codex = skill_targets.include?("codex")
+      validate_skill_frontmatter(path, skill_md, data["name"],
+                                 required: codex && directory, require_description: codex)
+    end
+
+    # 既存 frontmatter は両 source 形式とも無改変で配るため同じ境界で検証する。
+    # 無い単一 source は build が補完するが、directory は補完されず Codex では必須。
+    # YAML を読めない場合は target parser との identity 解釈差を fail-closed で止める。
+    def validate_skill_frontmatter(path, skill_md, manifest_name, required:, require_description:)
       content = File.read(skill_md)
-      return unless content.start_with?("---\n", "---\r\n")
+      unless content.start_with?("---\n", "---\r\n")
+        error(path, "Codex SKILL.md must contain YAML frontmatter with name and description") if required
+        return
+      end
 
       parts = content.sub(/\A---\r?\n/, "").split(/^---\r?\n/, 2)
       if parts.length < 2
@@ -487,12 +512,15 @@ module CheckManifests
         return
       end
       fm_name = fm["name"]
-      unless fm_name.is_a?(String) && !fm_name.empty?
+      unless fm_name.is_a?(String) && !fm_name.strip.empty?
         error(path, "SKILL.md frontmatter must declare a non-empty string name")
         return
       end
       if manifest_name.is_a?(String) && fm_name != manifest_name
         error(path, "SKILL.md frontmatter name #{fm_name.inspect} does not match manifest name #{manifest_name.inspect}")
+      end
+      if require_description && !(fm["description"].is_a?(String) && !fm["description"].strip.empty?)
+        error(path, "Codex SKILL.md frontmatter must declare a non-empty string description")
       end
     end
 

--- a/scripts/tests/skill-frontmatter-test.sh
+++ b/scripts/tests/skill-frontmatter-test.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# generated skill の target 別 frontmatter 契約を pipeline の入口で検証する。
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ruby - "$script_dir/.." <<'RUBY'
+require "tmpdir"
+require "fileutils"
+require "yaml"
+require "json"
+require "open3"
+
+scripts = File.expand_path(ARGV.fetch(0))
+require File.join(scripts, "lib/check_manifests")
+
+def fixture(root, format, content, targets, compatibility = nil)
+  name = "personal-frontmatter"
+  source = format == "directory" ? "shared/skills/#{name}" : "shared/skills/#{name}.md"
+  entry = format == "directory" ? "#{source}/SKILL.md" : source
+  manifest = format == "directory" ? "#{source}/asset.yml" : "shared/skills/#{name}.asset.yml"
+  FileUtils.mkdir_p(File.dirname(File.join(root, entry)))
+  File.write(File.join(root, entry), content)
+  data = {
+    "schema_version" => 1, "name" => name, "kind" => "skill", "visibility" => "public",
+    "targets" => targets, "risk" => { "prompt_injection" => "low", "privacy" => "low" },
+    "source" => { "path" => source, "format" => format }, "summary" => "Generated fixture description",
+  }
+  data["compatibility"] = compatibility if compatibility
+  File.write(File.join(root, manifest), YAML.dump(data))
+end
+
+def check_case(format, label, content, targets, expected_error, compatibility = nil)
+  Dir.mktmpdir("skill-frontmatter-") do |root|
+    fixture(root, format, content, targets, compatibility)
+    _, errors = CheckManifests::Runner.new(root).run
+    valid = expected_error ? errors.any? { |e| e.include?(expected_error) } : errors.empty?
+    abort "FAIL: #{format}/#{label}: #{errors.inspect}" unless valid
+  end
+end
+
+valid = "---\nname: personal-frontmatter\ndescription: Public fixture\n---\n\n# Fixture\n"
+missing_description = "---\nname: personal-frontmatter\n---\n\n# Fixture\n"
+%w[directory markdown].each do |format|
+  check_case(format, "valid", valid, %w[codex claude-code], nil)
+  check_case(format, "crlf", valid.gsub("\n", "\r\n"), %w[codex], nil)
+  check_case(format, "missing-description", missing_description, %w[codex], "non-empty string description")
+  check_case(format, "claude-description-optional", missing_description, %w[claude-code], nil)
+  ["''", "'   '", "null", "42", "[]", "{}"].each do |value|
+    content = valid.sub("description: Public fixture", "description: #{value}")
+    check_case(format, "description-#{value}", content, %w[codex], "non-empty string description")
+  end
+  check_case(format, "missing-name", valid.sub("name: personal-frontmatter\n", ""), %w[codex], "non-empty string name")
+  check_case(format, "name-type", valid.sub("name: personal-frontmatter", "name: []"), %w[codex], "non-empty string name")
+  check_case(format, "identity", valid.sub("name: personal-frontmatter", "name: personal-other"), %w[claude-code], "does not match manifest name")
+  check_case(format, "closing-marker", "---\nname: personal-frontmatter\n", %w[codex], "closing --- marker")
+  check_case(format, "yaml", "---\nname: [\n---\n", %w[codex], "YAML error")
+  check_case(format, "mapping", "---\n- item\n---\n", %w[codex], "YAML mapping")
+  check_case(format, "alias", "---\nname: &name personal-frontmatter\ndescription: *name\n---\n", %w[codex], "YAML error")
+end
+check_case("directory", "codex-frontmatter-required", "# Fixture\n", %w[codex], "must contain YAML frontmatter")
+check_case("directory", "claude-frontmatter-optional", "# Fixture\n", %w[claude-code], nil)
+check_case("markdown", "codex-instruction", missing_description, %w[codex claude-code], nil,
+           { "codex" => { "artifact_kind" => "instruction" } })
+
+# build と register は同じ gate を使い、必須 metadata の欠落を登録・生成前に拒否する。
+%w[directory markdown].each do |format|
+  Dir.mktmpdir("skill-frontmatter-gate-") do |root|
+    fixture(root, format, missing_description, %w[codex claude-code])
+    %w[build register].each do |stage|
+      output, status = Open3.capture2e(File.join(scripts, "#{stage}.sh"), "--root", root)
+      abort "FAIL: #{stage}/#{format} accepted missing description: #{output}" unless status.exitstatus == 1
+    end
+    abort "FAIL: invalid skill reached generated/" if File.exist?(File.join(root, "generated"))
+  end
+end
+
+# source の拒否より先に symlink の中身を frontmatter として読み込まない。
+Dir.mktmpdir("skill-frontmatter-source-") do |root|
+  fixture(root, "markdown", valid, %w[codex])
+  source = File.join(root, "shared/skills/personal-frontmatter.md")
+  File.rename(source, File.join(root, "outside.md"))
+  File.write(File.join(root, "outside.md"), "---\nname: [\n---\n")
+  File.symlink("../../outside.md", source)
+  _, errors = CheckManifests::Runner.new(root).run
+  abort "FAIL: source symlink accepted" unless errors.any? { |e| e.include?("must not be a symlink") }
+  abort "FAIL: rejected source was parsed" if errors.any? { |e| e.include?("SKILL.md frontmatter") }
+end
+
+# frontmatter を持たない単一 source は既存の adapter 補完で有効になる。
+Dir.mktmpdir("skill-frontmatter-generated-") do |root|
+  fixture(root, "markdown", "# Fixture\n", %w[codex claude-code])
+  %w[build register].each do |stage|
+    output, status = Open3.capture2e(File.join(scripts, "#{stage}.sh"), "--root", root)
+    abort "FAIL: #{stage} rejected generated frontmatter: #{output}" unless status.success?
+  end
+  %w[codex claude-code].each do |target|
+    content = File.read(File.join(root, "generated", target, "skills/personal-frontmatter/SKILL.md"))
+    fm = YamlUtil.load(content.split(/^---\n/, 3)[1], "generated SKILL.md")
+    abort "FAIL: generated metadata differs" unless fm == {
+      "name" => "personal-frontmatter", "description" => "Generated fixture description",
+    }
+  end
+  catalog = JSON.parse(File.read(File.join(root, "generated/catalog.json")))
+  abort "FAIL: valid skill not registered" unless catalog.fetch("assets").all? { |a| a["registration"] == "registered" }
+end
+puts "ok: skill frontmatter self-test passed"
+RUBY

--- a/scripts/tests/skill-frontmatter-test.sh
+++ b/scripts/tests/skill-frontmatter-test.sh
@@ -33,7 +33,8 @@ def check_case(format, label, content, targets, expected_error, compatibility = 
   Dir.mktmpdir("skill-frontmatter-") do |root|
     fixture(root, format, content, targets, compatibility)
     _, errors = CheckManifests::Runner.new(root).run
-    valid = expected_error ? errors.any? { |e| e.include?(expected_error) } : errors.empty?
+    entry = format == "directory" ? "shared/skills/personal-frontmatter/SKILL.md" : "shared/skills/personal-frontmatter.md"
+    valid = expected_error ? errors.any? { |e| e.include?(expected_error) && e.include?(entry) } : errors.empty?
     abort "FAIL: #{format}/#{label}: #{errors.inspect}" unless valid
   end
 end
@@ -83,7 +84,7 @@ Dir.mktmpdir("skill-frontmatter-source-") do |root|
   File.symlink("../../outside.md", source)
   _, errors = CheckManifests::Runner.new(root).run
   abort "FAIL: source symlink accepted" unless errors.any? { |e| e.include?("must not be a symlink") }
-  abort "FAIL: rejected source was parsed" if errors.any? { |e| e.include?("SKILL.md frontmatter") }
+  abort "FAIL: rejected source was parsed" if errors.any? { |e| e.include?("frontmatter has a YAML error") }
 end
 
 # frontmatter を持たない単一 source は既存の adapter 補完で有効になる。


### PR DESCRIPTION
skill を生成する target に応じて source frontmatter を検証します。Codex 向けは非空の name / description を必須にし、Claude Code の省略規則と frontmatter のない単一 source の生成補完を維持します。不正 source は先に拒否し、frontmatter の診断には実 source の相対 path を表示します。

Closes #234

## 検証・レビュー

- 公式仕様に基づく validation。確認日・省略規則・source 形式ごとの契約を docs に記録。実 runtime loader smoke の実施とは区別。
- frontmatter、check-manifests と関連 suite、21 manifests、diff check が成功。
- Claude 独立レビューの修正を反映し、最終 head `634ed06e71080ffe813a65f711b79893f1fb5350` で APPROVE（must 0 / should 0 / nit 1）。任意の nit は見送り。
- 同 head の CI は system Ruby / Ruby 3.4 の両方で成功。未解決 review threads 0、競合なし。

Claude native skill 実行面の制限は後続 #241 で扱います。