### PR TITLE
fix: 未対応の Claude skill 実行・権限機能を登録前に拒否する

### DIFF
--- a/adapters/claude-code/README.md
+++ b/adapters/claude-code/README.md
@@ -33,6 +33,9 @@ generated/claude-code/scripts/
   Claude-only skill は frontmatter 不在・description 省略を許可する。Codex にも skill として
   配る場合は Codex の必須項目を満たす必要がある。詳細は
   [Asset Manifest Schema](../../docs/asset-manifest-schema.md)。
+  `allowed-tools` / `hooks` と本文の dynamic shell command は未対応のため、生成・登録前に
+  拒否する。frontmatter の無い単一 source も本文を検査し、説明用 references / evals へは
+  この検査を広げない。対象構文は同 schema の「Native skill 機能」を参照する。
 - **instruction**: 単一ファイルを `CLAUDE.md` に生成し、本体先頭に 1 行コメント marker を
   付ける。directory 形式の instruction は非対応。
 - **script**: 単一実行ファイルを byte 保持で copy し (mode 0755)、隣に sidecar marker を

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -33,6 +33,9 @@ generated/codex/scripts/
   非空 string の `description` を登録前に検証する。directory の frontmatter 不在は拒否し、
   単一 source の frontmatter 不在は上記の生成経路を使う。詳細は
   [Asset Manifest Schema](../../docs/asset-manifest-schema.md)。
+  Codex のみへ生成する skill には Claude 固有の native 実行構文の拒否 gate を適用しない。
+  同じ source を Claude Code の skill にも配る場合は、そちらの未対応機能検査で asset 全体が
+  停止する。これは Codex の機能有効化や実行権限の承認を意味しない。
 - **instruction**: 単一ファイルを `AGENTS.md` に生成し、本体先頭に 1 行コメント marker を
   付ける。directory 形式の instruction は非対応。
 - **script**: 単一実行ファイルを byte 保持で copy し (mode 0755)、隣に sidecar marker を

--- a/docs/asset-manifest-schema.md
+++ b/docs/asset-manifest-schema.md
@@ -73,6 +73,10 @@ directory 形式の配置ルールと、両 source 形式に共通する frontma
   build / register はこの静的検証を共有する。根拠は 2026-09-06 に確認した上記公式契約:
   Claude Code は全 frontmatter field が任意で、name の省略時は directory 名、description の
   省略時は本文の先頭段落を使う。runtime loader を起動した検証ではない。
+- **Claude Code skill の native 実行・事前許可機能は未対応として拒否**する (#233)。
+  検査対象は source entrypoint (directory の `SKILL.md` / 単一 source) に限る。
+  実 frontmatter の `allowed-tools` / `hooks` は空値も含めて拒否し、本文の inline / fenced
+  dynamic shell command は非空 command を含む場合に拒否する。理由は下記「Native skill 機能」。
 - **asset source の入れ子・重複所有を禁止**する (#177 H-01)。directory asset の source dir 配下に
   その asset 自身の manifest 以外の manifest を置くと fail-closed で拒否する (子 asset が独立
   配布されつつ親の evals/ 抑止で injection check を回避する経路を断つ)。
@@ -82,6 +86,34 @@ manifest metadata を asset 本体の frontmatter と分ける理由:
 - target tool が独自 frontmatter を持つ可能性がある。
 - shared metadata と target-specific metadata を混ぜない。
 - markdown 以外の asset にも同じ考え方を使える。
+
+### Native skill 機能
+
+`allowed-tools` は事前許可の grant であり、利用可能 tool の制限ではない。`hooks` と dynamic
+shell command も host が実行する機能なので、通常の説明文と分けて検査する。これらを安全に
+配布する機能は現段階で提供せず、`check-manifests` が拒否する。build / register は同じ gate で
+停止し、`human_review: approved` でも未対応機能の拒否は解除しない。承認 schema は変更しない。
+
+| 解決済み target artifact | この拒否 gate の扱い |
+| --- | --- |
+| `claude-code` の `skill` | `allowed-tools` / `hooks` / dynamic shell command を拒否 |
+| `codex` のみの `skill` | Claude 固有の実行構文による拒否は適用しない。Codex の必須 frontmatter 検証は適用する |
+| `instruction` / `script` | この skill 用検査の対象外。既存の kind 別 gate を適用する |
+
+一つの source を両 target の skill に配る場合は、Claude Code 向けに拒否された時点で asset の
+build / register 全体が停止する。片側だけ登録しない。これは host の permissions を変更したり、
+Codex でこれらの機能の実行を承認したりする仕組みではない。
+
+[Claude Code の dynamic context 契約](https://code.claude.com/docs/en/skills#inject-dynamic-context)
+と 2.1.259 の静的 parser に基づき、inline は行頭または空白直後の bang + backtick 構文、fenced は
+三連 backtick + bang で始まる構文を扱う (改行無しの fenced 形も含む)。空または空白だけの
+command は実行形に数えない。通常の inline-code span に隠れた説明は除外するが、Markdown の
+code fence 全体を一律には除外しない。コード例でも host が実行する形をそのまま載せれば拒否する。
+`KEY=` 直後や backslash 直後の bang は inline command の開始にならない。
+
+本文中の `allowed-tools` / `hooks` という説明や YAML コード例、frontmatter の `metadata` 内の
+同名 key はこの検査の対象外。`references/` / `assets/` / 非配置の `evals/` の説明文も entrypoint
+として解析しない。既存の injection / 実行 bit / symlink 検査の対象範囲は変更しない。
 
 ## Required fields
 

--- a/scripts/lib/check_manifests.rb
+++ b/scripts/lib/check_manifests.rb
@@ -40,6 +40,8 @@ module CheckManifests
   NAME_PATTERN = /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/.freeze
   ASSET_CATEGORIES = %w[skills prompts workflows agents instructions scripts].freeze
   NON_ASSET_BASENAMES = %w[README.md].freeze
+  # JavaScript の whitespace / trim と同じ集合。Ruby の [:space:] は U+0085 等で異なる。
+  CLAUDE_DYNAMIC_SPACE = /[\t\n\v\f\r \u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]/.freeze
 
   class Runner
     def initialize(root)
@@ -109,7 +111,7 @@ module CheckManifests
       if data.key?("source")
         source_error_count = @errors.size
         validate_source(path, data["source"])
-        check_skill_frontmatter(data, path) if @errors.size == source_error_count
+        check_skill_entrypoint(data, path) if @errors.size == source_error_count
       end
       validate_review(path, data["review"]) if data.key?("review")
       validate_compatibility(path, data["compatibility"]) if data.key?("compatibility")
@@ -462,7 +464,7 @@ module CheckManifests
 
     # source の検証後だけ呼び、未検証 path や symlink の先を読まない。
     # kind ではなく生成先で判定し、Codex の instruction には skill の必須項目を課さない。
-    def check_skill_frontmatter(data, path)
+    def check_skill_entrypoint(data, path)
       targets = data["targets"]
       return unless targets.is_a?(Array)
 
@@ -479,8 +481,8 @@ module CheckManifests
       return unless File.file?(skill_md)
 
       codex = skill_targets.include?("codex")
-      validate_skill_frontmatter(path, skill_md, data["name"],
-                                 required: codex && directory, require_description: codex)
+      validate_skill_entrypoint(path, skill_md, data["name"], required: codex && directory,
+                                require_description: codex, claude_skill: skill_targets.include?("claude-code"))
     end
 
     # 既存 frontmatter は両 source 形式とも無改変で配るため同じ境界で検証する。
@@ -491,11 +493,12 @@ module CheckManifests
     # frontmatter で別 identity を宣言すると「レビューされた identity ≠ 実配備 identity」に
     # なるため、manifest name との一致を必須にする (#43 の外部 skill 配布で効く供給側ギャップ)。
     # YAML を読めない場合は target parser との identity 解釈差を fail-closed で止める。
-    def validate_skill_frontmatter(path, skill_md, manifest_name, required:, require_description:)
+    def validate_skill_entrypoint(path, skill_md, manifest_name, required:, require_description:, claude_skill:)
       source_path = rel(skill_md)
       content = File.read(skill_md)
       unless content.start_with?("---\n", "---\r\n")
         error(path, "Codex #{source_path} must contain YAML frontmatter with name and description") if required
+        check_claude_skill_features(path, source_path, {}, content) if claude_skill
         return
       end
 
@@ -514,6 +517,7 @@ module CheckManifests
         error(path, "#{source_path} frontmatter must be a YAML mapping")
         return
       end
+      check_claude_skill_features(path, source_path, fm, parts[1]) if claude_skill
       fm_name = fm["name"]
       unless fm_name.is_a?(String) && !fm_name.strip.empty?
         error(path, "#{source_path} frontmatter must declare a non-empty string name")
@@ -525,6 +529,31 @@ module CheckManifests
       if require_description && !(fm["description"].is_a?(String) && !fm["description"].strip.empty?)
         error(path, "Codex #{source_path} frontmatter must declare a non-empty string description")
       end
+    end
+
+    # native の事前許可と shell 実行は prose ではない。未対応なので承認で迂回させない (#233)。
+    def check_claude_skill_features(path, source_path, frontmatter, body)
+      %w[allowed-tools hooks].each do |feature|
+        if frontmatter.key?(feature)
+          error(path, "#{source_path}: unsupported Claude Code skill feature: #{feature} (see #233)")
+        end
+      end
+      if claude_dynamic_command?(body)
+        error(path, "#{source_path}: unsupported Claude Code skill feature: dynamic shell command (see #233)")
+      end
+    end
+
+    # Claude は通常の inline-code span を除いて inline command を探すが、code fence 全体は
+    # 除外しない。fenced command には改行無しの形もある (2.1.259 の parser と公式 docs を照合)。
+    def claude_dynamic_command?(body)
+      fenced = body.scan(/```!(.*?)```/m)
+      inline_body = body.gsub(/`[^`\n]+`/) do |span|
+        offset = Regexp.last_match.begin(0)
+        previous = offset.zero? ? nil : body[offset - 1]
+        %w[! `].include?(previous) ? span : "`#{' ' * (span.length - 2)}`"
+      end
+      inline = inline_body.scan(/(?:\A|#{CLAUDE_DYNAMIC_SPACE})!`([^`]+)`/)
+      (fenced + inline).any? { |match| !match.first.match?(/\A#{CLAUDE_DYNAMIC_SPACE}*\z/) }
     end
 
     # asset source の入れ子・重複所有を fail-closed で禁止する (#177 / H-01)。

--- a/scripts/tests/skill-frontmatter-test.sh
+++ b/scripts/tests/skill-frontmatter-test.sh
@@ -81,6 +81,7 @@ dynamic_commands = [
   "```!printf fixture```\n",
   "  ```!\nprintf fixture\n  ```\n",
   "```markdown\n!`printf fixture`\n```\n",
+  "!`printf fixture\nprintf fixture`\n",
 ]
 %w[directory markdown].each do |format|
   native_fields.each do |field|
@@ -94,6 +95,7 @@ dynamic_commands = [
     check_case(format, "no-frontmatter-dynamic", body, %w[claude-code], "unsupported Claude Code skill feature")
   end
   ["KEY=!`printf fixture`\n", "escaped \\!`printf fixture`\n",
+   "```!\nprintf fixture\n",
    "prefix\u0085!`printf fixture`\n",
    "literal: `example !`printf fixture`\n", "``!`printf fixture` ``\n",
    "!`   `\n", "```!\n \t\n```\n",

--- a/scripts/tests/skill-frontmatter-test.sh
+++ b/scripts/tests/skill-frontmatter-test.sh
@@ -63,6 +63,91 @@ check_case("directory", "claude-frontmatter-optional", "# Fixture\n", %w[claude-
 check_case("markdown", "codex-instruction", missing_description, %w[codex claude-code], nil,
            { "codex" => { "artifact_kind" => "instruction" } })
 
+native_fields = [
+  "allowed-tools: Bash(*)",
+  "allowed-tools: [Read, Grep]",
+  "allowed-tools: null",
+  "'allowed-tools': Read",
+  "hooks:\n  PreToolUse:\n    - matcher: Read\n      hooks:\n        - type: command\n          command: printf fixture",
+  "hooks: {}",
+]
+dynamic_commands = [
+  "!`printf fixture`\n",
+  "Context: !`printf fixture`\n",
+  "\t!`printf fixture`\n",
+  "\u00A0!`printf fixture`\n",
+  "```!\nprintf fixture\n```\n",
+  "```!\r\nprintf fixture\r\n```\r\n",
+  "```!printf fixture```\n",
+  "  ```!\nprintf fixture\n  ```\n",
+  "```markdown\n!`printf fixture`\n```\n",
+]
+%w[directory markdown].each do |format|
+  native_fields.each do |field|
+    content = valid.sub("description: Public fixture", "description: Public fixture\n#{field}")
+    check_case(format, field, content, %w[codex claude-code], "unsupported Claude Code skill feature")
+    check_case(format, "codex-only-#{field}", content, %w[codex], nil)
+  end
+  dynamic_commands.each do |body|
+    check_case(format, "dynamic-command", valid + body, %w[codex claude-code], "unsupported Claude Code skill feature")
+    check_case(format, "codex-only-dynamic", valid + body, %w[codex], nil)
+    check_case(format, "no-frontmatter-dynamic", body, %w[claude-code], "unsupported Claude Code skill feature")
+  end
+  ["KEY=!`printf fixture`\n", "escaped \\!`printf fixture`\n",
+   "prefix\u0085!`printf fixture`\n",
+   "literal: `example !`printf fixture`\n", "``!`printf fixture` ``\n",
+   "!`   `\n", "```!\n \t\n```\n",
+   "Use allowed-tools and hooks only after review.\n",
+   "```yaml\nallowed-tools: Read\nhooks: {}\n```\n",
+   "```sh\nprintf fixture\n```\n"].each do |body|
+    check_case(format, "literal-example", valid + body, %w[codex claude-code], nil)
+  end
+  content = valid.sub("description: Public fixture", "description: Public fixture\nmetadata:\n  hooks: example\n  allowed-tools: example")
+  check_case(format, "nested-metadata", content, %w[codex claude-code], nil)
+end
+check_case("markdown", "claude-instruction", valid + dynamic_commands.first, %w[codex claude-code], nil,
+           { "claude-code" => { "artifact_kind" => "instruction" } })
+
+# refs / evals に書いた説明は host が skill 本文として実行する入口ではない。
+Dir.mktmpdir("skill-native-references-") do |root|
+  fixture(root, "directory", valid, %w[codex claude-code])
+  %w[references evals].each do |subdir|
+    dir = File.join(root, "shared/skills/personal-frontmatter", subdir)
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, "example.md"), "---\nallowed-tools: Read\nhooks: {}\n---\n#{dynamic_commands.join}")
+  end
+  _, errors = CheckManifests::Runner.new(root).run
+  abort "FAIL: reference example treated as entrypoint: #{errors.inspect}" unless errors.empty?
+end
+
+# native 機能は未対応なので、content-bound 承認があっても build / register は拒否する。
+require File.join(scripts, "lib/build")
+%w[directory markdown].each do |format|
+  [valid.sub("description: Public fixture", "description: Public fixture\nallowed-tools: Read"),
+   valid.sub("description: Public fixture", "description: Public fixture\nhooks: {}"),
+   valid + dynamic_commands.first, valid + dynamic_commands[4], dynamic_commands.first].each do |content|
+    Dir.mktmpdir("skill-native-gate-") do |root|
+      fixture(root, format, content, %w[claude-code])
+      source = format == "directory" ? "shared/skills/personal-frontmatter" : "shared/skills/personal-frontmatter.md"
+      manifest = format == "directory" ? "#{source}/asset.yml" : "shared/skills/personal-frontmatter.asset.yml"
+      path = File.join(root, manifest)
+      data = YamlUtil.load(File.read(path), manifest)
+      data["review"] = {
+        "human_review" => "approved", "approved_artifact_kind" => "skill",
+        "approved_build_id" => Build.build_id_for(root, source, format),
+      }
+      File.write(path, YAML.dump(data))
+      %w[build register].each do |stage|
+        output, status = Open3.capture2e(File.join(scripts, "#{stage}.sh"), "--root", root)
+        unless status.exitstatus == 1 && output.include?("unsupported Claude Code skill feature")
+          abort "FAIL: #{stage}/#{format} accepted native feature: #{output}"
+        end
+      end
+      abort "FAIL: native skill reached generated/" if File.exist?(File.join(root, "generated"))
+    end
+  end
+end
+
 # build と register は同じ gate を使い、必須 metadata の欠落を登録・生成前に拒否する。
 %w[directory markdown].each do |format|
   Dir.mktmpdir("skill-frontmatter-gate-") do |root|


### PR DESCRIPTION
Claude skill の登録時に、配布 pipeline が扱わない native 実行面を拒否します。frontmatter の `allowed-tools` / `hooks` は存在した時点で拒否し、entrypoint 本文の実行形 dynamic command を検出して build / register 共通の gate で止めます。Codex-only target、instruction / script、配布対象外の references / evals は今回の gate の対象外です。

Closes #233

#240 は統合済みで、base は main です。

## 検証・レビュー

- Claude Code 2.1.259 の観測した構文境界を positive / negative fixtures に固定。未閉鎖 fenced 形と multiline inline の懸念も実 parser の規則と照合し、分類ロジックを変えず fixture 2 件を追加。
- 関連 8 suites / 21 manifests / diff check が成功。既存生成物の byte 差分 0。
- rebase の range-diff は 2 commits とも同一。判定 source は初回レビューから不変。
- 最終 head `396b5ba864e79e1c4fd8dd47fcf1df03e7dd34e1` は Claude APPROVE（追加指摘 0）。UTF-8 診断の任意 nit は見送り。
- 同 head の CI は system Ruby / Ruby 3.4 とも成功、未解決 review thread 0、競合なし。

native 構文の検出は確認した host 版に依存し、host の構文が変われば追従が必要です。実 runtime loader の網羅的 smoke を実施済みとは主張しません。