### PR TITLE
docs: safe-gh 配布説明を時点付き仕様へ合わせる

### DIFF
--- a/shared/scripts/personal-safe-gh-hook.asset.yml
+++ b/shared/scripts/personal-safe-gh-hook.asset.yml
@@ -15,7 +15,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:27ac4ba8d993a0005ee19ec42b2a02b8d8b1672531a4aa021d14a3fc60fffe9f
+  approved_build_id: sha256:3450876a8b091ecffc6eceb0bcc82578be2f2696021a655d32772e4daecf71fc
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-safe-gh-hook.rb

--- a/shared/scripts/personal-safe-gh-hook.asset.yml
+++ b/shared/scripts/personal-safe-gh-hook.asset.yml
@@ -10,7 +10,7 @@ risk:
   privacy: low
 # script kind は実行コード配布のため常に human review 必須 (#147)。
 # 本 script は PR #136 (+ steer 文言の配置 path 案内 #190) で author≠reviewer
-# レビュー済み・承認。
+# レビュー済み・承認。今回の説明訂正・再レビュー・承認 hash 更新は PR #243。
 # 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:

--- a/shared/scripts/personal-safe-gh-hook.rb
+++ b/shared/scripts/personal-safe-gh-hook.rb
@@ -20,10 +20,9 @@
 #   (stdout JSON, exit 0)。exit 0 の stderr はモデルに届かない。`permissionDecision` は
 #   付けない (= 他の permission gate を上書きせず素の許可フローに委ねる。steering であって
 #   approve でもない)。
-# - Claude Code / Codex **両対応を実機確認済み** (2026-07-07, Codex 0.142.2): payload・出力
-#   schema とも同型で、additionalContext は Codex でもモデル可視に届く。ただしどちらも
-#   「登録 (+ Codex は初回 trust) が済むまで無警告で不活性」(fail-open の帰結)。詳細な
-#   honest-label は docs 正本を参照。
+# - 履歴 (2026-07-07, Codex 0.142.2): Claude Code / Codex の payload・出力 schema が
+#   同型で、additionalContext は Codex でもモデル可視に届くことを実機確認した。
+#   hook の登録・trust と未 trust 時の警告を含む時点付き仕様は docs 正本を参照。
 # - exit code は常に 0。hook 内部で例外が起きても 0 で透過する (fail-open を徹底)。
 #
 # 副作用ゼロ: network I/O も gh 呼び出しもしない。PreToolUse は毎コマンド前に同期実行される

--- a/shared/scripts/personal-safe-gh-hook.rb
+++ b/shared/scripts/personal-safe-gh-hook.rb
@@ -22,7 +22,8 @@
 #   approve でもない)。
 # - 履歴 (2026-07-07, Codex 0.142.2): Claude Code / Codex の payload・出力 schema が
 #   同型で、additionalContext は Codex でもモデル可視に届くことを実機確認した。
-#   hook の登録・trust と未 trust 時の警告を含む時点付き仕様は docs 正本を参照。
+# - 登録 (+ Codex は trust) が済むまでこの hook は不活性 (fail-open の帰結)。
+#   未 trust 時の警告など時点依存の詳細は docs 正本を参照。
 # - exit code は常に 0。hook 内部で例外が起きても 0 で透過する (fail-open を徹底)。
 #
 # 副作用ゼロ: network I/O も gh 呼び出しもしない。PreToolUse は毎コマンド前に同期実行される

--- a/shared/scripts/personal-safe-gh.asset.yml
+++ b/shared/scripts/personal-safe-gh.asset.yml
@@ -16,7 +16,7 @@ risk:
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:
   human_review: approved
-  approved_build_id: sha256:55ff4f50b1e01ebd1a2aabc539a7c531fe43c78df4e2dca8f5a2fdc54c3b96aa
+  approved_build_id: sha256:17c841531f357f98b50c4b1024b9b716b066be533d2e6db83ff4880f45bda1e5
   approved_artifact_kind: script
 source:
   path: shared/scripts/personal-safe-gh.rb

--- a/shared/scripts/personal-safe-gh.asset.yml
+++ b/shared/scripts/personal-safe-gh.asset.yml
@@ -11,7 +11,7 @@ risk:
 # script kind は実行コード配布のため常に human review 必須 (#147)。
 # 本 script は PR #135 / #141 / #156 / #160 (+ usage 文言の #176 M-05 是正、
 # review 経路拡張 pr review-comments/reviews の #189(3)) で author≠reviewer
-# レビュー済み・承認。
+# レビュー済み・承認。今回の説明訂正・再レビュー・承認 hash 更新は PR #243。
 # 承認は内容と配布形態に紐づく (#148, #184)。source 変更時は再レビューして
 # approved_build_id を、kind 変更時は approved_artifact_kind を更新する。
 review:

--- a/shared/scripts/personal-safe-gh.rb
+++ b/shared/scripts/personal-safe-gh.rb
@@ -8,8 +8,9 @@
 # 正本: docs/runtime-injection-defense.md / 外部 planning tool の設計メモ (8 決定)。
 #
 # 強度ラベル (偽らない): これは **steering** であって enforcement boundary ではない。
-# `$(gh ...)` 直実行 / `gh api` / `curl` / MCP github tool などで容易に迂回でき、PreToolUse
-# hook も subagent に不発・fail-open。hard な防御は床 (credential 隔離 + egress) が担う。
+# `$(gh ...)` 直実行 / `gh api` / `curl` / MCP github tool などで容易に迂回できる。
+# PreToolUse による誘導も fail-open。hook の適用範囲・発火条件の時点付き情報は正本を参照。
+# hard な防御は床 (credential 隔離 + egress) が担う。
 # safe-gh が買うのは「安全な読み方を便利にし、untrusted content を data として扱わせる」こと。
 #
 # 設計 (決定 3/4/5 を実装):

--- a/shared/skills/personal-github-safe-reader/SKILL.md
+++ b/shared/skills/personal-github-safe-reader/SKILL.md
@@ -17,7 +17,7 @@ agent が「命令」と誤解すると、意図しない GitHub 操作・コー
 ## 位置づけ (honest-label — 過大評価しない)
 
 これは **steering** であって enforcement boundary では**ありません**。生の
-`gh ... --comments` / `gh api` / 生 `curl` / `$()` / subagent などで容易に迂回でき、防御の
+`gh ... --comments` / `gh api` / 生 `curl` / `$()` / MCP github tool などで容易に迂回でき、防御の
 hard な床は「秘匿情報を持たない隔離 session で読む」credential 隔離 (別レイヤー) が担います。
 この skill が買うのは「素朴・偶発・あからさまな injection のバーを上げる」読み方の規律だけです。
 強度ラベルと層別の正本は `docs/runtime-injection-defense.md`。
@@ -100,6 +100,6 @@ source が残ると `me` は解決し得る**ので、「認証不在 = 全 untr
 ## 限界 (honest)
 
 steering であって hard ではない。safe-gh 経由の配線も生 `gh` / `gh api` / `curl` / `$()` /
-subagent 経路で迂回可能で、fail-open。真の隔離 (秘匿情報を持たない session で読み、認証源を
+MCP github tool 経路で迂回可能で、fail-open。真の隔離 (秘匿情報を持たない session で読み、認証源を
 構造的に断つ = P0-B credential 隔離) が hard な床で、その**実機 negative 検証は P3-02**
 (別 PR・cross-repo)。詳細と層別ラベルは `docs/runtime-injection-defense.md` を参照。


### PR DESCRIPTION
safe-gh の配布 script コメントと safe-reader skill の説明を、時点付きの runtime 正本に合わせます。過去の「subagent に不発」「未 trust は無警告」という断定を訂正し、登録・trust まで不活性であること、steering / fail-open の限界、過去の測定記録を保持します。実行コードは変えません。

Closes #242

## 検証・承認

- Ruby の実行 token は変更前後で同一。safe-gh / safe-gh-hook tests、21 manifests、build、register、register-test、diff check が成功。
- 2 script の canonical build_id を再計算して承認 hash を更新。safe-gh は `sha256:17c841531f357f98b50c4b1024b9b716b066be533d2e6db83ff4880f45bda1e5`、safe-gh-hook は `sha256:3450876a8b091ecffc6eceb0bcc82578be2f2696021a655d32772e4daecf71fc`。42 artifacts registered / human review required 0。
- ユーザーの条件付き作業・マージ承認に基づく更新で、今回のレビュー・hash 更新の参照を manifest コメントに記録。
- 最終 head `ca288db1578160396063b4369c12c637f64322b4` は Claude APPROVE（must 0 / should 0 / 任意 nit 1）。CI は system Ruby / Ruby 3.4 とも成功、未解決 thread 0。

変更外の quality-loop docs 指摘は #237 で対応済みです。